### PR TITLE
fix bug in online_softmax when all loaded values in a warp are -inf

### DIFF
--- a/quack/reduce.py
+++ b/quack/reduce.py
@@ -140,13 +140,11 @@ def online_softmax_reduce(
         cute.arch.fmax,
         threads_in_group=min(threads_per_row, cute.arch.WARP_SIZE),
     )
+    if max_x == -Float32.inf:
+        max_x = Float32.zero
 
     log2_e = math.log2(math.e)
     exp_x = cute.math.exp2(x * log2_e - (max_x * log2_e), fastmath=True)
-    # if max_x=-inf, exp_x=nan, which causes error result.
-    if max_x == -Float32.inf:
-        exp_x = cute.zeros_like(x)  
-        
     sum_exp_x = cute.arch.warp_reduction(
         exp_x.reduce(cute.ReductionOp.ADD, init_val=0.0, reduction_profile=0),
         operator.add,

--- a/quack/reduce.py
+++ b/quack/reduce.py
@@ -140,8 +140,13 @@ def online_softmax_reduce(
         cute.arch.fmax,
         threads_in_group=min(threads_per_row, cute.arch.WARP_SIZE),
     )
+
     log2_e = math.log2(math.e)
     exp_x = cute.math.exp2(x * log2_e - (max_x * log2_e), fastmath=True)
+    # if max_x=-inf, exp_x=nan, which causes error result.
+    if max_x == -Float32.inf:
+        exp_x = cute.zeros_like(x)  
+        
     sum_exp_x = cute.arch.warp_reduction(
         exp_x.reduce(cute.ReductionOp.ADD, init_val=0.0, reduction_profile=0),
         operator.add,

--- a/tests/test_cross_entropy.py
+++ b/tests/test_cross_entropy.py
@@ -30,6 +30,7 @@ torch._dynamo.config.accumulated_cache_size_limit = 1024
         65536,
         128256,
         131072,
+        150000,
         256128,
         262144,
     ],


### PR DESCRIPTION
 if max_x=-inf, exp_x=nan, which causes error result.

```python
@cute.jit
def online_softmax_reduce(
    x: cute.TensorSSA,
    threads_per_row: cutlass.Constexpr[int],
    reduction_buffer: Optional[cute.Tensor] = None,
    mbar_ptr: Optional[cute.Pointer] = None,
    hook_fn: Optional[Callable] = None,
    phase: Optional[Int32] = None,
    return_exp_x: bool = False,
) -> [Float32, Float32, Optional[cute.TensorSSA]]:
    assert x.dtype == Float32, "x must be of type Float32"
    """reduction_buffer must have shape (num_warps / warps_per_row, (warps_per_row, cluster_n), 2)"""
    max_x = cute.arch.warp_reduction(
        x.reduce(cute.ReductionOp.MAX, init_val=-Float32.inf, reduction_profile=0),
        cute.arch.fmax,
        threads_in_group=min(threads_per_row, cute.arch.WARP_SIZE),
    )
    log2_e = math.log2(math.e)
    exp_x = cute.math.exp2(x * log2_e - (max_x * log2_e), fastmath=True)
    sum_exp_x = cute.arch.warp_reduction(
        exp_x.reduce(cute.ReductionOp.ADD, init_val=0.0, reduction_profile=0),
        operator.add,
        threads_in_group=min(threads_per_row, cute.arch.WARP_SIZE),
    )