### PR TITLE
ci: upgrade GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install ruff
         run: pip install ruff
       - name: Ruff check
@@ -35,7 +35,7 @@ jobs:
     name: test (${{ matrix.gpu }})
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/gpu-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install ruff
         run: pip install ruff
       - name: Ruff check
@@ -25,5 +25,5 @@ jobs:
     name: test (${{ matrix.gpu }})
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/gpu-test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,10 +9,10 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
 
@@ -25,7 +25,7 @@ jobs:
       run: python -m build
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: dist/*
         generate_release_notes: true


### PR DESCRIPTION
This PR upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.


| Action | Old Version | New Version | Reason |
| :--- | :--- | :--- | :--- |
| `actions/checkout` | `v4` | `v6` | Upgrade to Node 24 runtime |
| `actions/setup-python` | `v5` | `v6` | Official support for Node 24 |
| `softprops/action-gh-release` | `v2` | `v3` | Dedicated release for Node 24 upgrade |


Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.
GitHub explicitly recommends that Actions users update workflows to the latest versions of actions that run on Node 24.

