### PR TITLE
Add remaining SM120 / RTX 50 support for GEMM epilogues and RMS paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install 'quack-kernels[heuristics]'
 
 ## Requirements
 
-- H100 or B200/B300 GPU
+- H100, B200/B300, or RTX 50 GPU
 - CUDA toolkit 12.9+
 - Python 3.12
 
@@ -32,6 +32,7 @@ pip install 'quack-kernels[heuristics]'
 - 🦆 Layernorm forward
 - 🦆 Hopper gemm + epilogue
 - 🦆 Blackwell gemm + epilogue
+- 🦆 Blackwell GeForce gemm + epilogue
 
 ## Usage
 

--- a/benchmarks/benchmark_gemm_epilogues.py
+++ b/benchmarks/benchmark_gemm_epilogues.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Benchmark GEMM epilogue kernels with explicit config overrides.
+
+This script is designed for both wall-clock benchmarking and Nsight Compute
+profiling of GEMM epilogue-heavy kernels.
+
+Examples:
+    python benchmarks/benchmark_gemm_epilogues.py --kernel rms
+    python benchmarks/benchmark_gemm_epilogues.py --kernel norm_act --activation gelu_tanh_approx
+    python benchmarks/benchmark_gemm_epilogues.py --kernel act --tile-m 64 --tile-n 128 --pingpong
+    ncu python benchmarks/benchmark_gemm_epilogues.py --kernel rms --profile --tile-m 128 --tile-n 64
+"""
+
+import argparse
+import math
+import time
+
+import torch
+
+from quack.autotuner import _gpu_warmup
+from quack.gemm_config import GemmConfig
+from quack.gemm_interface import _gemm_rms_tuned, gemm_act, gemm_act_tuned, gemm_norm_act, gemm_norm_act_tuned
+
+
+def make_config(args) -> GemmConfig:
+    return GemmConfig(
+        tile_m=args.tile_m,
+        tile_n=args.tile_n,
+        pingpong=args.pingpong,
+        cluster_m=1,
+        cluster_n=1,
+        swap_ab=args.swap_ab,
+        max_swizzle_size=8,
+        device_capacity=torch.cuda.get_device_capability()[0],
+        is_dynamic_persistent=not args.no_dynamic_persistent,
+        use_tma_gather=False,
+    )
+
+
+def selected_config(args) -> GemmConfig | None:
+    return None if args.use_selected_config else make_config(args)
+
+
+def benchmark(fn, repeats: int, warmup: int, stat: str) -> tuple[float, list[float]]:
+    torch.cuda.synchronize()
+    time.sleep(0.2)
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    ordered = sorted(samples)
+    if stat == "min":
+        return ordered[0], samples
+    if stat == "second-min":
+        return ordered[1] if len(ordered) > 1 else ordered[0], samples
+    if stat == "median":
+        mid = len(ordered) // 2
+        if len(ordered) % 2 == 1:
+            return ordered[mid], samples
+        return 0.5 * (ordered[mid - 1] + ordered[mid]), samples
+    raise ValueError(f"Unsupported stat: {stat}")
+
+
+def profile_once(fn, warmup_launches: int) -> None:
+    for _ in range(warmup_launches):
+        fn()
+    torch.cuda.synchronize()
+    cudart = torch.cuda.cudart()
+    cudart.cudaProfilerStart()
+    try:
+        fn()
+        torch.cuda.synchronize()
+    finally:
+        cudart.cudaProfilerStop()
+
+
+def run_rms(args, config: GemmConfig):
+    a = torch.randn(args.m, args.k, device="cuda", dtype=args.dtype)
+    b = torch.randn(args.k, args.n, device="cuda", dtype=args.dtype) / math.sqrt(args.k)
+    c = (
+        torch.randn(args.m, args.n, device="cuda", dtype=args.dtype)
+        if not args.no_residual
+        else None
+    )
+    norm_weight = (
+        torch.randn(args.n, device="cuda", dtype=args.dtype) if not args.no_norm_weight else None
+    )
+    out = torch.empty(args.m, args.n, device="cuda", dtype=args.dtype)
+
+    if config is None:
+        fn = lambda: _gemm_rms_tuned.fn(
+            a,
+            b,
+            out,
+            C=c,
+            norm_weight=norm_weight,
+            eps=args.eps,
+            dynamic_scheduler=args.dynamic_scheduler,
+            config=None,
+        )
+    else:
+        fn = lambda: _gemm_rms_tuned.fn(
+            a,
+            b,
+            out,
+            C=c,
+            norm_weight=norm_weight,
+            eps=args.eps,
+            dynamic_scheduler=args.dynamic_scheduler,
+            config=config,
+        )
+    if args.profile:
+        profile_once(fn, args.profile_warmup)
+        return {"ms": None}
+    fn()
+    ms, samples = benchmark(fn, args.repeats, args.warmup, args.stat)
+    return {"ms": ms, "samples": samples}
+
+
+def run_norm_act(args, config: GemmConfig):
+    a = torch.randn(args.m, args.k, device="cuda", dtype=args.dtype)
+    b = torch.randn(args.k, args.n, device="cuda", dtype=args.dtype) / math.sqrt(args.k)
+    c = (
+        torch.randn(args.m, args.n, device="cuda", dtype=args.dtype)
+        if not args.no_residual
+        else None
+    )
+    rstd = torch.randn(args.m, device="cuda", dtype=torch.float32)
+    preact_out = torch.empty(args.m, args.n, device="cuda", dtype=args.dtype)
+    postact_out = torch.empty(args.m, args.n, device="cuda", dtype=args.dtype)
+
+    if config is None:
+        fn = lambda: gemm_norm_act(
+            a,
+            b,
+            C=c,
+            rstd=rstd,
+            activation=args.activation,
+            preact_out=preact_out,
+            postact_out=postact_out,
+            dynamic_scheduler=args.dynamic_scheduler,
+            tuned=args.tuned,
+        )
+    else:
+        fn = lambda: gemm_norm_act_tuned.fn(
+            a,
+            b,
+            preact_out,
+            postact_out,
+            C=c,
+            rstd=rstd,
+            activation=args.activation,
+            dynamic_scheduler=args.dynamic_scheduler,
+            config=config,
+        )
+    if args.profile:
+        profile_once(fn, args.profile_warmup)
+        return {"ms": None}
+    fn()
+    ms, samples = benchmark(fn, args.repeats, args.warmup, args.stat)
+    return {"ms": ms, "samples": samples}
+
+
+def run_act(args, config: GemmConfig):
+    a = torch.randn(args.m, args.k, device="cuda", dtype=args.dtype)
+    b = torch.randn(args.k, args.n, device="cuda", dtype=args.dtype) / math.sqrt(args.k)
+    c = (
+        torch.randn(args.m, args.n, device="cuda", dtype=args.dtype)
+        if not args.no_residual
+        else None
+    )
+    preact_out = torch.empty(args.m, args.n, device="cuda", dtype=args.dtype)
+    postact_out = torch.empty(args.m, args.n, device="cuda", dtype=args.dtype)
+
+    if config is None:
+        fn = lambda: gemm_act(
+            a,
+            b,
+            C=c,
+            activation=args.activation,
+            preact_out=preact_out,
+            postact_out=postact_out,
+            dynamic_scheduler=args.dynamic_scheduler,
+            tuned=args.tuned,
+        )
+    else:
+        fn = lambda: gemm_act_tuned.fn(
+            a,
+            b,
+            preact_out,
+            postact_out,
+            C=c,
+            activation=args.activation,
+            dynamic_scheduler=args.dynamic_scheduler,
+            config=config,
+        )
+    if args.profile:
+        profile_once(fn, args.profile_warmup)
+        return {"ms": None}
+    fn()
+    ms, samples = benchmark(fn, args.repeats, args.warmup, args.stat)
+    return {"ms": ms, "samples": samples}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark GEMM epilogue kernels")
+    parser.add_argument("--kernel", choices=["rms", "norm_act", "act"], default="rms")
+    parser.add_argument("--m", type=int, default=4096)
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--k", type=int, default=4096)
+    parser.add_argument("--dtype", choices=["float16", "bfloat16"], default="bfloat16")
+    parser.add_argument("--activation", default="gelu_tanh_approx")
+    parser.add_argument("--tile-m", type=int, default=128)
+    parser.add_argument("--tile-n", type=int, default=64)
+    parser.add_argument("--pingpong", action="store_true")
+    parser.add_argument("--swap-ab", action="store_true")
+    parser.add_argument("--dynamic-scheduler", action="store_true")
+    parser.add_argument("--use-selected-config", action="store_true")
+    parser.add_argument("--tuned", action="store_true", help="When using selected config mode, call the tuned path")
+    parser.add_argument("--no-dynamic-persistent", action="store_true")
+    parser.add_argument("--no-residual", action="store_true")
+    parser.add_argument("--no-norm-weight", action="store_true")
+    parser.add_argument("--eps", type=float, default=1e-6)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=30)
+    parser.add_argument(
+        "--stat",
+        choices=["min", "second-min", "median"],
+        default="second-min",
+        help="Statistic to report from repeated CUDA-event timings",
+    )
+    parser.add_argument("--profile", action="store_true", help="Run one profiled launch after a small warmup")
+    parser.add_argument("--profile-warmup", type=int, default=1)
+    parser.add_argument(
+        "--preheat-ms",
+        type=int,
+        default=0,
+        help="Optional GPU preheat duration before timing/profile to reduce thermal skew",
+    )
+    args = parser.parse_args()
+
+    args.dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[args.dtype]
+    config = selected_config(args)
+
+    print("GEMM epilogue benchmark")
+    print(f"  kernel={args.kernel}")
+    print(f"  shape=({args.m}, {args.k}) x ({args.k}, {args.n})")
+    print(f"  dtype={args.dtype}")
+    if config is None:
+        print(f"  config=selected-by-{'autotune' if args.tuned else 'default'}")
+    else:
+        print(f"  config={config}")
+    if args.preheat_ms > 0:
+        print(f"  preheat_ms={args.preheat_ms}")
+        _gpu_warmup(args.preheat_ms)
+
+    if args.kernel == "rms":
+        result = run_rms(args, config)
+    elif args.kernel == "norm_act":
+        result = run_norm_act(args, config)
+    else:
+        result = run_act(args, config)
+
+    if args.profile:
+        print("  profile=completed")
+    else:
+        print(f"  stat={args.stat}")
+        print(f"  samples_ms={[round(x, 3) for x in result['samples']]}")
+        print(f"  runtime={result['ms']:.3f}ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sm120_ncu_profiling.md
+++ b/docs/sm120_ncu_profiling.md
@@ -1,0 +1,175 @@
+# SM120 Nsight Compute Profiling Guide
+
+This note describes how to profile SM120 / RTX 50 GEMM epilogue kernels using
+the generic benchmark harness:
+
+- `benchmarks/benchmark_gemm_epilogues.py`
+
+The immediate target of this note is SM120 performance work for:
+
+- `gemm_rms`
+- `gemm_norm_act`
+- optionally `gemm_act` as a control path
+
+## Why this harness exists
+
+The existing GEMM benchmark scripts are useful for wall-clock timing, but they
+do not provide a stable, explicit profiling entrypoint for SM120 epilogue-heavy
+kernels.
+
+This harness makes the following inputs explicit from the command line:
+
+- kernel family
+- shape
+- dtype
+- `tile_m`
+- `tile_n`
+- `pingpong`
+- `swap_ab`
+- dynamic persistence mode
+- optional GPU preheat duration
+
+That makes it suitable for both:
+
+- quick timing with repeated CUDA-event samples
+- reproducible `ncu` runs
+
+All timings recorded during this SM120 tuning pass were taken on a desktop
+Blackwell RTX 5060 8GB. Because the local machine is noisy, comparisons should
+use the second-best sample (`--stat second-min`), not a single run or the raw
+minimum.
+
+These findings should be revalidated on other RTX 50 models, especially the RTX
+5090. Its larger memory capacity and different performance envelope may change
+the winning defaults or the performance expectations.
+
+## First comparison matrix
+
+Start with `gemm_rms` on these configs:
+
+1. `128x64`, `pingpong=False`
+2. `64x128`, `pingpong=False`
+3. `128x64`, `pingpong=True`
+4. `64x128`, `pingpong=True`
+
+Use these shapes first:
+
+1. `(4096, 4096) x (4096, 4096)`
+2. `(4096, 2048) x (2048, 2048)`
+
+These are the right first comparisons because SM120 timing already showed that
+RMS is sensitive to tile shape and pingpong choice.
+
+## Example timing commands
+
+```bash
+python benchmarks/benchmark_gemm_epilogues.py \
+  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
+  --preheat-ms 500 \
+  --stat second-min \
+  --tile-m 128 --tile-n 64
+
+python benchmarks/benchmark_gemm_epilogues.py \
+  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
+  --preheat-ms 500 \
+  --stat second-min \
+  --tile-m 64 --tile-n 128
+
+python benchmarks/benchmark_gemm_epilogues.py \
+  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
+  --preheat-ms 500 \
+  --stat second-min \
+  --tile-m 128 --tile-n 64 --pingpong
+
+python benchmarks/benchmark_gemm_epilogues.py \
+  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
+  --preheat-ms 500 \
+  --stat second-min \
+  --tile-m 64 --tile-n 128 --pingpong
+```
+
+## Example `ncu` commands
+
+Profile one configuration at a time.
+
+Large square RMS case:
+
+```bash
+ncu --profile-from-start off python benchmarks/benchmark_gemm_epilogues.py \
+  --profile \
+  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
+  --preheat-ms 500 \
+  --tile-m 128 --tile-n 64
+```
+
+Moderate-width RMS case:
+
+```bash
+ncu --profile-from-start off python benchmarks/benchmark_gemm_epilogues.py \
+  --profile \
+  --kernel rms --dtype bfloat16 --m 4096 --n 2048 --k 2048 \
+  --preheat-ms 500 \
+  --tile-m 128 --tile-n 64
+```
+
+Norm-act comparison:
+
+```bash
+ncu --profile-from-start off python benchmarks/benchmark_gemm_epilogues.py \
+  --profile \
+  --kernel norm_act --dtype bfloat16 --activation gelu_tanh_approx \
+  --m 4096 --n 4096 --k 4096 \
+  --preheat-ms 500 \
+  --tile-m 128 --tile-n 64
+```
+
+Act control path:
+
+```bash
+ncu --profile-from-start off python benchmarks/benchmark_gemm_epilogues.py \
+  --profile \
+  --kernel act --dtype bfloat16 --activation gelu_tanh_approx \
+  --m 4096 --n 14336 --k 4096 \
+  --preheat-ms 500 \
+  --tile-m 64 --tile-n 128 --pingpong
+```
+
+## Metrics to inspect first
+
+Look at these categories before changing code or config pruning:
+
+1. achieved occupancy
+2. registers per thread
+3. shared memory per block
+4. active warps / active CTAs
+5. tensor pipeline utilization
+6. memory pipeline utilization
+7. stall reasons related to barriers, waits, and scheduler backpressure
+
+## How to interpret the first results
+
+Use the profiling results to answer these questions:
+
+1. Why does `pingpong=False` beat `pingpong=True` for `gemm_rms` on SM120?
+2. Is the losing config limited by:
+   - lower occupancy
+   - higher SMEM pressure
+   - barrier overhead
+   - epilogue serialization
+   - lower tensor-pipe utilization
+3. Does `gemm_norm_act` show the same limiting behavior as `gemm_rms`?
+4. Is the current generic SM120 default config (`128x128`, pingpong) sufficient
+   for RMS, or does RMS need its own justified default once `ncu` and timing
+   are considered together?
+
+## What should change only after profiling
+
+Do not change SM120 defaults until the timing and `ncu` story agree.
+
+The first config changes that profiling should justify are limited to SM120 defaults, such as `gemm_rms` or possibly `gemm_norm_act` if it shows the same bottleneck pattern
+
+The first profiling pass should not trigger:
+
+- kernel algorithm rewrites
+- major SM120 pipeline redesign
+- broad retuning of all SM120 GEMM paths at once

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "torch",
     "apache-tvm-ffi>=0.1.6,<0.2",
     "torch-c-dlpack-ext",
+    "einops",
 ]
 
 [project.optional-dependencies]

--- a/quack/epi_ops.py
+++ b/quack/epi_ops.py
@@ -538,12 +538,14 @@ def colvec_reduce_accumulate(gemm, tDrReduce, tRS_rInput, transform_fn=None, rSc
 
 class ColVecReduce(EpiOp):
     """Column vector reduction: accumulates across N subtiles in registers,
-    then warp-reduces and writes to gmem in epi_end.
+    then reduces across N lanes/warps and writes to gmem in epi_end.
 
-    No smem. The accumulation itself happens in epi_visit_subtile (user code).
+    The accumulation itself happens in epi_visit_subtile (user code).
     This op handles the register allocation (begin), per-subtile slicing (begin_loop),
-    and final warp reduction + gmem write (end).
+    and final reduction + gmem write (end).
     """
+
+    max_warps_in_n = 8
 
     def param_fields(self):
         return [(self.name, object, None)]
@@ -551,9 +553,26 @@ class ColVecReduce(EpiOp):
     def to_params(self, gemm, args):
         return {self.name: assume_stride_divisibility(getattr(args, self.name))}
 
+    def smem_bytes(self, arg_tensor, cta_tile_shape_mnk, epi_tile):
+        if arg_tensor is None:
+            return 0
+        return cta_tile_shape_mnk[0] * self.max_warps_in_n * (Float32.width // 8)
+
+    def smem_struct_field(self, gemm, params):
+        tensor = getattr(params, self.name, None)
+        size = gemm.cta_tile_shape_mnk[0] * self.max_warps_in_n if tensor is not None else 0
+        return (f"s_{self.name}", cute.struct.Align[cute.struct.MemRange[Float32, size], 16])
+
+    def get_smem_tensor(self, gemm, params, storage_epi):
+        if getattr(params, self.name, None) is None:
+            return None
+        return getattr(storage_epi, f"s_{self.name}").get_tensor(
+            cute.make_layout((gemm.cta_tile_shape_mnk[0], self.max_warps_in_n))
+        )
+
     @cute.jit
     def begin(self, gemm, param, smem_tensor, ctx):
-        tDrReduce = None
+        result = None
         if const_expr(param is not None):
             colvec_mma_layout = cute.make_layout((ctx.tile_M, ctx.tile_N), stride=(1, 0))
             tDrReduce_layout = ctx.partition_for_epilogue_fn(
@@ -561,13 +580,17 @@ class ColVecReduce(EpiOp):
             ).layout
             tDrReduce = cute.make_rmem_tensor(tDrReduce_layout, Float32)
             cute.filter_zeros(tDrReduce).fill(0.0)
-        return tDrReduce
+            result = (tDrReduce, smem_tensor)
+        return result
 
     @cute.jit
     def begin_loop(self, gemm, state, epi_coord):
         result = None
         if const_expr(state is not None):
-            result = cute.group_modes(state, 3, cute.rank(state))[None, None, None, epi_coord]
+            tDrReduce = state[0]
+            result = cute.group_modes(tDrReduce, 3, cute.rank(tDrReduce))[
+                None, None, None, epi_coord
+            ]
         return result
 
     @cute.jit
@@ -583,9 +606,9 @@ class ColVecReduce(EpiOp):
         varlen_manager,
         tidx,
     ):
-        """Intra-warp shuffle reduction across N lanes, then direct gmem write."""
+        """Intra-warp reduction across N lanes, then optional inter-warp reduction."""
         if const_expr(param is not None):
-            tDrReduce = state
+            tDrReduce, sDrReduce = state[0], state[1]
             tiled_copy = tiled_copy_t2r if tiled_copy_t2r is not None else tiled_copy_r2s
             reference_src = tiled_copy_t2r is None
 
@@ -593,6 +616,7 @@ class ColVecReduce(EpiOp):
             lane_layout_MN, warp_layout_MN = _get_lane_warp_layouts(tiled_copy, reference_src)
             # For ColVecReduce: reduce across N lanes (lanes_in_N threads share same M row)
             lanes_in_N = cute.size(lane_layout_MN, mode=[1])
+            is_lane_n_leader = cute.arch.lane_idx() % lanes_in_N == 0
             # Typically lanes_in_N is 4 for Sm90
             assert lanes_in_N == 1 << int(math.log2(lanes_in_N)), (
                 "lanes_in_N must be a power of 2 for butterfly reduction"
@@ -608,11 +632,10 @@ class ColVecReduce(EpiOp):
                     )
 
             warp_N = warp_layout_MN[1]
-            assert cute.size(warp_N) == 1, (
-                "ColVecReduce assumes all reduction cols are within the same warp"
-            )
+            warps_in_N = const_expr(cute.size(warp_N))
+            max_warps_in_n = const_expr(self.max_warps_in_n)
+            assert warps_in_N <= max_warps_in_n, "ColVecReduce warp_N exceeds smem staging"
 
-            # ── Direct gmem write (no inter-warp reduction needed: warps_in_N == 1) ──
             partition_for_epilogue_fn = partial(
                 partition_for_epilogue,
                 epi_tile=epi_tile,
@@ -621,6 +644,7 @@ class ColVecReduce(EpiOp):
                 reference_src=tiled_copy_t2r is None,
             )
             tile_M, tile_N = gemm.cta_tile_shape_mnk[:2]
+            epilogue_barrier = gemm.epilogue_barrier
             batch_idx = tile_coord_mnkl[3]
             limit_n = param.shape[2] if not varlen_manager.varlen_m else param.shape[1]
             if tile_coord_mnkl[1] < limit_n:
@@ -641,8 +665,26 @@ class ColVecReduce(EpiOp):
                     None, 0
                 ]
                 tDcD_m = layout_utils.convert_layout_zero_stride(tDcD, tDrReduce.layout)[None, 0]
-                if tDcD_m[0][1] == 0:
-                    for m in cutlass.range(cute.size(tDcD_m, mode=[0])):
-                        row_idx = tDcD_m[m][0]
-                        if row_idx < limit_m:
-                            gColVec[row_idx] = tDrReduce_m[m]
+                if const_expr(warps_in_N == 1):
+                    if is_lane_n_leader:
+                        for m in cutlass.range(cute.size(tDcD_m, mode=[0])):
+                            row_idx = tDcD_m[m][0]
+                            if row_idx < limit_m:
+                                gColVec[row_idx] = tDrReduce_m[m]
+                else:
+                    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+                    warp_n_idx = warp_layout_MN.get_hier_coord(warp_idx)[1]
+                    if is_lane_n_leader:
+                        for m in cutlass.range(cute.size(tDcD_m, mode=[0])):
+                            row_idx = tDcD_m[m][0]
+                            if row_idx < limit_m:
+                                sDrReduce[row_idx, warp_n_idx] = tDrReduce_m[m]
+                    epilogue_barrier.arrive_and_wait()
+                    if warp_n_idx == 0 and is_lane_n_leader:
+                        for m in cutlass.range(cute.size(tDcD_m, mode=[0])):
+                            row_idx = tDcD_m[m][0]
+                            if row_idx < limit_m:
+                                row_sum = Float32(0.0)
+                                for warp_n in cutlass.range_constexpr(warps_in_N):
+                                    row_sum += sDrReduce[row_idx, warp_n]
+                                gColVec[row_idx] = row_sum

--- a/quack/gemm_act.py
+++ b/quack/gemm_act.py
@@ -300,8 +300,6 @@ def _compile_gemm_act(
         "act": {9: GemmActSm90, 10: GemmActSm100, 11: GemmActSm100, 12: GemmActSm120},
         "gated": {9: GemmGatedSm90, 10: GemmGatedSm100, 11: GemmGatedSm100, 12: GemmGatedSm120},
     }
-    if device_capacity[0] == 12 and gemm_cls_name == "act":
-        raise NotImplementedError("SM120 non-gated activation GEMM epilogue is not yet supported")
     GemmCls = sm_to_cls[gemm_cls_name][device_capacity[0]]
     pa_leading = 1 if postact_major == "n" else 0
     mA, mB, mD, mC, m, n, k, l = make_fake_gemm_tensors(

--- a/quack/gemm_dact.py
+++ b/quack/gemm_dact.py
@@ -271,8 +271,6 @@ def _compile_gemm_dact(
             12: GemmDGatedSm120,
         },
     }
-    if device_capacity[0] == 12 and gemm_cls_name == "dact":
-        raise NotImplementedError("SM120 non-gated dactivation GEMM epilogue is not yet supported")
     GemmCls = sm_to_cls[gemm_cls_name][device_capacity[0]]
     mA, mB, mD, mC, m, n, k, l = make_fake_gemm_tensors(
         a_dtype,

--- a/quack/gemm_sq_reduce.py
+++ b/quack/gemm_sq_reduce.py
@@ -204,8 +204,6 @@ def gemm_sq_reduce(
     """
     device_capacity = get_device_capacity(A.device)
     assert device_capacity[0] in [9, 10, 11, 12], "Only SM90, SM100, SM110, and SM120 are supported"
-    if device_capacity[0] == 12:
-        raise NotImplementedError("SM120 GEMM sq reduce epilogue is not yet supported")
 
     A_p, B_p, D_p, C_p = perm3d(A, B, D, C)
     a_major, b_major, d_major, c_major = get_majors(A_p, B_p, D_p, C_p)

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -787,8 +787,6 @@ def test_gemm_rms(m, k, n, input_dtype, has_C, has_norm_weight, use_compile):
     D_raw = A @ B (+ C), rstd = rsqrt(mean(D_raw^2) + eps), D_out = D_raw * norm_weight.
     """
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 GEMM sq reduce epilogue is not yet supported")
     torch.random.manual_seed(0)
     eps = 1e-6
     A = torch.randn((m, k), device=device, dtype=input_dtype)
@@ -928,8 +926,6 @@ def test_gemm_rms_then_norm_act(input_dtype, activation, use_compile):
       postact = gemm_norm_act(D, W1_fused, rstd=rstd, activation=act)
     """
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 GEMM sq reduce epilogue is not yet supported")
     torch.random.manual_seed(0)
     m, k, n = 1024, 4096, 2048
     eps = 1e-6

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -164,8 +164,6 @@ def test_gemm_concat_layout(
 # @pytest.mark.parametrize("in_features", [4096])
 def test_linear_act(in_features, out_features, has_bias, input_dtype, activation, store_preact):
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 non-gated activation GEMM epilogue is not yet supported")
     torch.random.manual_seed(0)
     m = 1920
     x = torch.randn((m, in_features), device=device, dtype=input_dtype)

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -196,8 +196,6 @@ def test_linear_act(in_features, out_features, has_bias, input_dtype, activation
 def test_gemm_dact(n, k, input_dtype, activation):
     """Test GEMM with activation gradient computation."""
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 non-gated dactivation GEMM epilogue is not yet supported")
     torch.random.manual_seed(0)
     m = 960
     dout_input = torch.randn((m, k), device=device, dtype=input_dtype)

--- a/tests/test_linear_varlen_m.py
+++ b/tests/test_linear_varlen_m.py
@@ -404,8 +404,6 @@ def test_gemm_act_varlen_m(
 ):
     """Test GEMM with activation and variable length M dimension."""
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 non-gated activation GEMM epilogue is not yet supported")
     torch.random.manual_seed(42)
     seq_lens = torch.randint(100, 500, (num_groups,), device=device)
     total_m = seq_lens.sum().item()

--- a/tests/test_linear_varlen_m.py
+++ b/tests/test_linear_varlen_m.py
@@ -469,8 +469,6 @@ def test_gemm_dact_varlen_m(
 ):
     """Test GEMM with activation gradient and variable length M dimension."""
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 non-gated dactivation GEMM epilogue is not yet supported")
     torch.random.manual_seed(42)
     seq_lens = torch.randint(100, 500, (num_groups,), device=device)
     total_m = seq_lens.sum().item()

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -17,14 +17,14 @@ torch._dynamo.config.cache_size_limit = 64
 @pytest.mark.parametrize("in_features", [512])
 def test_mlp(in_features, hidden_features, dtype, activation, use_compile):
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 (d)activation GEMM epilogues not yet supported")
+    gated = activation in gated_to_pytorch_fn_map
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12 and gated:
+        pytest.skip("SM120 gated dactivation GEMM epilogue is not yet supported")
     torch.random.manual_seed(0)
     batch = 256
     mlp = MLP(
         in_features, hidden_features, activation=activation, device=device, dtype=dtype, tuned=False
     )
-    gated = activation in gated_to_pytorch_fn_map
     if gated:
         assert mlp.fc1.out_features == 2 * hidden_features
         assert mlp.fc2.in_features == hidden_features
@@ -58,8 +58,9 @@ def test_mlp(in_features, hidden_features, dtype, activation, use_compile):
 def test_mlp_zero_stride_grad(dtype, activation, use_compile):
     """out.sum().backward() produces expanded gradient with zero strides."""
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 (d)activation GEMM epilogues not yet supported")
+    gated = activation in gated_to_pytorch_fn_map
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12 and gated:
+        pytest.skip("SM120 gated dactivation GEMM epilogue is not yet supported")
     torch.random.manual_seed(0)
     mlp = MLP(512, 512, activation=activation, device=device, dtype=dtype, tuned=False)
     w1_ref = mlp.fc1.weight.detach().clone().float()
@@ -73,7 +74,6 @@ def test_mlp_zero_stride_grad(dtype, activation, use_compile):
     # Reference
     x_ref = x.detach().clone().float().requires_grad_(True)
     y_ref = F.linear(x_ref, w1_ref)
-    gated = activation in gated_to_pytorch_fn_map
     if gated:
         y_ref = gated_to_pytorch_fn_map[activation](y_ref[..., ::2], y_ref[..., 1::2])
     else:
@@ -89,11 +89,11 @@ def test_mlp_zero_stride_grad(dtype, activation, use_compile):
 def test_mlp_recompute(dtype, activation, use_compile):
     """recompute=True should match normal mode and float32 reference."""
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 (d)activation GEMM epilogues not yet supported")
+    gated = activation in gated_to_pytorch_fn_map
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12 and gated:
+        pytest.skip("SM120 gated dactivation GEMM epilogue is not yet supported")
     torch.random.manual_seed(0)
     batch, dim, hidden = 256, 512, 512
-    gated = activation in gated_to_pytorch_fn_map
     mlp = MLP(dim, hidden, activation=activation, device=device, dtype=dtype, tuned=False)
     x = torch.randn(batch, dim, device=device, dtype=dtype, requires_grad=True)
     dout = torch.randn(batch, dim, device=device, dtype=dtype)
@@ -146,11 +146,11 @@ def test_mlp_recompute_partial_grad(dtype, activation, freeze):
     Tests that needs_input_grad indexing is correct: x=[0], weight1=[1], weight2=[2].
     """
     device = "cuda"
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12:
-        pytest.skip("SM120 (d)activation GEMM epilogues not yet supported")
+    gated = activation in gated_to_pytorch_fn_map
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12 and gated:
+        pytest.skip("SM120 gated dactivation GEMM epilogue is not yet supported")
     torch.random.manual_seed(0)
     batch, dim, hidden = 256, 512, 512
-    gated = activation in gated_to_pytorch_fn_map
     mlp = MLP(
         dim,
         hidden,


### PR DESCRIPTION
Author: Alecco (& Codex) for Ologan

## Summary

Add SM120 support for RTX 50 GPUs across missing GEMM epilogue paths and dependent wrappers.

This PR enables and validates:

- gemm_dgated
- non-gated gemm_act
- non-gated gemm_dact
- gemm_sq_reduce
- gemm_rms
- gemm_rms_then_norm_act
- non-gated MLP eager and torch.compile(fullgraph=True)
- varlen non-gated activation and dactivation

It also adds generic GEMM epilogue profiling/benchmark tooling, SM120-specific profiling docs, and an SM120 gemm_rms default selected from repeated local measurements.

NOTE: I took the liberty to list RTX 50 as supported, but I understand this is a repo maintainer’s responsibility and it would entail more than just a drive-by PR. Please
let me know if I can help or if you’d prefer it removed for now.

## What changed

### Kernel and interface support

- enable SM120 non-gated activation forward in quack/gemm_act.py
- enable SM120 non-gated dactivation backward in quack/gemm_dact.py
- enable SM120 sq-reduce / RMS paths in quack/gemm_sq_reduce.py
- add an SM120-specific gemm_rms default in quack/gemm_interface.py
- keep autotune pruning correctness-only rather than pruning valid configs for local RTX 5060 performance

### ColVecReduce fix

- generalize ColVecReduce in quack/epi_ops.py to support inter-warp reduction when warp_N > 1
- preserve the old fast path for warp_N == 1
- this fixes the structural blocker behind SM120 sq-reduce / RMS

### Wrapper-level compile fix

- fix torch.compile(fullgraph=True) wrapper behavior in quack/linear.py and quack/mlp.py
- avoid tracing method dispatch through ops classes inside autograd wrapper code
- store concrete callables on the autograd context instead
- this is needed for non-gated MLP compile coverage on the local PyTorch 2.11.0+cu130 stack

### GEMM epilogue profiling and benchmark tooling

- add benchmarks/benchmark_gemm_epilogues.py as a generic GEMM epilogue benchmark harness for:
    - gemm_rms
    - gemm_norm_act
    - gemm_act
- support explicit config overrides from the CLI:
    - tile_m
    - tile_n
    - pingpong
    - swap_ab
    - dynamic persistence mode
- explicit configs use the active GPU capability instead of hardcoding SM120
- support benchmarking selected/default paths with:
    - --use-selected-config
    - --tuned
- support ncu --profile-from-start off with:
    - --profile
    - cudaProfilerStart/Stop
- use repeated CUDA-event timings with configurable statistic
- default the timing statistic to second-min, which is more reliable on a noisy desktop GPU than a single sample or raw minimum
- add SM120-specific profiling notes in docs/sm120_ncu_profiling.md

### Config and perf updates

- remove earlier non-gated act/dact tile_m==64 correctness-style restrictions
- do not change act/dact/norm-act selected defaults in this PR
- do not add performance-based autotune pruning for act/dact/norm-act
- keep _prune_gemm_rms_configs correctness-only:
    - it removes swap_ab because ColVecReduce requires no swap_ab
    - it does not prune valid SM120 candidates based on RTX 5060 performance
- add an explicit SM120 gemm_rms default selected from local repeated measurements:
    - 64x128, pingpong=True, swap_ab=False

### Packaging and docs

- add einops to pyproject.toml
- update README.md to list RTX 50 in Requirements and explicitly mention RTX 50 / SM120 support
- add docs/sm120_ncu_profiling.md with copy-paste timing and ncu commands

## Root causes fixed

### Missing SM120 activation / dactivation routes

The missing non-gated activation and dactivation paths were not missing API routes. They were explicitly blocked for SM120.

This PR removes those SM120-only NotImplementedError guards and enables the existing numerical tests on SM120.

An earlier version of this PR described tile_m=64 as required for act/dact compile validity under the 99 KiB SMEM limit. Follow-up testing showed that was too strong:
representative tile_m=128 non-gated act/dact configs compile, launch, and pass correctness on the local RTX 5060.

The final PR does not treat act/dact tile_m=64 as a correctness or SMEM-limit requirement, and it does not add act/dact default changes.

### ColVecReduce single-warp assumption

sq_reduce / rms were blocked by an assumption in ColVecReduce that all reduction columns fit inside one warp. SM120’s warp-level MMA epilogue layout can violate that
assumption.

This PR adds the required inter-warp reduction path through shared memory.

### Wrapper compile dispatch

Non-gated MLP compile-mode failures were caused by Dynamo not being able to trace method dispatch on ops classes inside autograd wrapper code.

Observed local repro before the wrapper fix:

pytest tests/test_mlp.py -x -k 'not swiglu and not reglu and not geglu'

Failure:

torch._dynamo.exc.Unsupported: Dynamo does not know how to trace method matmul_bwd_dx of class type

Failing case:

tests/test_mlp.py::test_mlp[512-512-dtype0-gelu_tanh_approx-True]

This PR converts those traced paths to concrete callable storage on the autograd context.

### Benchmarking on a noisy desktop GPU needed a better timing rule

Some early config conclusions were based on one-off or aggregate timing on a locally noisy desktop machine. That was enough to find broad direction, but not enough to
safely finalize defaults.

This PR adds a reusable GEMM epilogue benchmark harness and uses repeated CUDA-event samples with second-min timing so the final RMS default change is tied to a
reproducible and reviewer-friendly method.

## Performance notes

All config changes below were measured on a local desktop Blackwell RTX 5060 8GB.

Because this machine is noisy and the GPU is used for other desktop work, comparisons were made using the second-best repeated run rather than a single sample or raw
minimum.

This should be further tested on other RTX 50 models, especially the RTX 5090, since a larger desktop Blackwell SKU may prefer different defaults.

CUDA reports the following on the RTX 5060:

shared_memory_per_block_optin=101376
shared_memory_per_multiprocessor=102400

So the opt-in per-block limit is 99 KiB. Nsight Compute launch stats for sampled act/dact configs reported about 99.33 Kbyte/block dynamic SMEM plus about 1.02 Kbyte/block
driver SMEM. These kernels are close to the SM120 limit, but the sampled tile_m=128 configs launch successfully and pass correctness.

### gemm_act / gemm_dact

Non-gated gemm_act and gemm_dact no longer have a blanket tile_m==64 restriction. Representative tile_m=128 configs compile, launch, and pass correctness on the local RTX
5060.

This PR does not change the selected act/dact defaults.

Measured on (4096, 4096) x (4096, 14336) with bfloat16, using second-best of 9 CUDA-event samples:

gemm_act:
64x128, pingpong=False                  11.631 ms
64x128, pingpong=True                   11.495 ms
64x128, pingpong=False, swap_ab=True    11.468 ms
64x128, pingpong=True, swap_ab=True     11.407 ms
128x128, pingpong=False                 11.574 ms
128x128, pingpong=True                  11.402 ms
128x64, pingpong=False                  11.494 ms
128x64, pingpong=True                   11.444 ms

gemm_dact:
64x128, pingpong=False                  11.786 ms
64x128, pingpong=True                   11.486 ms
128x128, pingpong=False                 12.901 ms
128x128, pingpong=True                  13.703 ms
128x64, pingpong=False                  11.726 ms
128x64, pingpong=True                   34.880 ms

Interpretation:

- tile_m=64 is not clearly better for gemm_act; tile_m=128 is effectively tied on the tested shape
- tile_m=64 is about 2.1% faster than the best tested tile_m=128 dact config on the local RTX 5060
- this supports “do not prune valid tile_m=128 configs”, not a correctness or SMEM-limit assertion

### gemm_norm_act

This PR does not add norm-act-specific performance pruning or change norm-act selected defaults.

Measured competitive explicit candidates on (4096, 4096) x (4096, 4096) with bfloat16:

128x64, pingpong=False    3.374 ms
64x128, pingpong=False    3.785 ms
64x128, pingpong=True     3.296 ms
128x128, pingpong=False   3.822 ms
128x160, pingpong=False   3.689 ms

Selected-path measurements from the local run:

selected default:
samples [3.392, 4.643, 4.571, 4.573, 4.571, 3.276, 3.373]
second-best 3.373 ms

selected autotune:
samples [5.987, 7.177, 7.17, 7.172, 5.977, 7.168, 7.165]
second-best 5.987 ms

These measurements are retained as local context only. They are not used to prune norm-act candidates in this PR.

### gemm_rms

Final default untuned SM120 gemm_rms config:

64x128, pingpong=True, swap_ab=False

Measured on (4096, 4096) x (4096, 4096) with bfloat16 and preheat=500 ms.

Baseline selected-path measurements from the local tuning run:

default candidate 128x64, pingpong=False: second-best 5.672 ms
autotuned path from that run: second-best 3.454 ms

Explicit candidate measurements:

128x64, pingpong=False: second-best 5.679 ms
64x128, pingpong=True:  second-best 3.347 ms

After the final RMS default change:

selected default samples:
[3.353, 3.356, 3.347, 3.354, 3.35, 3.354, 3.352]

selected default second-best:
3.350 ms

Interpretation:

- the untuned/default RMS path now matches the measured local winner very closely
- _prune_gemm_rms_configs remains correctness-only and does not prune valid SM120 configs based on local performance

## Validation

Targeted validation run on SM120 / desktop RTX 5060 8GB:

pytest tests/test_linear.py -x -k 'test_gemm_dgated or test_gemm_act or test_gemm_dact or test_gemm_rms or test_gemm_rms_then_norm_act or test_gemm_norm_act or
test_linear_act or test_autocast or test_autocast_compile'

168 passed, 86 skipped, 1960 deselected

pytest tests/test_linear_varlen_m.py -x -k 'test_gemm_act_varlen_m or test_gemm_dact_varlen_m'

384 passed, 5396 deselected

pytest tests/test_mlp.py -x -k 'not swiglu and not reglu and not geglu'

14 passed, 38 deselected

Additional targeted validation after reviewer feedback:

pytest tests/test_linear.py -x -k 'test_gemm_act or test_gemm_dact or test_linear_act or test_autocast or test_autocast_compile'

66 passed, 6 skipped, 2206 deselected

pytest tests/test_linear_varlen_m.py -x -k 'test_gemm_act_varlen_m or test_gemm_dact_varlen_m'

384 passed, 5396 deselected

pytest tests/test_linear.py -x -k 'test_gemm_norm_act'

32 passed, 2246 deselected

Wrapper-dispatch validation after restoring the compile fix:

pytest tests/test_mlp.py -x -k 'not swiglu and not reglu and not geglu'

14 passed, 38 deselected, 14 warnings

pytest tests/test_linear.py -x -k 'test_linear_act or test_autocast_compile'

52 passed, 4 skipped, 2222 deselected, 14 warnings

Additional targeted validation on the same stack covered:

- direct minimized _compile_gemm_sq_reduce(...) repro on SM120
- direct gemm_rms(...) probes
- pytest tests/test_linear.py -x -k 'test_gemm_rms or test_gemm_rms_then_norm_act or test_gemm_norm_act'
    - 102 passed, 2176 deselected
- pytest tests/test_linear.py -x -k 'test_gemm_rms or test_gemm_rms_then_norm_act'
    - 70 passed, 2208 deselected
- benchmarks/benchmark_gemm_autotuned.py for gemm_act

## Reproduction commands for reviewers

Timing and config checks use the generic GEMM epilogue harness and the second-min rule where possible.

Examples:

python benchmarks/benchmark_gemm_epilogues.py \
  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
  --preheat-ms 500 --stat second-min --use-selected-config --repeats 7 --warmup 2

python benchmarks/benchmark_gemm_epilogues.py \
  --kernel rms --dtype bfloat16 --m 4096 --n 4096 --k 4096 \
  --preheat-ms 500 --stat second-min --use-selected-config --tuned --repeats 7 --warmup 2

python benchmarks/benchmark_gemm_epilogues.py \
  --kernel norm_act --dtype bfloat16 --activation gelu_tanh_approx \
  --m 4096 --n 4096 --k 4096 \
  --preheat-ms 500 --stat second-min --use-selected-config --repeats 7 --warmup 2

python benchmarks/benchmark_gemm_epilogues.py \
  --kernel act --dtype bfloat16 --activation gelu_tanh_approx \
  --m 4096 --n 14336 --k 4096 \
  --preheat-ms 500 --stat second-min --use-selected-config --repeats 7 --warmup 2

Example ncu run:

ncu --profile-from-start off python benchmarks/benchmark_gemm_epilogues.py \
  --profile --kernel rms --dtype bfloat16 \
  --m 4096 --n 4096 --k 4096 --preheat-ms 500 \
  --tile-m 64 --tile-n 128 --pingpong

For act/dact tile_m=128 checks, use direct lower-level dispatch to avoid conflating public selected defaults with explicit config testing.

## Risk assessment

### SM120

This PR is directly validated on local SM120 hardware and is the primary target.

### SM90 / SM100

Most behavior changes are gated on device_capacity == 12 in quack/gemm_interface.py, so they should not affect SM90/SM100.

The main shared-code change is ColVecReduce in quack/epi_ops.py. The old warp_N == 1 fast path is preserved, and the new logic only activates when the old code would have
asserted. That keeps cross-architecture risk narrow, but it is still the main place to recheck on SM90/SM100 hardware.

The wrapper compile-dispatch change touches shared Python wrapper code in quack/linear.py and quack/mlp.py. It preserves the same selected operations, but stores concrete
callables on the autograd context instead of storing ops classes and dispatching through class attributes. This should be behavior-preserving, but it is shared-code
surface area.

### Other RTX 50 models

This PR was tuned and validated on a desktop RTX 5060 8GB, not across the whole RTX 50 stack.

The tuning and support story should be further tested on other RTX 50 models, especially the RTX 5090. Larger Blackwell desktop SKUs may prefer different defaults.

## Files changed

- README.md
- pyproject.toml
- docs/sm120_ncu_profiling.md
- benchmarks/benchmark_gemm_epilogues.py
- quack/epi_ops.py
- quack/gemm_act.py
- quack/gemm_dact.py
- quack/gemm_interface.py
- quack/gemm_sq_reduce.py
- quack/linear.py
- quack/mlp.py
- tests/test_linear.py
- tests/test_linear_varlen_m.py
- tests/test_mlp.py

## Agent disclosure

This work was created with OpenAI Codex CLI agent, but directed, supervised, and every line reviewed by a human.