### PR TITLE
Refine package discovery to only include quack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "benchmarks"]
+where = ["."]
+include = ["quack*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "quack.__version__"}


### PR DESCRIPTION
Previously, if I used uv pip install . multiple times without cleaning up, the build directory would get installed into site-packages. And the site-packages/build would keep getting more deeply nested. Also, .venv/lib/python3.13/site-packages/quack_kernels-0.2.4.dist-info/top_level.txt (ref to https://setuptools.pypa.io/en/latest/deprecated/python_eggs.html#top-level-txt-conflict-management-metadata) would contain other extraneous things.
![image](https://github.com/user-attachments/assets/4d4eb88b-44cb-46fe-80ff-f5440d419720)
