### PR TITLE
Support to only store mPostAct

### DIFF
--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -599,7 +599,7 @@ class GemmSm100(GemmSm90):
         varlen_params = VarlenManager.to_underlying_arguments(varlen_args)
 
         TileSchedulerCls = self.get_scheduler_class(varlen_m=varlen_args.mCuSeqlensM is not None)
-        tile_sched_args = self.get_scheduler_arguments(mA, mB, mD, scheduler_args, varlen_args)
+        tile_sched_args = self.get_scheduler_arguments(mA, mB, mD, scheduler_args, varlen_args, epilogue_args)
         tile_sched_params = TileSchedulerCls.to_underlying_arguments(tile_sched_args)
         grid = TileSchedulerCls.get_grid_shape(
             tile_sched_params, scheduler_args.max_active_clusters

--- a/quack/gemm_sm90.py
+++ b/quack/gemm_sm90.py
@@ -454,7 +454,7 @@ class GemmSm90:
         varlen_params = VarlenManager.to_underlying_arguments(varlen_args)
 
         TileSchedulerCls = self.get_scheduler_class(varlen_m=varlen_args.mCuSeqlensM is not None)
-        tile_sched_args = self.get_scheduler_arguments(mA, mB, mD, scheduler_args, varlen_args)
+        tile_sched_args = self.get_scheduler_arguments(mA, mB, mD, scheduler_args, varlen_args, epilogue_args)
         tile_sched_params = TileSchedulerCls.to_underlying_arguments(tile_sched_args)
         grid = TileSchedulerCls.get_grid_shape(
             tile_sched_params, scheduler_args.max_active_clusters
@@ -1299,6 +1299,7 @@ class GemmSm90:
         mD: Optional[cute.Tensor],
         scheduler_args,
         varlen_args,
+        epilogue_args
     ):
         """Create scheduler arguments. Override in subclasses for custom schedulers."""
         if const_expr(not self.is_persistent):
@@ -1335,7 +1336,7 @@ class GemmSm90:
                 persistence_mode=persistence_mode,
             )
         else:
-            assert mD is not None or not self.gather_A
+            assert (mD is not None) or (epilogue_args.mPostAct is not None) or (not self.gather_A)
             problem_shape_ntile_mnl = (
                 None,
                 cute.ceil_div(mB.shape[0], self.cta_tile_shape_mnk[1]),


### PR DESCRIPTION
During inference, we can only store mPostAct and do not store pre activation results. This PR fix an assertion error raised in this case. 

```
    y1 = torch.empty(T * K, I, dtype=x.dtype, device=x.device)
    
    gemm_gated(
        x,
        w1.permute(1, 2, 0).permute(2, 1, 0),
        activation="swiglu",
        cu_seqlens_m=expert_frequency_offset,
        A_idx=x_gather_idx,
        preact_out=None,
        postact_out=y1,
        store_preact=False
    )
```

Test cases are passed in both Hopper and Blackwell GPUs. 