### PR TITLE
fix: fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ from quack import rmsnorm, softmax, cross_entropy
 To set up the development environment:
 
 ```bash
-pip install -e .[dev]
+pip install -e '.[dev]'
 pre-commit install
 ```


### PR DESCRIPTION
orginal install command `pip install -e .[dev]` leads to error in zshell(zsh): 

```
zsh: no matches found: .[dev]
```

Quoting `.[dev]` fix it