### PR TITLE
Fix a potential use-def issue in dynamic control flow

### DIFF
--- a/quack/symmetric_dense_gemm_sm90.py
+++ b/quack/symmetric_dense_gemm_sm90.py
@@ -907,8 +907,11 @@ class HopperSymmetricGemmKernel:
 
             acc_shape = tiled_mma.partition_shape_C(cute.select(self.tile_shape_mnk, mode=[0, 1]))
             acc = cute.make_fragment(acc_shape, self.acc_dtype)
-            if const_expr(self.fp8_slow_accum):
-                acc_slow = cute.make_fragment(acc_shape, self.acc_dtype)
+            acc_slow = (
+                cute.make_fragment(acc_shape, self.acc_dtype)
+                if const_expr(self.fp8_slow_accum)
+                else None
+            )
 
             if const_expr(self.pingpong):
                 if warp_group_idx == 0:

--- a/quack/tile_scheduler.py
+++ b/quack/tile_scheduler.py
@@ -267,7 +267,7 @@ class TileScheduler:
         return self.get_current_work(loc=loc, ip=ip)
 
     @cute.jit
-    def fetch_next_work(self, is_scheduler_warp: bool | Boolean, *, loc=None, ip=None):
+    def fetch_next_work(self, is_scheduler_warp: bool | Boolean=False, *, loc=None, ip=None):
         """is_scheduler_warp should only be true for one warp in the whole cluster"""
         if const_expr(self.params.tile_count_semaphore is not None):
             params = self.params


### PR DESCRIPTION
In `symmetric_dense_gemm_sm90.py`, this following pattern exists with `acc_slow`:

```python

if const_expr(...):
   acc_slow = ...

while ...:
   if const_expr(...):
      acc_slow.store(...)

```

The `acc_slow` actually has a potential write effect in the dynamic `while`, this requires `acc_slow` to be defined before the `while`.

This change fixed this issue.