### PR TITLE
Add support for 3D Inputs for Quack.RMSNorm (support real world training usage)

### DIFF
--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -711,15 +711,22 @@ _rmsnorm_backward.compile_cache = {}
 class RMSNormFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, weight, eps):
+        x_shape_start = x.shape
+
+        # Flatten input
+        x = x.view(-1, x.shape[-1])
+
         out, rstd = _rmsnorm_fwd(x, weight, eps, return_rstd=True)
-        ctx.save_for_backward(x, weight, rstd)
+        ctx.save_for_backward(x, weight, rstd, x_shape_start)
         ctx.eps = eps
-        return out
+
+        return out.reshape(x_shape_start)
 
     @staticmethod
     def backward(ctx, dout):
-        x, weight, rstd = ctx.saved_tensors
+        x, weight, rstd, x_shape_start = ctx.saved_tensors
         dx, dw = _rmsnorm_backward(x, weight, dout, rstd)
+        dx = dx.view(x_shape_start)
         # dw is returned for weight gradient, None for eps gradient
         return dx, dw, None
 


### PR DESCRIPTION
This PR:
1 - updates the forward and backward to support 3D inputs.  For most training scenarios, the inputs to RMSNorm will not be 2D but rather batched and thus 3D.  
Hence, only supporting 2D is a limiting factor for real world usage.

The changes are really in the external aspects and not to the kernel - we use view to force a 3D input to 2D for the kernel and restore it on the way out.
For backward, we save the 3D shape via torch ctx mgr, and then also restore it on the way out for the dX return. 

Testing:
2 - Updated the input validation test to now verify that 3D input *is* supported.  
Also ran all the original tests and verified same number of passing tests as original. 