### PR TITLE
Fix bias with concat layout

### DIFF
--- a/quack/gemm_interface.py
+++ b/quack/gemm_interface.py
@@ -60,6 +60,10 @@ def _concat_interleave(t):
     dim = -2 if t.stride(-1) == 1 else -1
     return t.unflatten(dim, (2, t.shape[dim] // 2)).transpose(dim - 1, dim).flatten(dim - 1, dim)
 
+def _concat_interleave_bias(t):
+    """Interleave [gate; up] along last dim for bias vectors."""
+    half = t.shape[-1] // 2
+    return t.unflatten(-1, (2, half)).transpose(-2, -1).flatten(-2, -1)
 
 def default_config(device):
     cap = get_device_capacity(device)[0]
@@ -208,6 +212,8 @@ def gemm_tuned(
         if config.swap_ab and concat_layout
         else concat_layout
     )
+    if concat_layout and "B" in concat_layout and bias is not None:
+        bias = _concat_interleave_bias(bias)
     gemm_dispatch(
         A if not config.swap_ab else B,
         B if not config.swap_ab else A,
@@ -507,6 +513,8 @@ def gemm_ref(
             A = _concat_interleave(A)
         if "B" in concat_layout:
             B = _concat_interleave(B)
+            if bias is not None:
+                bias = _concat_interleave_bias(bias)
     if cu_seqlens_m is None and cu_seqlens_k is None:
         fn = torch.bmm if A.ndim == 3 else torch.mm
         out = fn(A, B, out_dtype=out_dtype, out=out)
@@ -702,6 +710,8 @@ def gemm_add_ref(
             A = _concat_interleave(A)
         if "B" in concat_layout:
             B = _concat_interleave(B)
+            if bias is not None:
+                bias = _concat_interleave_bias(bias)
         if "C" in concat_layout:
             C = _concat_interleave(C)
     if cu_seqlens_m is None and cu_seqlens_k is None:
@@ -1260,6 +1270,8 @@ def gemm_gated_tuned(
         PostAct = postact_out
     if bias is not None and bias.ndim == 1:
         bias = bias.unsqueeze(0)  # (L, N)
+    if concat_layout and "B" in concat_layout and bias is not None:
+        bias = _concat_interleave_bias(bias)
     dynamic_scheduler = dynamic_scheduler or config.is_dynamic_persistent
     tile_count_semaphore = (
         torch.zeros(1, dtype=torch.int32, device=A.device)


### PR DESCRIPTION
We will interleave the bias if the bias has a concat layout. The time regression is minor as bias is small and can fit seamlessly with the current epi tiling strategy. 