### PR TITLE
Remove asm_dialect=AD_ATT from inline PTX assembly calls

### DIFF
--- a/quack/activation.py
+++ b/quack/activation.py
@@ -30,7 +30,6 @@ def tanh(a: float | Float32, *, loc=None, ip=None) -> Float32:
             "=f,f",
             has_side_effects=False,
             is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
         )
     )
 

--- a/quack/copy_utils.py
+++ b/quack/copy_utils.py
@@ -584,7 +584,6 @@ def cpasync_reduce_bulk_add_f32(
         # "l,r,r,l",
         has_side_effects=True,
         is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
     )
 
 
@@ -715,7 +714,6 @@ def tma_gather4_load(
         "r,l,r,r,r,r,r,r",  # constraints: register, long, 6x register
         has_side_effects=True,
         is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
         loc=loc,
         ip=ip,
     )

--- a/quack/rounding.py
+++ b/quack/rounding.py
@@ -52,7 +52,6 @@ def mul_wide_u32(a: Uint32, b: Uint32, *, loc=None, ip=None) -> tuple:
         "=r,=r,r,r",
         has_side_effects=False,
         is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
     )
     i32_ty = T.i32()
     hi = cutlass.Uint32(llvm.extractvalue(i32_ty, result, [0], loc=loc, ip=ip))
@@ -85,7 +84,6 @@ def cvt_f32x2_bf16x2_rs(
             "=r,f,f,r",
             has_side_effects=False,
             is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
         )
     )
 

--- a/quack/tensormap_manager.py
+++ b/quack/tensormap_manager.py
@@ -87,7 +87,6 @@ class TensorMapManagerSm90(TensorMapManager):
                         "r,r",
                         has_side_effects=True,
                         is_align_stack=False,
-                        asm_dialect=llvm.AsmDialect.AD_ATT,
                     )
             # wait until it's safe to update tensormap in global memory
             with cute.arch.elect_one():
@@ -109,7 +108,6 @@ class TensorMapManagerSm90(TensorMapManager):
                         "l,r",
                         has_side_effects=True,
                         is_align_stack=False,
-                        asm_dialect=llvm.AsmDialect.AD_ATT,
                     )
                 cute.arch.sync_warp()
                 cute.nvgpu.cpasync.fence_tma_desc_release()

--- a/quack/utils.py
+++ b/quack/utils.py
@@ -39,7 +39,6 @@ def set_block_rank(
             "=r,r,r",
             has_side_effects=False,
             is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
         )
     )
 
@@ -72,7 +71,6 @@ def store_shared_remote(
         f"r,{constraint},r",
         has_side_effects=True,
         is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
     )
 
 
@@ -120,7 +118,6 @@ def store_shared_remote_x4(
         f"r,r,{constraint},{constraint},{constraint},{constraint}",
         has_side_effects=True,
         is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
     )
 
 
@@ -156,7 +153,6 @@ def sqrt(a: float | Float32, *, loc=None, ip=None) -> Float32:
             "=f,f",
             has_side_effects=False,
             is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
         )
     )
 
@@ -171,7 +167,6 @@ def ceil(a: float | Float32, *, loc=None, ip=None) -> Int32:
             "=r,f",
             has_side_effects=False,
             is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
         )
     )
 


### PR DESCRIPTION
## Summary

- Remove `asm_dialect=llvm.AsmDialect.AD_ATT` from all 12 `llvm.inline_asm` call sites across 5 files
- Fixes ptxas parse errors when inline PTX contains `{}` register grouping braces

## Problem

`AD_ATT` tells LLVM to interpret the asm string as AT&T syntax, where `{` has special meaning as a group delimiter. PTX uses `{}` for register lists (e.g., `mov.b64 {$1, $0}, prod`), causing a conflict:

```
ptxas application ptx input, line 2445; fatal: Parsing error near '.reg': syntax error
```

This affects `mul_wide_u32`, `store_shared_remote_x4`, `update_tensormap_shape`, and `tma_gather4_load` — any function using multi-line PTX blocks wrapped in `{}`.

CUTLASS's own `nvvm_wrappers.py` already follows the correct pattern: inline asm calls with PTX braces omit `asm_dialect` entirely.

## Fix

Remove `asm_dialect=llvm.AsmDialect.AD_ATT` from all inline asm calls. PTX is neither AT&T nor Intel syntax — the default (no dialect specified) passes the asm string through to ptxas unmodified, which is the correct behavior.

Also removed from single-instruction calls (`tanh`, `sqrt`, `ceil`, etc.) for consistency, though those aren't affected since they don't use braces.

## Validation

Tested on SM121a (NVIDIA GB10, DGX Spark) with CUDA 13.0, nvidia-cutlass-dsl 4.4.1:

**Before fix:** `quack.rounding.mul_wide_u32` fails during compilation:
```
error: <inline asm>:1:2: unrecognized instruction mnemonic, did you mean: b?
        {
        ^
```

**After fix:** Compiles and runs correctly. Verified `mul_wide_u32` produces correct 64-bit multiply results matching Python reference.

Contributed by Second Nature Computing (https://joinsecondnature.com)

## Test plan

- [ ] Verify `mul_wide_u32` compiles on SM90 (H100)
- [ ] Verify `store_shared_remote_x4` compiles on SM90
- [ ] Run existing quack test suite (`pytest tests/`)
- [ ] Verify no regression on SM100 (B200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)