### PR TITLE
Minor fixes to build scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "quack-kernels"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 dependencies = [
     "nvidia-cutlass-dsl==4.1.0.dev0",
     "torch",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
* setup.py is redundant with pyproject.toml which specifies `build-backend = "setuptools.build_meta"` so `pip install .` still works
* Also kinda unfortunate but nvidia-cutlass-dsl seems to support only python 3.12 moving forward https://pypi.org/project/nvidia-cutlass-dsl/4.1.0/ which means if you have an older version of python installed installed you'll try to install the yoinked nvidia-cutlass-dsl 0.0.0.0 version and fail