### PR TITLE
Allow multiple parameters in AutotuneConfig

### DIFF
--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -451,11 +451,11 @@ class AutotuneConfig:
         return ", ".join(res)
 
     def __hash__(self):
-        return hash(tuple(*self.all_kwargs().items()))
+        return hash(tuple(self.all_kwargs().items()))
 
     def __eq__(self, other):
-        self_tuple = tuple(*self.all_kwargs().items())
-        other_tuple = tuple(*other.all_kwargs().items())
+        self_tuple = tuple(self.all_kwargs().items())
+        other_tuple = tuple(other.all_kwargs().items())
         return self_tuple == other_tuple
 
 

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -1,0 +1,15 @@
+from quack.autotuner import AutotuneConfig
+
+
+def test_autotune_config_supports_multi_kwarg_hash_and_equality():
+    config_a = AutotuneConfig(block_m=128, num_warps=4)
+    config_b = AutotuneConfig(block_m=128, num_warps=4)
+    config_c = AutotuneConfig(block_m=64, num_warps=4)
+
+    assert config_a == config_b
+    assert hash(config_a) == hash(config_b)
+    assert config_a != config_c
+
+    timings = {config_a: 1.25, config_c: 2.5}
+    assert timings[config_b] == 1.25
+    assert len({config_a, config_b, config_c}) == 2


### PR DESCRIPTION
`tuple(1,2,3)` is an error, but `tuple([1,2,3])` is not.