### PR TITLE
Fix gemm_out inplace versus separate out tensor pytorch custom op schema mismatch

### DIFF
--- a/quack/gemm_interface.py
+++ b/quack/gemm_interface.py
@@ -562,23 +562,40 @@ def gemm_add(
     alpha = alpha if isinstance(alpha, float) else 1.0
     beta_tensor = beta if not isinstance(beta, float) else None
     beta = beta if isinstance(beta, float) else 1.0
-    gemm_add_out(
-        A,
-        B,
-        C if not add_to_output else None,
-        out,
-        alpha,
-        beta,
-        alpha_tensor,
-        beta_tensor,
-        cu_seqlens_m=cu_seqlens_m,
-        cu_seqlens_k=cu_seqlens_k,
-        A_idx=A_idx,
-        batch_idx_permute=batch_idx_permute,
-        add_to_output=add_to_output,
-        dynamic_scheduler=dynamic_scheduler,
-        tuned=tuned,
-    )
+    alpha_arg = alpha_tensor if alpha_tensor is not None else alpha
+    beta_arg = beta_tensor if beta_tensor is not None else beta
+    if add_to_output:
+        gemm_add_inplace(
+            A,
+            B,
+            out,
+            alpha=alpha_arg,
+            beta=beta_arg,
+            cu_seqlens_m=cu_seqlens_m,
+            cu_seqlens_k=cu_seqlens_k,
+            A_idx=A_idx,
+            batch_idx_permute=batch_idx_permute,
+            dynamic_scheduler=dynamic_scheduler,
+            tuned=tuned,
+        )
+    else:
+        gemm_add_out(
+            A,
+            B,
+            C,
+            out,
+            alpha,
+            beta,
+            alpha_tensor,
+            beta_tensor,
+            cu_seqlens_m=cu_seqlens_m,
+            cu_seqlens_k=cu_seqlens_k,
+            A_idx=A_idx,
+            batch_idx_permute=batch_idx_permute,
+            add_to_output=add_to_output,
+            dynamic_scheduler=dynamic_scheduler,
+            tuned=tuned,
+        )
     return out
 
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -9,6 +9,7 @@ from quack.linear import linear_gated_func
 from quack.mlp import mlp_func
 from quack.gemm_interface import (
     gemm,
+    gemm_add,
     gemm_add_inplace,
     gemm_dact,
     gemm_gated,
@@ -145,6 +146,27 @@ def test_gemm_add_inplace(m, k, n, input_dtype):
     gemm_add_inplace(A, B, C, tuned=False)
     C_ref = C_og.float() + torch.mm(A.float(), B.float())
     C_pt = C_og + torch.mm(A, B)
+    assert (C - C_ref).abs().max() < 2 * (C_pt - C_ref).abs().max() + 1e-5
+
+
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16])
+@pytest.mark.parametrize("n", [1504, 2048])
+@pytest.mark.parametrize("k", [736, 1024])
+@pytest.mark.parametrize("m", [960, 1920])
+def test_gemm_add_out_reuses_c_storage(m, k, n, input_dtype):
+    """Regression test for gemm_add(..., out=C) dispatching to the in-place path."""
+    device = "cuda"
+    torch.random.manual_seed(123)
+    A = torch.randn((m, k), device=device, dtype=input_dtype)
+    B = torch.randn((k, n), device=device, dtype=input_dtype)
+    C = torch.randn((m, n), device=device, dtype=input_dtype)
+    alpha = torch.tensor(0.5, device=device, dtype=torch.float32)
+    C_og = C.clone()
+    out = gemm_add(A, B, C, out=C, alpha=alpha, beta=1.0, tuned=False)
+    alpha_val = alpha.item()
+    C_ref = alpha_val * torch.mm(A.float(), B.float()) + C_og.float()
+    C_pt = alpha_val * torch.mm(A, B) + C_og
+    assert out is C
     assert (C - C_ref).abs().max() < 2 * (C_pt - C_ref).abs().max() + 1e-5
 
 


### PR DESCRIPTION
`gemm_add()` had an invalid dispatch path for the out is C case. When callers reused C storage as the output, the wrapper marked the operation as in-place but still called `gemm_add_out()` with `C=None`. That violates the `gemm_add_out` custom-op contract, which requires `C: Tensor`, and can trigger PyTorch schema/assert failures.

This change fixes the wrapper to dispatch that case to `gemm_add_inplace()` instead. The normal out-of-place path still goes through `gemm_add_out()`.

A regression test was added to cover `gemm_add(A, B, C, out=C, alpha=tensor, beta=1.0)` so the wrapper contract stays correct.