### PR TITLE
Fix autotuner worker device affinity

### DIFF
--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -25,6 +25,29 @@ PACKAGE_NAME = "quack"
 VERSION = __version__
 
 
+def _get_current_cuda_device() -> str | None:
+    """Return the physical CUDA device identifier for the current process.
+
+    Maps the logical ``torch.cuda.current_device()`` index through
+    ``CUDA_VISIBLE_DEVICES`` (if set) so the result is valid as a
+    standalone ``CUDA_VISIBLE_DEVICES`` value (handles integer IDs,
+    GPU UUIDs, and MIG IDs).
+
+    Returns ``None`` if CUDA is not initialized or the device cannot
+    be determined.
+    """
+    if not (torch.cuda.is_available() and torch.cuda.is_initialized()):
+        return None
+    logical_device = torch.cuda.current_device()
+    parent_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if parent_visible is not None:
+        visible_devices = [d.strip() for d in parent_visible.split(",")]
+        if logical_device < len(visible_devices):
+            return visible_devices[logical_device]
+        return None
+    return str(logical_device)
+
+
 def get_home_dir():
     return os.getenv(f"{PACKAGE_NAME.upper()}_HOME", Path.home())
 
@@ -214,17 +237,9 @@ class Autotuner:
         # Without this, all workers default to cuda:0 and their CUDA context
         # initialization can OOM when many ranks share a node.
         worker_env = os.environ.copy()
-        if torch.cuda.is_available() and torch.cuda.is_initialized():
-            logical_device = torch.cuda.current_device()
-            parent_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
-            if parent_visible is not None:
-                # Map logical index back to the physical device token (handles
-                # integer IDs, GPU UUIDs, and MIG IDs).
-                visible_devices = [d.strip() for d in parent_visible.split(",")]
-                if logical_device < len(visible_devices):
-                    worker_env["CUDA_VISIBLE_DEVICES"] = visible_devices[logical_device]
-            else:
-                worker_env["CUDA_VISIBLE_DEVICES"] = str(logical_device)
+        current_device = _get_current_cuda_device()
+        if current_device is not None:
+            worker_env["CUDA_VISIBLE_DEVICES"] = current_device
 
         # Launch persistent worker pool
         workers = []

--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -210,6 +210,22 @@ class Autotuner:
         fn_module = self.fn.__module__
         fn_qualname = self.fn.__qualname__
 
+        # Restrict worker subprocesses to the parent's current CUDA device.
+        # Without this, all workers default to cuda:0 and their CUDA context
+        # initialization can OOM when many ranks share a node.
+        worker_env = os.environ.copy()
+        if torch.cuda.is_available() and torch.cuda.is_initialized():
+            logical_device = torch.cuda.current_device()
+            parent_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+            if parent_visible is not None:
+                # Map logical index back to the physical device token (handles
+                # integer IDs, GPU UUIDs, and MIG IDs).
+                visible_devices = [d.strip() for d in parent_visible.split(",")]
+                if logical_device < len(visible_devices):
+                    worker_env["CUDA_VISIBLE_DEVICES"] = visible_devices[logical_device]
+            else:
+                worker_env["CUDA_VISIBLE_DEVICES"] = str(logical_device)
+
         # Launch persistent worker pool
         workers = []
         for _ in range(max_workers):
@@ -218,6 +234,7 @@ class Autotuner:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL if not verbose else None,
+                env=worker_env,
             )
             ready = _recv(p.stdout)
             if ready != "READY":


### PR DESCRIPTION
I observed the following issue when using quack in combination with fsdp on 8 B200s. All 8 GPUs run quack autotuning simultaneously, in a subprocesses. It seems that all these subprocesses run on cuda:0, the first GPU. They also all take up memory. Unfortunately, this causes an OOM. The other GPUs wait around for their subprocesses to finish, but they never do.

The stack trace showing the OOM error is attached.
[stderr.log.20260410T015022.txt](https://github.com/user-attachments/files/26618493/stderr.log.20260410T015022.txt)

The simplest fix is for each GPU to run its own subprocesses, rather than sending it to cuda:0. This reduces the memory pressure on the first GPU, preventing the OOM. In production, this can make a big difference. I'm using configs that have been designed so that training takes up as much of the GPUs memory as possible without OOMing, so there is not much extra room. The memory overhead of 7 extra processes pushes me over.

This PR simply sets the environment variable CUDA_VISIBLE_DEVICES of the subprocess so that it runs on the current device.