### PR TITLE
Add RMSNorm support for BF16 and FP16 weights, add unit tests to verify BF16, FP16 weight results for fwd, bwd

### DIFF
--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -648,7 +648,7 @@ class RMSNormBackward(ReductionBase):
                 cute.copy(copy_atom_store_dW, tdWrdW, tdWgdW, pred=tdWpdW)
         else:
             # Convert from fp32 to weight dtype at and only when storing
-            tdWrdW_converted = cute.make_fragment_likd(tdWgdW)
+            tdWrdW_converted = cute.make_fragment_like(tdWgdW)
             tdWrdW_converted.store(tXrdW.load().to(tdWgdW.element_type))
 
             cute.copy(copy_atom_store_dW, tdWrdW, tdWgdW, pred=tdWpdW)

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -686,10 +686,12 @@ def _rmsnorm_backward(
         torch.bfloat16,
         torch.float32,
     ], "Unsupported dtype"
+
     assert weight.dtype in [
         torch.float32,
         torch.bfloat16,
-    ], "Weight must be float32 or bfloate16"
+        torch.float16,
+    ], "Weight must be float32, float16 or bfloat16"
 
     M, N = x.shape
     dx = torch.empty_like(x)

--- a/tests/test_rmsnorm.py
+++ b/tests/test_rmsnorm.py
@@ -143,9 +143,7 @@ def test_rmsnorm_input_validation():
     x = torch.randn(32, 1024, device=device, dtype=torch.float16)
     weight_wrong = torch.randn(512, device=device, dtype=torch.float32)
 
-    with pytest.raises(
-        AssertionError, match="Last dimension of input must match weight dimension"
-    ):
+    with pytest.raises(AssertionError, match="Last dimension of input must match weight dimension"):
         rmsnorm(x, weight_wrong)
 
     # Test CPU tensors (should fail)
@@ -166,9 +164,7 @@ def test_rmsnorm_input_validation():
     x = torch.randn(32, 1024, device=device, dtype=torch.float16)
     weight_wrong_dtype = torch.randn(1024, device=device, dtype=torch.float64)
 
-    with pytest.raises(
-        AssertionError, match="Weight must be float32, float16 or bfloat16"
-    ):
+    with pytest.raises(AssertionError, match="Weight must be float32, float16 or bfloat16"):
         rmsnorm(x, weight_wrong_dtype)
 
 
@@ -209,9 +205,7 @@ def test_rmsnorm_bf16_weights_backward():
 
     # Create tensors with gradients
     x = torch.randn(M, N, device=device, dtype=torch.bfloat16, requires_grad=True)
-    weight_bf16 = torch.randn(
-        N, device=device, dtype=torch.bfloat16, requires_grad=True
-    )
+    weight_bf16 = torch.randn(N, device=device, dtype=torch.bfloat16, requires_grad=True)
 
     # Create reference tensors with float32 weights for comparison
     x_ref = x.detach().clone().requires_grad_()
@@ -281,6 +275,59 @@ def test_rmsnorm_fp16_weights():
 
     # Verify output values match reference implementation
     torch.testing.assert_close(out_fp16, out_ref, atol=1e-2, rtol=1e-2)
+
+
+def test_rmsnorm_fp16_weights_backward():
+    """Test that float16 weights work correctly with rmsnorm backward pass."""
+    device = "cuda"
+    M, N = 32, 1024
+    eps = 1e-6
+    atol = 1e-2  # Tolerance for float16
+
+    # Create tensors with gradients
+    x = torch.randn(M, N, device=device, dtype=torch.float16, requires_grad=True)
+    weight_fp16 = torch.randn(N, device=device, dtype=torch.float16, requires_grad=True)
+
+    # Create reference tensors with float32 weights for comparison
+    x_ref = x.detach().clone().requires_grad_()
+    weight_fp32 = weight_fp16.to(torch.float32).detach().requires_grad_()
+
+    # Forward pass
+    out_fp16 = rmsnorm(x, weight_fp16, eps=eps)
+    out_ref = rmsnorm(x_ref, weight_fp32, eps=eps)
+
+    # Create gradient for backward pass
+    grad_out = torch.randn_like(out_fp16)
+    grad_out_ref = grad_out.clone()
+
+    # Backward pass
+    torch.cuda.synchronize()
+    out_fp16.backward(grad_out)
+    out_ref.backward(grad_out_ref)
+
+    # Verify gradients
+    torch.testing.assert_close(x.grad, x_ref.grad, atol=atol, rtol=1e-2)
+    torch.testing.assert_close(
+        weight_fp16.grad, weight_fp32.grad.to(torch.float16), atol=atol, rtol=1e-2
+    )
+
+    # Test with mixed precision: float16 input and float32 weights
+    x = torch.randn(M, N, device=device, dtype=torch.float16, requires_grad=True)
+    weight_fp32 = torch.randn(N, device=device, dtype=torch.float32, requires_grad=True)
+
+    # Forward pass
+    out_mixed = rmsnorm(x, weight_fp32, eps=eps)
+
+    # Create gradient for backward pass
+    grad_out = torch.randn_like(out_mixed)
+
+    # Backward pass
+    torch.cuda.synchronize()
+    out_mixed.backward(grad_out)
+
+    # Just verify that backward pass completes without errors
+    assert x.grad is not None
+    assert weight_fp32.grad is not None
 
 
 def test_rmsnorm_compile_cache():


### PR DESCRIPTION
Based on issue (https://github.com/Dao-AILab/quack/issues/12), this PR adds:
1 - Support for RMSNorm weights in BF16, FP16, or FP32.  Previous code was limited to weights only in Fp32. 
Note that per @tridao, I've implemented it such that partial weight gradients are always computed in fp32. 
("we still want to compute the partial weight gradient in fp32 before summing up, then convert that to bf16")

* Now running in TorchTitan with FSDP2 and successfully training! 
* Speedup on LLama3-8B, B200*8, FSDP2 with TorchTitan:
<img width="373" height="82" alt="Screenshot 2025-07-15 at 4 06 37 PM" src="https://github.com/user-attachments/assets/f47523fd-5494-4d54-8c7c-5e5535bdac60" />


2 - adds unit tests to verify BF16 and FP16 weights produce matching results to reference, for both forward and backwards. 
*   Forward pass tests:
    *   test_rmsnorm_bf16_weights 
    *   test_rmsnorm_fp16_weights 
*   Backward pass tests:
    *   test_rmsnorm_bf16_weights_backward 
    *   test_rmsnorm_fp16_weights_backward. 
    
 2a - update input validation test to verify fp16, bf16 and fp32 are accepted.  
 use fp64 input to test bad weight input. 
    
3 - compile cache is also updated to key on weight dtype as well. 


Testing:
a - verified all previous unit tests passing as before (337 passing)
b - add and run new unit tests (test_rmsnorm_bf16_weights is passing.
<img width="1085" height="78" alt="Screenshot 2025-07-15 at 11 05 18 AM" src="https://github.com/user-attachments/assets/073298bb-ecdf-4f83-84f1-ff8348f80dd4" />
<img width="1085" height="78" alt="Screenshot 2025-07-15 at 12 22 42 PM" src="https://github.com/user-attachments/assets/89b0ac14-7178-4d80-a728-55ed2dbbc2aa" />

In TorchTitan:

#### =====================================================
#### Quack RMSNorm:  Calculating training performance metrics
#### =====================================================
Median Tokens/Second (excluding step 1): 9854.0
Max Memory Usage: 80.17 GiB

#### =====================================================
#### T orch nn.RMSNorm: Calculating training performance metrics
####  =====================================================
Median Tokens/Second (excluding step 1): 8752.0
Max Memory Usage: 90.37 GiB
