### PR TITLE
Speedup Torch Wrapper for Symm Matmul

### DIFF
--- a/quack/symmetric_dense_gemm_sm90.py
+++ b/quack/symmetric_dense_gemm_sm90.py
@@ -1884,8 +1884,6 @@ def run(
 
 @lru_cache(maxsize=32)
 def get_max_active_clusters_cached(cluster_shape_mn_tuple):
-    """Cached version of max_active_clusters calculation"""
-    print(f"CACHE MISS: Computing max_active_clusters for {cluster_shape_mn_tuple}")
     cluster_shape_mn = tuple(cluster_shape_mn_tuple)
     return cutlass.utils.HardwareInfo().get_max_active_clusters(
         cluster_shape_mn[0] * cluster_shape_mn[1]

--- a/quack/symmetric_dense_gemm_sm90.py
+++ b/quack/symmetric_dense_gemm_sm90.py
@@ -57,6 +57,8 @@ from quack.reduction_base import torch2cute_dtype_map
 from quack.pipeline import make_pipeline_state
 import quack.utils as utils
 
+from functools import lru_cache
+
 # /////////////////////////////////////////////////////////////////////////////
 #  Helpers to parse args
 # /////////////////////////////////////////////////////////////////////////////
@@ -1880,6 +1882,15 @@ def run(
     tflops_cublas = flops / (timing_cublas * 1e9)  # Convert to TFlops
     print(f"CuBLAS Average time: {timing_cublas:.3f} ms, TFLOPS: {tflops_cublas:.1f}")
 
+@lru_cache(maxsize=32)
+def get_max_active_clusters_cached(cluster_shape_mn_tuple):
+    """Cached version of max_active_clusters calculation"""
+    print(f"CACHE MISS: Computing max_active_clusters for {cluster_shape_mn_tuple}")
+    cluster_shape_mn = tuple(cluster_shape_mn_tuple)
+    return cutlass.utils.HardwareInfo().get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+
 def _symmetric_dense_gemm(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1900,7 +1911,7 @@ def _symmetric_dense_gemm(
     cutlass_dtype = torch2cute_dtype_map[dtype]
 
     def make_cute_tensor(x: torch.Tensor):
-        cpu_ref = x.cpu().to(torch.float32)
+        x_fp32 = x.to(torch.float32)
         t = from_dlpack(x, assumed_align=16)
         t.element_type = cutlass_dtype
         if x.stride()[0] == 1:
@@ -1910,7 +1921,7 @@ def _symmetric_dense_gemm(
         else:
             raise ValueError(f"Input tesnor should have stride 1 along either dim 0 or 1. Strides: {x.stride()}")
         t = t.mark_layout_dynamic(leading_dim=leading_dim)
-        return cutlass_torch.convert_cute_tensor(cpu_ref, t, cutlass_dtype, is_dynamic_layout=True)
+        return cutlass_torch.convert_cute_tensor(x_fp32, t, cutlass_dtype, is_dynamic_layout=True)
     
     mA = make_cute_tensor(a)
     mB = make_cute_tensor(b) 
@@ -1938,9 +1949,7 @@ def _symmetric_dense_gemm(
     )
 
     if persistent:
-        max_active = cutlass.utils.HardwareInfo().get_max_active_clusters(
-            cluster_shape_mn[0] * cluster_shape_mn[1]
-        )
+        max_active = get_max_active_clusters_cached(cluster_shape_mn)
     else:
         max_active = 0
 


### PR DESCRIPTION
Previously:

1) We extraneously cast to cpu explicitly and then back to gpu via `convert_cute_tensor`: https://github.com/NVIDIA/cutlass/blob/19772cd63ecccc07a5cf5da852b15cd3ccecf63b/python/CuTeDSL/cutlass/torch.py#L143.

2) We didn't cache ```cutlass.utils.HardwareInfo().get_max_active_clusters(
        cluster_shape_mn[0] * cluster_shape_mn[1]
    )``` which is fairly expensive.