### PR TITLE
Fix ColVecReduce shared-memory staging

### DIFF
--- a/quack/epi_ops.py
+++ b/quack/epi_ops.py
@@ -545,7 +545,9 @@ class ColVecReduce(EpiOp):
     and final reduction + gmem write (end).
     """
 
-    max_warps_in_n = 8
+    def __init__(self, name, max_warps_in_n=1):
+        super().__init__(name)
+        self.max_warps_in_n = max_warps_in_n
 
     def param_fields(self):
         return [(self.name, object, None)]
@@ -554,17 +556,19 @@ class ColVecReduce(EpiOp):
         return {self.name: assume_stride_divisibility(getattr(args, self.name))}
 
     def smem_bytes(self, arg_tensor, cta_tile_shape_mnk, epi_tile):
-        if arg_tensor is None:
+        if arg_tensor is None or self.max_warps_in_n <= 1:
             return 0
         return cta_tile_shape_mnk[0] * self.max_warps_in_n * (Float32.width // 8)
 
     def smem_struct_field(self, gemm, params):
         tensor = getattr(params, self.name, None)
-        size = gemm.cta_tile_shape_mnk[0] * self.max_warps_in_n if tensor is not None else 0
+        if tensor is None or self.max_warps_in_n <= 1:
+            return None
+        size = gemm.cta_tile_shape_mnk[0] * self.max_warps_in_n
         return (f"s_{self.name}", cute.struct.Align[cute.struct.MemRange[Float32, size], 16])
 
     def get_smem_tensor(self, gemm, params, storage_epi):
-        if getattr(params, self.name, None) is None:
+        if getattr(params, self.name, None) is None or self.max_warps_in_n == 1:
             return None
         return getattr(storage_epi, f"s_{self.name}").get_tensor(
             cute.make_layout((gemm.cta_tile_shape_mnk[0], self.max_warps_in_n))
@@ -634,7 +638,10 @@ class ColVecReduce(EpiOp):
             warp_N = warp_layout_MN[1]
             warps_in_N = const_expr(cute.size(warp_N))
             max_warps_in_n = const_expr(self.max_warps_in_n)
-            assert warps_in_N <= max_warps_in_n, "ColVecReduce warp_N exceeds smem staging"
+            if const_expr(max_warps_in_n <= 1):
+                assert warps_in_N == 1, "ColVecReduce has no inter-warp-N smem staging"
+            else:
+                assert warps_in_N <= max_warps_in_n, "ColVecReduce warp_N exceeds smem staging"
 
             partition_for_epilogue_fn = partial(
                 partition_for_epilogue,

--- a/quack/gemm_sq_reduce.py
+++ b/quack/gemm_sq_reduce.py
@@ -97,7 +97,7 @@ class GemmSqReduceSm100(GemmSqReduceMixin, GemmSm100):
 
 
 class GemmSqReduceSm120(GemmSqReduceMixin, GemmSm120):
-    pass
+    _epi_ops = (*GemmDefaultEpiMixin._epi_ops, ColVecReduce("mColVecReduce", max_warps_in_n=2))
 
 
 @jit_cache

--- a/tests/test_epi_ops.py
+++ b/tests/test_epi_ops.py
@@ -1,0 +1,20 @@
+import cutlass
+
+from quack.epi_ops import ColVecReduce
+
+
+class _ArgTensor:
+    element_type = cutlass.Float32
+
+
+def test_colvec_reduce_smem_bytes_default_to_direct_write_path():
+    op = ColVecReduce("mColVecReduce")
+
+    assert op.smem_bytes(_ArgTensor(), (64, 128, 64), (64, 32)) == 0
+
+
+def test_colvec_reduce_smem_bytes_use_configured_n_warp_staging():
+    op = ColVecReduce("mColVecReduce", max_warps_in_n=2)
+
+    assert op.smem_bytes(_ArgTensor(), (64, 128, 64), (64, 32)) == 64 * 2 * 4
+    assert op.smem_bytes(None, (64, 128, 64), (64, 32)) == 0


### PR DESCRIPTION
My https://github.com/Dao-AILab/quack/pull/118 added shared-memory staging to ColVecReduce so SM120 epilogues with warps_in_N > 1 can reduce partial row sums across N-warps.

This PR fixes two issues:

1. The staging buffer was allocated for all architectures, even though SM90/SM100/SM110 use the original warps_in_N == 1 direct-write path.
2. SM120 reserved space for 8 N-warps, which was overly conservative.

New allocation policy:

SM90/SM100/SM110: 0 bytes
SM120:            tile_M * 2 * sizeof(float32)

For the default SM120 RMS config with tile_M=64, this reduces extra staging from:

64 * 8 * 4 = 2048B

to:

64 * 2 * 4 = 512B

## Why 2 N-warps on SM120

I temporarily instrumented ColVecReduce.end() after layout analysis:

lane_layout_MN, warp_layout_MN = _get_lane_warp_layouts(tiled_copy, reference_src)
lanes_in_N = cute.size(lane_layout_MN, mode=[1])
warps_in_N = cute.size(warp_layout_MN[1])

I checked representative SM120 RMS configs:

tile_m=64  tile_n=128 pingpong=True
tile_m=128 tile_n=64  pingpong=False
tile_m=128 tile_n=128 pingpong=False
tile_m=128 tile_n=160 pingpong=False
tile_m=128 tile_n=192 pingpong=False
tile_m=128 tile_n=64  pingpong=True
tile_m=128 tile_n=128 pingpong=True
tile_m=128 tile_n=160 pingpong=True

All reported:

lanes_in_N=4
warps_in_N=2

So SM120 only needs one FP32 partial per M row per two N-warps.

For non-SM120, the PR keeps zero extra shared memory and asserts if a future layout unexpectedly reports warps_in_N > 1.

## Validation

Added tests/test_epi_ops.py to verify:

SM90/SM100/SM110 -> 0 bytes
SM120            -> tile_M * 2 * sizeof(float32)
missing tensor   -> 0 bytes

Also ran an SM120 gemm_rms correctness check with the reduced staging.