### PR TITLE
Add missing default value for `is_scheduler_warp`

### DIFF
--- a/quack/tile_scheduler.py
+++ b/quack/tile_scheduler.py
@@ -267,7 +267,7 @@ class TileScheduler:
         return self.get_current_work(loc=loc, ip=ip)
 
     @cute.jit
-    def fetch_next_work(self, is_scheduler_warp: bool | Boolean, *, loc=None, ip=None):
+    def fetch_next_work(self, is_scheduler_warp: bool | Boolean=False, *, loc=None, ip=None):
         """is_scheduler_warp should only be true for one warp in the whole cluster"""
         if const_expr(self.params.tile_count_semaphore is not None):
             params = self.params


### PR DESCRIPTION
There is a call to `fetch_next_work` without any argument [here](https://github.com/Dao-AILab/quack/blob/e026e94bb2f0d11346d4d551843106335c8dd181/quack/symmetric_dense_gemm_sm90.py#L831) and cause a failure when running `symmetric_dense_gemm_sm90`.

Added a default value for parameter `is_scheduler_warp` to fix the failure.