### PR TITLE
Avoid CUDA context initialization at import time

### DIFF
--- a/quack/gemm_config.py
+++ b/quack/gemm_config.py
@@ -79,7 +79,9 @@ def _get_sm100_configs(
     swap_ab_vals = [False, True]
     if epilogue in ["lse", "gated"]:
         swap_ab_vals = [False]
-    GemmConfigCls = partial(GemmConfig, pingpong=False, device_capacity=10)  # There's no pingpong on Sm100
+    GemmConfigCls = partial(
+        GemmConfig, pingpong=False, device_capacity=10
+    )  # There's no pingpong on Sm100
     return [
         GemmConfigCls(
             tile_m=m, tile_n=n, cluster_m=cm, cluster_n=cn, swap_ab=sab, max_swizzle_size=8

--- a/quack/gemm_interface.py
+++ b/quack/gemm_interface.py
@@ -1055,9 +1055,7 @@ def gemm_symmetric(
 
 
 @autotune(
-    configs=[
-        AutotuneConfig(config=c) for c in get_all_configs("gated")
-    ],
+    configs=[AutotuneConfig(config=c) for c in get_all_configs("gated")],
     key=["activation", "dynamic_scheduler"],
     prune_configs_by={"early_config_prune": prune_invalid_gemm_configs},
 )
@@ -1132,9 +1130,7 @@ def prune_invalid_gemm_dgated_configs(configs, named_args: dict, **kwargs):
 
 
 @autotune(
-    configs=[
-        AutotuneConfig(config=c) for c in get_all_configs("dgated")
-    ],
+    configs=[AutotuneConfig(config=c) for c in get_all_configs("dgated")],
     key=["activation", "colvec_reduce", "dynamic_scheduler"],
     prune_configs_by={"early_config_prune": prune_invalid_gemm_dgated_configs},
 )


### PR DESCRIPTION
Previously, `import quack.gemm_interface` called
`get_device_capacity(torch.device("cuda"))` at module level to determine which autotuning configs to generate. This eagerly initialized a CUDA context. In our use case, sometimes we do it in a CPU only environment. 

Fix: generate configs for all supported arches (sm90 + sm100) at import time — this is pure CPU work. Tag each GemmConfig with its target `device_capacity` and filter to the actual device at runtime in `prune_invalid_gemm_configs`, which already runs at call time when the tensor's device is known.

cc @thakkarV 