### PR TITLE
Add Sm120 blockscaled FP4 GEMM path

### DIFF
--- a/AI/varlen_blockscaled_sf_layout.md
+++ b/AI/varlen_blockscaled_sf_layout.md
@@ -152,7 +152,7 @@ a tile-unit offset integer.
 
 ## Tests
 
-`tests/test_gemm_sm100_blockscaled.py`:
+`tests/test_gemm_blockscaled.py`:
 - `test_blockscaled_mxfp8_varlen_m_nonaligned` — 4 seqlen patterns × 2 B-majors = 8 cases.
   Patterns include `[128, 128, 128]`, `[100, 200, 150]`, `[30, 300, 64, 200]`,
   `[1, 128, 127, 129]`.

--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -194,19 +194,21 @@ def _run_blockscaled(args):
         compile_blockscaled_gemm_tvm_ffi,
         create_blockscaled_operand_quantized,
         create_blockscaled_operand_tensor,
+        create_sm120_blockscaled_scale_tensor,
         create_blockscaled_varlen_m_operands,
         scale_blocked_for_cublas,
         torch_dtype_for_cutlass,
     )
     from quack.cute_dsl_utils import get_device_capacity
-    from quack.gemm_default_epi import GemmDefaultSm100
+    from quack.gemm_default_epi import GemmDefaultSm100, GemmDefaultSm120
 
     sm_major = get_device_capacity(torch.device("cuda"))[0]
-    assert sm_major in (10, 11), (
-        f"Blockscaled GEMM requires SM100 (B200/B300) or SM110; got SM{sm_major}x. "
-        "MXFP8/MXFP4/NVFP4 use tcgen05 UMMA which is SM100+."
+    assert sm_major in (10, 11, 12), (
+        f"Blockscaled GEMM requires SM100/SM110 or SM120; got SM{sm_major}x."
     )
 
+    if sm_major == 12 and (args.varlen_m or args.varlen_k):
+        raise NotImplementedError("SM120 blockscaled benchmark path does not support varlen")
     if args.varlen_k or args.gather_A or args.pingpong:
         raise NotImplementedError(
             "blockscaled + varlen_k/gather/pingpong is not wired up yet. "
@@ -255,12 +257,16 @@ def _run_blockscaled(args):
         raise ValueError(
             f"MXFP4/NVFP4 require K-major for both A and B; got a_major={a_major}, b_major={b_major}"
         )
-    if not GemmDefaultSm100.can_implement_blockscaled(
+    GemmBlockscaledCls = GemmDefaultSm120 if sm_major == 12 else GemmDefaultSm100
+    mma_tiler_for_validation = (
+        tuple(mma_tiler_mnk) if len(mma_tiler_mnk) == 3 or sm_major != 12 else (*mma_tiler_mnk, 64)
+    )
+    if not GemmBlockscaledCls.can_implement_blockscaled(
         ab_dtype,
         sf_dtype,
         sf_vec_size,
         d_dtype,
-        mma_tiler_mnk,
+        mma_tiler_for_validation,
         cluster_shape_mn,
         m,
         n,
@@ -320,28 +326,43 @@ def _run_blockscaled(args):
         def fn():
             runner(mA, mB, mD, mSFA, mSFB, cu_seqlens_m)
     else:
-        a_ref, mA, a_sc_contig = create_blockscaled_operand_quantized(
-            l,
-            m,
-            k,
-            a_major == "m",
-            sf_vec_size,
-            ab_dtype,
-            sf_dtype,
-        )
-        b_ref, mB, b_sc_contig = create_blockscaled_operand_quantized(
-            l,
-            n,
-            k,
-            b_major == "n",
-            sf_vec_size,
-            ab_dtype,
-            sf_dtype,
-        )
-        # (l, rm, rk, 512) contig scale — consumed directly by the kernel.
-        mSFA, mSFB = a_sc_contig, b_sc_contig
-        sfa_ref = torch.ones_like(a_ref)
-        sfb_ref = torch.ones_like(b_ref)
+        if sm_major == 12:
+            if ab_dtype is not cutlass.Float4E2M1FN or d_dtype is not cutlass.BFloat16:
+                raise TypeError(
+                    "SM120 blockscaled benchmark currently supports FP4 inputs and BF16 D"
+                )
+            _, mA = create_blockscaled_operand_tensor(l, m, k, False, ab_dtype, init="empty")
+            _, mB = create_blockscaled_operand_tensor(l, n, k, False, ab_dtype, init="empty")
+            mA.view(torch.uint8).fill_(0x22)
+            mB.view(torch.uint8).fill_(0x22)
+            a_ref = torch.ones((m, k, l), device="cuda", dtype=torch.float32)
+            b_ref = torch.ones((n, k, l), device="cuda", dtype=torch.float32)
+            sfa_ref, mSFA = create_sm120_blockscaled_scale_tensor(l, m, k, sf_vec_size, sf_dtype)
+            sfb_ref, mSFB = create_sm120_blockscaled_scale_tensor(l, n, k, sf_vec_size, sf_dtype)
+            a_sc_contig = b_sc_contig = None
+        else:
+            a_ref, mA, a_sc_contig = create_blockscaled_operand_quantized(
+                l,
+                m,
+                k,
+                a_major == "m",
+                sf_vec_size,
+                ab_dtype,
+                sf_dtype,
+            )
+            b_ref, mB, b_sc_contig = create_blockscaled_operand_quantized(
+                l,
+                n,
+                k,
+                b_major == "n",
+                sf_vec_size,
+                ab_dtype,
+                sf_dtype,
+            )
+            # (l, rm, rk, 512) contig scale — consumed directly by the kernel.
+            mSFA, mSFB = a_sc_contig, b_sc_contig
+            sfa_ref = torch.ones_like(a_ref)
+            sfb_ref = torch.ones_like(b_ref)
         _, mD = create_blockscaled_operand_tensor(l, m, n, False, d_dtype, init="empty")
         runner = compile_blockscaled_gemm_tvm_ffi(
             ab_dtype,
@@ -372,10 +393,12 @@ def _run_blockscaled(args):
             torch.testing.assert_close(mD.float(), ref, atol=tol, rtol=1e-3)
         else:
             ref = blockscaled_gemm_reference(a_ref, b_ref, sfa_ref, sfb_ref)
+            if d_dtype != cutlass.Float32:
+                ref = ref.to(torch_dtype_for_cutlass(d_dtype)).float()
             torch.testing.assert_close(mD.float(), ref, atol=tol, rtol=1e-3)
         print("Ref check PASSED")
 
-    print("Running SM100 Blockscaled GEMM with:")
+    print(f"Running SM{sm_major}0 Blockscaled GEMM with:")
     print(f"mnkl: {args.mnkl}")
     print(f"tile_shape_mnk: {mma_tiler_mnk}, cluster_shape_mnk: {cluster_shape_mnk}")
     print(
@@ -394,6 +417,12 @@ def _run_blockscaled(args):
         # with per-group swizzled scales we don't build here. Looping F.scaled_mm per
         # batch would be an unfair comparison (hides batching potential), so skip.
         print("(skipping cuBLAS: batched blockscaled mm not supported via a single call)")
+        return
+    if sm_major == 12:
+        print(
+            "(skipping cuBLAS comparison: SM120 benchmark currently builds QuACK's "
+            "padded row-major scale tensors, not the cuBLAS/PyTorch scaled_mm scale layout)"
+        )
         return
     if a_major != "k" or b_major != "k":
         # F.scaled_mm requires A (M,K) row-major and B (K,N) col-major —

--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -7,8 +7,9 @@ from triton.testing import do_bench
 from quack.gemm import gemm as quack_gemm
 
 """
-GEMM benchmark using quack.gemm.gemm() (dense path) or the SM100 blockscaled
-path (MXFP8 / MXFP4 / NVFP4) via --blockscaled.
+GEMM benchmark using quack.gemm.gemm() (dense path) or the blockscaled
+path (MXFP8 / MXFP4 / NVFP4). The blockscaled path is selected by passing
+--sf_dtype and/or --sf_vec_size.
 
 Usage (dense):
     python benchmarks/benchmark_gemm.py --mnkl 512,7168,2048,256 \
@@ -17,18 +18,17 @@ Usage (dense):
 
 Usage (blockscaled MXFP8, with cuBLAS comparison):
     python benchmarks/benchmark_gemm.py --mnkl 4096,4096,4096,1 \
-        --blockscaled --ab_dtype Float8E4M3FN --sf_dtype Float8E8M0FNU \
-        --sf_vec_size 32 --init quant --compare_cublas
+        --ab_dtype Float8E4M3FN --sf_dtype Float8E8M0FNU --sf_vec_size 32
 
 Usage (blockscaled MXFP4):
     python benchmarks/benchmark_gemm.py --mnkl 4096,4096,4096,1 \
-        --blockscaled --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU \
-        --sf_vec_size 32 --d_dtype Float32
+        --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU \
+        --sf_vec_size 32 --d_dtype BFloat16
 
 Usage (blockscaled NVFP4):
     python benchmarks/benchmark_gemm.py --mnkl 4096,4096,4096,1 \
-        --blockscaled --ab_dtype Float4E2M1FN --sf_dtype Float8E4M3FN \
-        --sf_vec_size 16 --d_dtype Float32
+        --ab_dtype Float4E2M1FN --sf_dtype Float8E4M3FN \
+        --sf_vec_size 16 --d_dtype BFloat16
 """
 
 

--- a/quack/blockscaled_gemm_utils.py
+++ b/quack/blockscaled_gemm_utils.py
@@ -11,7 +11,7 @@ import cutlass.cute as cute
 
 from quack.compile_utils import make_fake_tensor as fake_tensor
 from quack.cute_dsl_utils import get_device_capacity, get_max_active_clusters
-from quack.gemm_default_epi import GemmDefaultSm100
+from quack.gemm_default_epi import GemmDefaultSm100, GemmDefaultSm120
 from quack.gemm_tvm_ffi_utils import div_for_dtype, make_scheduler_args
 from quack.mx_utils import (
     to_mx_compiled,
@@ -225,6 +225,53 @@ def create_blockscaled_scale_tensor(
     packed_f32 = _pack_blockscaled_scales(ref_blocks)
     packed = torch.empty_like(packed_f32, dtype=torch_dtype_for_cutlass(dtype))
     packed.copy_(packed_f32)
+    ref = (
+        ref_blocks.permute(2, 0, 1)
+        .unsqueeze(-1)
+        .expand(l, mn, sf_k, sf_vec_size)
+        .reshape(l, mn, sf_k * sf_vec_size)
+        .permute(1, 2, 0)
+    )[:, :k, :]
+    return ref, packed
+
+
+def create_sm120_blockscaled_scale_tensor(
+    l: int,
+    mn: int,
+    k: int,
+    sf_vec_size: int,
+    dtype: Type[cutlass.Numeric],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create row-major padded SM120 blockscaled scale tensors.
+
+    SM120 TMA copies scale factors as 2D row-major pages. Physical scale columns
+    are padded to a multiple of 16; columns beyond ``ceil(k / sf_vec_size)`` are
+    padding and ignored by the kernel.
+    """
+    if k % 64 != 0:
+        raise ValueError("SM120 blockscaled scale helper requires K divisible by 64")
+    if sf_vec_size not in (16, 32):
+        raise ValueError("SM120 blockscaled scale helper supports sf_vec_size 16 or 32")
+    expected_dtype = cutlass.Float8E4M3FN if sf_vec_size == 16 else cutlass.Float8E8M0FNU
+    if dtype is not expected_dtype:
+        raise ValueError(f"SM120 sf_vec_size={sf_vec_size} requires {expected_dtype}, got {dtype}")
+    sf_k = ceil_div(k, sf_vec_size)
+    physical_sf_k = ceil_div(sf_k, 16) * 16
+    if dtype == cutlass.Float8E8M0FNU:
+        exponents = torch.randint(0, 2, (mn, sf_k, l), device="cuda", dtype=torch.int32)
+        ref_blocks = torch.pow(2.0, exponents.float())
+    else:
+        ref_blocks = torch.randint(1, 4, (mn, sf_k, l), device="cuda", dtype=torch.int32).float()
+    packed = torch.empty(
+        (mn, physical_sf_k, l), device="cuda", dtype=torch_dtype_for_cutlass(dtype)
+    )
+    packed[:, :sf_k, :].copy_(ref_blocks.to(packed.dtype))
+    if physical_sf_k > sf_k:
+        poison = torch.tensor([0.5, 1.5, 2.0, 3.0], device="cuda", dtype=torch.float32).to(
+            packed.dtype
+        )
+        cols = torch.arange(physical_sf_k - sf_k, device="cuda")
+        packed[:, sf_k:, :] = poison[cols % poison.numel()][None, :, None]
     ref = (
         ref_blocks.permute(2, 0, 1)
         .unsqueeze(-1)
@@ -609,7 +656,7 @@ def compile_blockscaled_gemm_tvm_ffi(
     varlen_m: bool = False,
     varlen_k: bool = False,
 ) -> Callable:
-    """Compile the SM100 blockscaled GEMM.
+    """Compile the blockscaled GEMM.
 
     When varlen_m: mA is (total_m, k) K-major, mD is (total_m, n) N-major,
     mB is (n, k, l); run(...) takes an extra cu_seqlens_m tensor.
@@ -617,15 +664,63 @@ def compile_blockscaled_gemm_tvm_ffi(
     run(...) takes an extra cu_seqlens_k tensor.
     """
     device_capacity = get_device_capacity(mA.device)
-    if device_capacity[0] not in (10, 11):
-        raise RuntimeError("Blockscaled SM100 GEMM requires SM100/SM110")
+    if device_capacity[0] not in (10, 11, 12):
+        raise RuntimeError("Blockscaled GEMM requires SM100/SM110 or SM120")
     assert not (varlen_m and varlen_k), "Only one of varlen_m / varlen_k"
 
-    gemm = partial(
-        GemmDefaultSm100,
-        sf_vec_size=sf_vec_size,
-        use_clc_persistence=use_clc_persistence,
-    )(cutlass.Float32, ab_dtype, mma_tiler_mn, (*cluster_shape_mn, 1))
+    mma_tiler_mn_only = mma_tiler_mn[:2]
+    mma_tiler_k = mma_tiler_mn[2] if len(mma_tiler_mn) == 3 else 64
+
+    if device_capacity[0] == 12:
+        if varlen_m or varlen_k:
+            raise NotImplementedError("SM120 blockscaled GEMM does not support varlen")
+        if mma_tiler_k != 64:
+            raise NotImplementedError("SM120 blockscaled GEMM requires tile_K=64")
+        if len(mA.shape) != 3 or len(mB.shape) != 3 or len(mD.shape) != 3:
+            raise ValueError("SM120 blockscaled GEMM requires rank-3 A/B/D tensors")
+        logical_k = mA.shape[1] * (2 if ab_dtype is cutlass.Float4E2M1FN else 1)
+        physical_scale_cols = ceil_div(ceil_div(logical_k, sf_vec_size), 16) * 16
+        expected_sfa_shape = (mA.shape[0], physical_scale_cols, mA.shape[2])
+        expected_sfb_shape = (mB.shape[0], physical_scale_cols, mB.shape[2])
+        if tuple(mSFA.shape) != expected_sfa_shape:
+            raise ValueError(f"SFA shape must be {expected_sfa_shape}, got {tuple(mSFA.shape)}")
+        if tuple(mSFB.shape) != expected_sfb_shape:
+            raise ValueError(f"SFB shape must be {expected_sfb_shape}, got {tuple(mSFB.shape)}")
+        if not GemmDefaultSm120.can_implement_blockscaled(
+            ab_dtype,
+            sf_dtype,
+            sf_vec_size,
+            d_dtype,
+            (*mma_tiler_mn_only, 64),
+            cluster_shape_mn,
+            mA.shape[0],
+            mB.shape[0],
+            logical_k,
+            mA.shape[2],
+            "k",
+            "k",
+            "n",
+        ):
+            raise RuntimeError(
+                "Unsupported SM120 blockscaled config; supported formats are MXFP4 "
+                "(Float4E2M1FN + Float8E8M0FNU + vec32) and NVFP4 "
+                "(Float4E2M1FN + Float8E4M3FN + vec16)"
+            )
+        gemm = GemmDefaultSm120(
+            cutlass.Float32,
+            ab_dtype,
+            (*mma_tiler_mn_only, 64),
+            (*cluster_shape_mn, 1),
+            is_persistent=False,
+            sf_vec_size=sf_vec_size,
+            sf_dtype=sf_dtype,
+        )
+    else:
+        gemm = partial(
+            GemmDefaultSm100,
+            sf_vec_size=sf_vec_size,
+            use_clc_persistence=use_clc_persistence,
+        )(cutlass.Float32, ab_dtype, mma_tiler_mn, (*cluster_shape_mn, 1))
     compile_epi_args = gemm.EpilogueArguments()
     scheduler_args = make_scheduler_args(
         get_max_active_clusters(cluster_shape_mn[0] * cluster_shape_mn[1]),
@@ -709,7 +804,16 @@ def compile_blockscaled_gemm_tvm_ffi(
         varlen_args,
         stream,
     ):
-        gemm(a, b, d, None, compile_epi_args, scheduler_args, varlen_args, stream, sfa, sfb, None)
+        if cutlass.const_expr(device_capacity[0] == 12):
+            # SM120 FFI has already validated packed torch storage and compiles
+            # logical fake CuTe tensor views. Do not route through
+            # blockscaled_call, whose host validation expects logical class-call
+            # tensors rather than packed torch.float4_e2m1fn_x2 storage.
+            gemm._blockscaled_call_jit(a, b, d, varlen_args, stream, sfa, sfb, None)
+        else:
+            gemm(
+                a, b, d, None, compile_epi_args, scheduler_args, varlen_args, stream, sfa, sfb, None
+            )
 
     compiled = cute.compile(
         runner,

--- a/quack/gemm_sm120.py
+++ b/quack/gemm_sm120.py
@@ -17,12 +17,97 @@ import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass import Int32, Boolean, const_expr
+from cutlass.utils import LayoutEnum
 
-from quack.varlen_utils import VarlenManager
+from quack.varlen_utils import VarlenArguments, VarlenManager
 from quack.pipeline import make_pipeline_state
 from quack import copy_utils
 from quack.gemm_sm90 import GemmSm90, NamedBarrierGemm
 from quack import sm80_utils
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return ((x + multiple - 1) // multiple) * multiple
+
+
+@cute.jit
+def _sm120_blockscaled_scale_fragment(
+    dtype: cutlass.Constexpr[Type[cutlass.Numeric]],
+    sf_vec_size: cutlass.Constexpr[int],
+    is_sfa: cutlass.Constexpr[bool],
+):
+    if const_expr(sf_vec_size == 16):
+        if const_expr(is_sfa):
+            return warp.make_mxf4nvf4_sfa_fragment(dtype)
+        return warp.make_mxf4nvf4_sfb_fragment(dtype)
+    return cute.make_rmem_tensor(cute.make_layout(((32, 2),), stride=((0, 1),)), dtype)
+
+
+@cute.jit
+def _load_sm120_blockscaled_selector0_scale_fragments(
+    sSFA: cute.Tensor,
+    sSFB: cute.Tensor,
+    stage: cutlass.Int32,
+    m_atom_base: cutlass.Int32,
+    n_atom_base: cutlass.Int32,
+    k_scale_base: cutlass.Int32,
+    sf_vec_size: cutlass.Constexpr[int],
+    sf_dtype: cutlass.Constexpr[Type[cutlass.Numeric]],
+):
+    """Load selector-zero SM120 FP4 blockscaled scale packets from SMEM.
+
+    The tuple-lowered SM120 blockscaled MMA uses byte-id-a=byte-id-b=0. For
+    selector zero, SFA provider lanes map tid 0 to row group and tid 1 to row
+    group+8; SFB provider lanes map group 0..7 to logical N columns 0..7.
+    """
+    lane = cute.arch.lane_idx()
+    group = lane >> 2
+    tid = lane & 3
+    sfa_row = m_atom_base + group + 8 * (tid & 1)
+    sfb_col = n_atom_base + group
+    sfa = _sm120_blockscaled_scale_fragment(sf_dtype, sf_vec_size, True)
+    sfb = _sm120_blockscaled_scale_fragment(sf_dtype, sf_vec_size, False)
+    compact_sfa = cute.filter_zeros(sfa)
+    compact_sfb = cute.filter_zeros(sfb)
+    for kb in cutlass.range_constexpr(64 // sf_vec_size):
+        compact_sfa[kb] = sSFA[sfa_row, k_scale_base + kb, stage]
+        compact_sfb[kb] = sSFB[sfb_col, k_scale_base + kb, stage]
+    return sfa, sfb
+
+
+@cute.jit
+def _make_sm120_fp4_ldmatrix_smem_view(
+    smem: cute.Tensor,
+    mn: cutlass.Constexpr[int],
+):
+    return cute.make_tensor(
+        smem.iterator,
+        cute.make_layout((mn, (8, 4)), stride=(64, (1, 16))),
+    )
+
+
+@cute.jit
+def _expand_compact_fp4_to_sm120_ldmatrix_smem(
+    compact: cute.Tensor,
+    padded: cute.Tensor,
+    mn: cutlass.Constexpr[int],
+):
+    """Expand packed FP4 bytes into the padded SM120 ldmatrix SMEM layout."""
+    tidx, _, _ = cute.arch.thread_idx()
+
+    for i in cutlass.range((mn * 64 + 31) // 32, unroll_full=True):
+        flat = tidx + i * 32
+        if flat < mn * 64:
+            padded[flat // 64, flat % 64] = cutlass.Int8(0)
+
+    for i in cutlass.range((mn * 32 + 31) // 32, unroll_full=True):
+        flat = tidx + i * 32
+        if flat < mn * 32:
+            row = flat // 32
+            packed_k = flat - row * 32
+            group = packed_k // 8
+            in_group = packed_k - group * 8
+            padded[row, group * 16 + in_group] = compact[row, packed_k]
 
 
 class GemmSm120(GemmSm90):
@@ -49,6 +134,8 @@ class GemmSm120(GemmSm90):
         gather_A: bool = False,
         concat_layout: tuple | None = None,
         use_pdl: bool = True,
+        sf_vec_size: int | None = None,
+        sf_dtype: Type[cutlass.Numeric] | None = None,
     ):
         # Don't call super().__init__ — we set up our own config
         self.acc_dtype = acc_dtype
@@ -59,6 +146,27 @@ class GemmSm120(GemmSm90):
         self.fp8_slow_accum = False
         self.gather_A = gather_A
         self.concat_layout = concat_layout or ()
+        self.blockscaled = sf_vec_size is not None
+        self.sf_vec_size = sf_vec_size
+        self.sf_dtype = sf_dtype
+        if self.blockscaled:
+            if a_dtype is not cutlass.Float4E2M1FN:
+                raise ValueError("SM120 blockscaled path currently supports Float4E2M1FN A/B only")
+            if acc_dtype is not cutlass.Float32:
+                raise ValueError("SM120 blockscaled path requires Float32 accumulation")
+            if sf_vec_size not in (16, 32):
+                raise ValueError("SM120 blockscaled path supports sf_vec_size 16 or 32")
+            expected_sf_dtype = cutlass.Float8E4M3FN if sf_vec_size == 16 else cutlass.Float8E8M0FNU
+            if sf_dtype is not expected_sf_dtype:
+                raise ValueError(
+                    f"SM120 blockscaled sf_vec_size={sf_vec_size} requires {expected_sf_dtype}"
+                )
+            if pingpong:
+                raise NotImplementedError("SM120 blockscaled pingpong is not implemented")
+            if gather_A:
+                raise NotImplementedError("SM120 blockscaled gather_A is not implemented")
+            if cluster_shape_mnk != (1, 1, 1):
+                raise ValueError("SM120 blockscaled path requires cluster_shape_mnk=(1,1,1)")
         if self.pingpong:
             assert self.is_persistent, "Pingpong gemm requires persistent scheduler"
         if gather_A:
@@ -74,7 +182,7 @@ class GemmSm120(GemmSm90):
 
         # Pingpong: 2 warp groups each with (2,2,1) atom layout
         # Non-pingpong: 1 group of 8 warps with (4,2,1) atom layout
-        self.mma_inst_mnk = (16, 8, 16)
+        self.mma_inst_mnk = (16, 8, 64) if self.blockscaled else (16, 8, 16)
         self.atom_layout_mnk = (4, 2, 1) if not self.pingpong else (2, 2, 1)
         # num_mma_warps = total warps doing MMA (both warp groups in pingpong)
         self.num_mma_warps = math.prod(self.atom_layout_mnk) * (1 if not self.pingpong else 2)
@@ -129,7 +237,14 @@ class GemmSm120(GemmSm90):
 
     def _setup_tiled_mma(self):
         """Set up warp-level MMA (MmaF16BF16Op) and tile K dimension."""
-        op = warp.MmaF16BF16Op(self.a_dtype, self.acc_dtype, self.mma_inst_mnk)
+        if const_expr(self.blockscaled):
+            if self.sf_vec_size == 16:
+                op = warp.MmaMXF4NVF4Op(self.a_dtype, self.acc_dtype, self.sf_dtype)
+            else:
+                op = warp.MmaMXF4Op(self.a_dtype, self.acc_dtype, self.sf_dtype)
+            self.mma_inst_mnk = (16, 8, 64)
+        else:
+            op = warp.MmaF16BF16Op(self.a_dtype, self.acc_dtype, self.mma_inst_mnk)
         tC = cute.make_layout(self.atom_layout_mnk)
         atom_m, atom_n, atom_k = self.atom_layout_mnk
         # We want each warp to have 16 consecutive elements in the N direction, for STSM
@@ -152,8 +267,963 @@ class GemmSm120(GemmSm90):
         )
         self.cta_tile_shape_mnk = (self.cta_tile_shape_mnk[0], self.cta_tile_shape_mnk[1], tile_k)
 
-    # __call__, _setup_attributes, make_ab_pipeline, make_epi_store_pipeline,
-    # make_sched_pipeline, epilogue are all inherited from GemmSm90.
+    # Dense __call__, _setup_attributes, make_ab_pipeline, make_epi_store_pipeline,
+    # make_sched_pipeline, epilogue are inherited from GemmSm90.
+
+    @staticmethod
+    def padded_blockscale_cols(k: int, sf_vec_size: int) -> int:
+        if k % 64 != 0:
+            raise ValueError("SM120 blockscaled GEMM requires K divisible by 64")
+        return _round_up(k // sf_vec_size, 16)
+
+    @staticmethod
+    def can_implement_blockscaled(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        d_dtype: Type[cutlass.Numeric],
+        mma_tiler_mnk: Tuple[int, int] | Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        d_major: str,
+    ) -> bool:
+        del d_major
+        if ab_dtype is not cutlass.Float4E2M1FN:
+            return False
+        if sf_vec_size == 16:
+            if sf_dtype is not cutlass.Float8E4M3FN:
+                return False
+        elif sf_vec_size == 32:
+            if sf_dtype is not cutlass.Float8E8M0FNU:
+                return False
+        else:
+            return False
+        if d_dtype is not cutlass.BFloat16:
+            return False
+        if a_major != "k" or b_major != "k":
+            return False
+        if cluster_shape_mn != (1, 1):
+            return False
+        if len(mma_tiler_mnk) == 3 and mma_tiler_mnk[2] != 64:
+            return False
+        if mma_tiler_mnk[0] != 128 or mma_tiler_mnk[1] != 128:
+            return False
+        return m % 128 == 0 and n % 128 == 0 and k % 64 == 0 and l == 1
+
+    @staticmethod
+    def _shape_tuple(tensor: cute.Tensor) -> tuple[int, ...]:
+        return tuple(int(dim) for dim in tensor.shape)
+
+    @staticmethod
+    def _is_empty_varlen(varlen_args: VarlenArguments) -> bool:
+        return (
+            varlen_args.mCuSeqlensM is None
+            and varlen_args.mCuSeqlensK is None
+            and varlen_args.mAIdx is None
+        )
+
+    def blockscaled_call(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mD: Optional[cute.Tensor],
+        mC: Optional[cute.Tensor],
+        epilogue_args: tuple,
+        scheduler_args,
+        varlen_args: Optional[VarlenArguments],
+        stream,
+        mSFA: Optional[cute.Tensor] = None,
+        mSFB: Optional[cute.Tensor] = None,
+        trace_ptr: Optional[cutlass.Int64] = None,
+    ):
+        varlen_args = self._validate_blockscaled_call(
+            mA, mB, mD, mC, mSFA, mSFB, epilogue_args, scheduler_args, varlen_args, trace_ptr
+        )
+        return self._blockscaled_call_jit(
+            mA,
+            mB,
+            mD,
+            varlen_args,
+            stream,
+            mSFA,
+            mSFB,
+            trace_ptr,
+        )
+
+    @cute.jit
+    def _blockscaled_call_jit(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mD: cute.Tensor,
+        varlen_args: Optional[VarlenArguments],
+        stream,
+        mSFA: cute.Tensor,
+        mSFB: cute.Tensor,
+        trace_ptr: Optional[cutlass.Int64] = None,
+    ):
+        if const_expr(varlen_args is None):
+            varlen_args = VarlenArguments()
+        return self._call_blockscaled(
+            mA,
+            mB,
+            mD,
+            varlen_args,
+            stream,
+            mSFA,
+            mSFB,
+            trace_ptr,
+        )
+
+    def _validate_blockscaled_call(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mD: cute.Tensor,
+        mC: Optional[cute.Tensor],
+        mSFA: Optional[cute.Tensor],
+        mSFB: Optional[cute.Tensor],
+        epilogue_args: tuple,
+        scheduler_args,
+        varlen_args: Optional[VarlenArguments],
+        trace_ptr: Optional[cutlass.Int64],
+    ) -> VarlenArguments:
+        if mSFA is None or mSFB is None:
+            raise ValueError("SM120 blockscaled GEMM requires SFA and SFB scale tensors")
+        if mD is None:
+            raise ValueError("SM120 blockscaled GEMM requires an output tensor")
+        if mC is not None:
+            raise NotImplementedError("SM120 blockscaled C/beta path is not implemented")
+        if epilogue_args not in (None, ()):
+            beta = getattr(epilogue_args, "beta", None)
+            add_to_output = getattr(epilogue_args, "add_to_output", False)
+            if beta not in (None, 0) or add_to_output:
+                raise NotImplementedError("SM120 blockscaled C/beta path is not implemented")
+        del scheduler_args
+        if trace_ptr is not None:
+            raise NotImplementedError("SM120 blockscaled trace path is not implemented")
+        if self.cta_tile_shape_mnk != (128, 128, 64):
+            raise NotImplementedError("SM120 blockscaled path currently supports 128x128x64 tiles")
+        if self.cluster_shape_mnk != (1, 1, 1):
+            raise NotImplementedError("SM120 blockscaled path requires cluster_shape_mnk=(1,1,1)")
+        if (
+            mA.element_type is not cutlass.Float4E2M1FN
+            or mB.element_type is not cutlass.Float4E2M1FN
+        ):
+            raise TypeError("SM120 blockscaled path requires Float4E2M1FN A/B")
+        if mSFA.element_type is not self.sf_dtype or mSFB.element_type is not self.sf_dtype:
+            raise TypeError(f"SM120 blockscaled path requires {self.sf_dtype} SFA/SFB")
+        if mD.element_type is not cutlass.BFloat16:
+            raise NotImplementedError("SM120 blockscaled path currently supports only BF16 D")
+
+        if varlen_args is None:
+            varlen_args = VarlenArguments()
+        if not self._is_empty_varlen(varlen_args):
+            raise NotImplementedError("SM120 blockscaled varlen GEMM is not implemented")
+
+        a_shape = self._shape_tuple(mA)
+        b_shape = self._shape_tuple(mB)
+        d_shape = self._shape_tuple(mD)
+        if len(a_shape) != 3 or len(b_shape) != 3 or len(d_shape) != 3:
+            raise ValueError("SM120 blockscaled tensors must use logical rank-3 shapes")
+        m, k, l = a_shape
+        n, kb, lb = b_shape
+        if k != kb or l != lb:
+            raise ValueError("SM120 blockscaled A/B K and L extents must match")
+        if k % 64 != 0:
+            if k * 2 % 64 == 0:
+                raise ValueError(
+                    "SM120 blockscaled class call expects logical Float4E2M1FN K extent; "
+                    "use compile_blockscaled_gemm_tvm_ffi for packed torch.float4_e2m1fn_x2 "
+                    "storage"
+                )
+            raise ValueError("SM120 blockscaled path requires logical K to be divisible by 64")
+        if d_shape != (m, n, l):
+            raise ValueError(f"SM120 blockscaled D shape must be {(m, n, l)}, got {d_shape}")
+        if m % 128 != 0 or n % 128 != 0:
+            raise NotImplementedError("SM120 blockscaled path requires M/N multiples of 128")
+        if l != 1:
+            raise NotImplementedError("SM120 blockscaled path currently supports L=1")
+        scale_cols = self.padded_blockscale_cols(k, self.sf_vec_size)
+        if self._shape_tuple(mSFA) != (m, scale_cols, l):
+            raise ValueError(
+                f"SFA shape must be {(m, scale_cols, l)}, got {self._shape_tuple(mSFA)}"
+            )
+        if self._shape_tuple(mSFB) != (n, scale_cols, l):
+            raise ValueError(
+                f"SFB shape must be {(n, scale_cols, l)}, got {self._shape_tuple(mSFB)}"
+            )
+        return varlen_args
+
+    @cute.jit
+    def _call_blockscaled(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mD: cute.Tensor,
+        varlen_args: Optional[VarlenArguments],
+        stream,
+        mSFA: cute.Tensor,
+        mSFB: cute.Tensor,
+        trace_ptr: Optional[cutlass.Int64] = None,
+    ):
+        del stream, trace_ptr
+
+        self.a_dtype = mA.element_type
+        self.b_dtype = mB.element_type
+        self.d_dtype = mD.element_type
+        self.c_dtype = None
+        self.sf_dtype = mSFA.element_type
+        self.a_layout = LayoutEnum.from_tensor(mA)
+        self.b_layout = LayoutEnum.from_tensor(mB)
+        self.d_layout = LayoutEnum.from_tensor(mD)
+        self.c_layout = None
+        self._setup_attributes(())
+        self.ab_stage = 1
+        tile_m, tile_n, tile_k = self.cta_tile_shape_mnk
+
+        self.a_smem_layout_staged = cute.make_layout(
+            (tile_m, tile_k, self.ab_stage), stride=(tile_k, 1, tile_m * tile_k)
+        )
+        self.b_smem_layout_staged = cute.make_layout(
+            (tile_n, tile_k, self.ab_stage), stride=(tile_k, 1, tile_n * tile_k)
+        )
+        scale_tile_k = 16
+        a_compact_smem_layout_staged = cute.make_layout(
+            (tile_m, tile_k // 2, self.ab_stage),
+            stride=(tile_k // 2, 1, tile_m * (tile_k // 2)),
+        )
+        b_compact_smem_layout_staged = cute.make_layout(
+            (tile_n, tile_k // 2, self.ab_stage),
+            stride=(tile_k // 2, 1, tile_n * (tile_k // 2)),
+        )
+        self.sfa_smem_layout_staged = cute.make_layout(
+            (tile_m, scale_tile_k, self.ab_stage),
+            stride=(scale_tile_k, 1, tile_m * scale_tile_k),
+        )
+        self.sfb_smem_layout_staged = cute.make_layout(
+            (tile_n, scale_tile_k, self.ab_stage),
+            stride=(scale_tile_k, 1, tile_n * scale_tile_k),
+        )
+        acc_smem_layout = cute.make_layout((tile_m, tile_n), stride=(tile_n, 1))
+
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, 0))
+        a_compact_smem_layout = cute.slice_(a_compact_smem_layout_staged, (None, None, 0))
+        b_compact_smem_layout = cute.slice_(b_compact_smem_layout_staged, (None, None, 0))
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, 0))
+
+        m_extent = cute.size(mA, mode=[0])
+        k_extent = cute.size(mA, mode=[1])
+        packed_k_extent = k_extent // 2
+        n_extent = cute.size(mB, mode=[0])
+        l_extent = cute.size(mA, mode=[2])
+        mA_u8 = cute.make_tensor(
+            cute.recast_ptr(mA.iterator, dtype=cutlass.Uint8),
+            cute.make_layout(
+                (m_extent, packed_k_extent, l_extent),
+                stride=(packed_k_extent, 1, m_extent * packed_k_extent),
+            ),
+        )
+        mB_u8 = cute.make_tensor(
+            cute.recast_ptr(mB.iterator, dtype=cutlass.Uint8),
+            cute.make_layout(
+                (n_extent, packed_k_extent, l_extent),
+                stride=(packed_k_extent, 1, n_extent * packed_k_extent),
+            ),
+        )
+        op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_a, tma_tensor_a = cpasync.make_tiled_tma_atom(
+            op, mA_u8, a_compact_smem_layout, (tile_m, tile_k // 2)
+        )
+        tma_atom_b, tma_tensor_b = cpasync.make_tiled_tma_atom(
+            op, mB_u8, b_compact_smem_layout, (tile_n, tile_k // 2)
+        )
+        tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
+            mSFA, sfa_smem_layout, (tile_m, scale_tile_k), 1
+        )
+        tma_atom_sfb, tma_tensor_sfb = self._make_tma_atoms_and_tensors(
+            mSFB, sfb_smem_layout, (tile_n, scale_tile_k), 1
+        )
+        self.num_tma_load_bytes = (
+            cute.size_in_bytes(cutlass.Uint8, a_compact_smem_layout)
+            + cute.size_in_bytes(cutlass.Uint8, b_compact_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        )
+
+        a_compact_smem_size = cute.cosize(a_compact_smem_layout_staged)
+        b_compact_smem_size = cute.cosize(b_compact_smem_layout_staged)
+        sfa_smem_size = cute.cosize(self.sfa_smem_layout_staged)
+        sfb_smem_size = cute.cosize(self.sfb_smem_layout_staged)
+        acc_smem_size = cute.cosize(acc_smem_layout)
+
+        @cute.struct
+        class BlockscaledSharedStorage:
+            ab_pipeline_array_ptr: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int8, cute.cosize(self.a_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int8, cute.cosize(self.b_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sACompact: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint8, a_compact_smem_size],
+                self.buffer_align_bytes,
+            ]
+            sBCompact: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint8, b_compact_smem_size],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, sfa_smem_size],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, sfb_smem_size],
+                self.buffer_align_bytes,
+            ]
+            # Correctness scratch: for K > 64, K64 partials stay in FP32 here
+            # until the final K tile writes BF16 D exactly once.
+            sAcc: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, acc_smem_size],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = BlockscaledSharedStorage
+
+        if const_expr(self.sf_vec_size == 16):
+            mma_op = warp.MmaMXF4NVF4Op(cutlass.Float4E2M1FN, cutlass.Float32, self.sf_dtype)
+        else:
+            mma_op = warp.MmaMXF4Op(cutlass.Float4E2M1FN, cutlass.Float32, self.sf_dtype)
+        one_warp_mma = cute.make_tiled_mma(mma_op)
+        varlen_params = VarlenManager.to_underlying_arguments(varlen_args)
+        self.blockscaled_kernel(
+            one_warp_mma,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            mD,
+            varlen_params,
+            cute.make_layout((1, 1, 1)),
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            a_compact_smem_layout_staged,
+            b_compact_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            acc_smem_layout,
+        ).launch(
+            grid=[cute.ceil_div(m_extent, tile_m), cute.ceil_div(n_extent, tile_n), l_extent],
+            block=[64, 1, 1],
+            cluster=(1, 1, 1),
+        )
+
+    @cute.kernel
+    def blockscaled_kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl16: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl16: cute.Tensor,
+        mD_mnl: cute.Tensor,
+        varlen_params: VarlenManager.Params,
+        cluster_layout_mnk: cute.Layout,
+        a_smem_layout: cute.Layout,
+        b_smem_layout: cute.Layout,
+        a_compact_smem_layout: cute.Layout,
+        b_compact_smem_layout: cute.Layout,
+        sfa_smem_layout: cute.Layout,
+        sfb_smem_layout: cute.Layout,
+        acc_smem_layout: cute.Layout,
+    ):
+        del varlen_params
+
+        tidx, _, _ = cute.arch.thread_idx()
+        cta_m, cta_n, cta_l = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if warp_idx == 1:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        ab_pipeline = self.make_ab_pipeline(
+            tiled_mma=tiled_mma,
+            cluster_layout_vmnk=cute.make_layout((1, *cluster_layout_mnk.shape)),
+            ab_pipeline_mbar_ptr=storage.ab_pipeline_array_ptr.data_ptr(),
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=(1, 1), is_relaxed=True)
+        sA = storage.sA.get_tensor(a_smem_layout)
+        sB = storage.sB.get_tensor(b_smem_layout)
+        sACompact = storage.sACompact.get_tensor(a_compact_smem_layout)
+        sBCompact = storage.sBCompact.get_tensor(b_compact_smem_layout)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout)
+        sAcc = storage.sAcc.get_tensor(acc_smem_layout)
+        pipeline_init_wait(cluster_shape_mn=(1, 1))
+
+        k_tile_count = cute.size(mA_mkl, mode=[1]) // (self.cta_tile_shape_mnk[2] // 2)
+        scales_per_k_tile = 64 // self.sf_vec_size
+
+        if warp_idx == 1:
+            producer_state = make_pipeline_state(pipeline.PipelineUserType.Producer, self.ab_stage)
+            gA_mk = cute.local_tile(
+                mA_mkl[None, None, cta_l],
+                (self.cta_tile_shape_mnk[0], self.cta_tile_shape_mnk[2] // 2),
+                (cta_m, None),
+            )
+            gB_nk = cute.local_tile(
+                mB_nkl[None, None, cta_l],
+                (self.cta_tile_shape_mnk[1], self.cta_tile_shape_mnk[2] // 2),
+                (cta_n, None),
+            )
+            gSFA_mk16 = cute.local_tile(
+                mSFA_mkl16[None, None, cta_l],
+                (self.cta_tile_shape_mnk[0], 16),
+                (cta_m, None),
+            )
+            gSFB_nk16 = cute.local_tile(
+                mSFB_nkl16[None, None, cta_l],
+                (self.cta_tile_shape_mnk[1], 16),
+                (cta_n, None),
+            )
+            if const_expr(k_tile_count == 1):
+                producer_state = self.load_blockscaled_tma_tile(
+                    ab_pipeline,
+                    producer_state,
+                    tma_atom_a,
+                    gA_mk,
+                    tma_atom_b,
+                    gB_nk,
+                    tma_atom_sfa,
+                    gSFA_mk16,
+                    tma_atom_sfb,
+                    gSFB_nk16,
+                    sACompact,
+                    sBCompact,
+                    sSFA,
+                    sSFB,
+                )
+            else:
+                for k_tile in cutlass.range(k_tile_count, unroll=1):
+                    scale_base = k_tile * scales_per_k_tile
+                    scale_page = scale_base // 16
+                    producer_state = self.load_blockscaled_tma_tile_indexed(
+                        ab_pipeline,
+                        producer_state,
+                        k_tile,
+                        scale_page,
+                        tma_atom_a,
+                        gA_mk,
+                        tma_atom_b,
+                        gB_nk,
+                        tma_atom_sfa,
+                        gSFA_mk16,
+                        tma_atom_sfb,
+                        gSFB_nk16,
+                        sACompact,
+                        sBCompact,
+                        sSFA,
+                        sSFB,
+                    )
+            ab_pipeline.producer_tail(producer_state)
+
+        if warp_idx == 0:
+            gD_mn = cute.local_tile(
+                mD_mnl[None, None, cta_l],
+                (self.cta_tile_shape_mnk[0], self.cta_tile_shape_mnk[1]),
+                (cta_m, cta_n),
+            )
+            read_state = make_pipeline_state(pipeline.PipelineUserType.Consumer, self.ab_stage)
+            self.mma_blockscaled_kloop_store_bf16(
+                ab_pipeline,
+                read_state,
+                tiled_mma,
+                sA,
+                sB,
+                sACompact,
+                sBCompact,
+                sSFA,
+                sSFB,
+                sAcc,
+                gD_mn,
+                k_tile_count,
+                tidx,
+            )
+
+    @cute.jit
+    def load_blockscaled_tma_tile(
+        self,
+        ab_pipeline: pipeline.PipelineAsync,
+        producer_state: pipeline.PipelineState,
+        tma_atom_a: cute.CopyAtom,
+        gA_mk: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        gB_nk: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        gSFA_mk16: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        gSFB_nk16: cute.Tensor,
+        sACompact: cute.Tensor,
+        sBCompact: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+    ) -> pipeline.PipelineState:
+        copy_A, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_a,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gA_mk,
+            dst_tensor=sACompact,
+            mcast_mask=0,
+        )
+        copy_B, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_b,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gB_nk,
+            dst_tensor=sBCompact,
+            mcast_mask=0,
+        )
+        copy_SFA, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_sfa,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gSFA_mk16,
+            dst_tensor=sSFA,
+            mcast_mask=0,
+        )
+        copy_SFB, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_sfb,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gSFB_nk16,
+            dst_tensor=sSFB,
+            mcast_mask=0,
+        )
+        return self.load_tma(
+            ab_pipeline,
+            producer_state,
+            [copy_A, copy_B, copy_SFA, copy_SFB],
+            Int32(1),
+        )
+
+    @cute.jit
+    def load_blockscaled_tma_tile_indexed(
+        self,
+        ab_pipeline: pipeline.PipelineAsync,
+        producer_state: pipeline.PipelineState,
+        k_tile: cutlass.Int32,
+        scale_page: cutlass.Int32,
+        tma_atom_a: cute.CopyAtom,
+        gA_mk: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        gB_nk: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        gSFA_mk16: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        gSFB_nk16: cute.Tensor,
+        sACompact: cute.Tensor,
+        sBCompact: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+    ) -> pipeline.PipelineState:
+        copy_A, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_a,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gA_mk,
+            dst_tensor=sACompact,
+            mcast_mask=0,
+        )
+        copy_B, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_b,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gB_nk,
+            dst_tensor=sBCompact,
+            mcast_mask=0,
+        )
+        copy_SFA, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_sfa,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gSFA_mk16,
+            dst_tensor=sSFA,
+            mcast_mask=0,
+        )
+        copy_SFB, _, _ = copy_utils.tma_get_copy_fn(
+            tma_atom_sfb,
+            cta_coord=0,
+            cta_layout=cute.make_layout(1),
+            src_tensor=gSFB_nk16,
+            dst_tensor=sSFB,
+            mcast_mask=0,
+        )
+        peek_empty_status = ab_pipeline.producer_try_acquire(producer_state)
+        ab_pipeline.producer_acquire(producer_state, peek_empty_status)
+        tma_bar_ptr = ab_pipeline.producer_get_barrier(producer_state)
+        smem_idx = producer_state.index
+        copy_A(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+        copy_B(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+        copy_SFA(scale_page, smem_idx, tma_bar_ptr=tma_bar_ptr)
+        copy_SFB(scale_page, smem_idx, tma_bar_ptr=tma_bar_ptr)
+        ab_pipeline.producer_commit(producer_state)
+        producer_state.advance()
+        return producer_state
+
+    @cute.jit
+    def mma_blockscaled_kloop_store_bf16(
+        self,
+        ab_pipeline: pipeline.PipelineAsync,
+        read_state: pipeline.PipelineState,
+        tiled_mma: cute.TiledMma,
+        sA: cute.Tensor,
+        sB: cute.Tensor,
+        sACompact: cute.Tensor,
+        sBCompact: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+        sAcc: cute.Tensor,
+        gD_mn: cute.Tensor,
+        k_tile_count: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ) -> None:
+        thr_mma = tiled_mma.get_slice(tidx)
+        a_shape = tiled_mma.partition_shape_A((16, 64))
+        b_shape = tiled_mma.partition_shape_B((8, 64))
+        acc_shape = tiled_mma.partition_shape_C((16, 8))
+        accum_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32)
+        store_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gD_mn.element_type)
+        scales_per_k_tile = 64 // self.sf_vec_size
+        if const_expr(k_tile_count == 1):
+            read_state = self.mma_blockscaled_one_k_tile_accumulate_smem(
+                ab_pipeline,
+                read_state,
+                tiled_mma,
+                sA,
+                sB,
+                sACompact,
+                sBCompact,
+                sSFA,
+                sSFB,
+                sAcc,
+                gD_mn,
+                tidx,
+                thr_mma,
+                a_shape,
+                b_shape,
+                acc_shape,
+                accum_atom,
+                store_atom,
+                scales_per_k_tile,
+                cutlass.Int32(0),
+                False,
+                True,
+            )
+        else:
+            read_state = self.mma_blockscaled_one_k_tile_accumulate_smem(
+                ab_pipeline,
+                read_state,
+                tiled_mma,
+                sA,
+                sB,
+                sACompact,
+                sBCompact,
+                sSFA,
+                sSFB,
+                sAcc,
+                gD_mn,
+                tidx,
+                thr_mma,
+                a_shape,
+                b_shape,
+                acc_shape,
+                accum_atom,
+                store_atom,
+                scales_per_k_tile,
+                cutlass.Int32(0),
+                False,
+                False,
+            )
+            for k_iter in cutlass.range(k_tile_count - 2, unroll=1):
+                k_tile = k_iter + 1
+                read_state = self.mma_blockscaled_one_k_tile_accumulate_smem(
+                    ab_pipeline,
+                    read_state,
+                    tiled_mma,
+                    sA,
+                    sB,
+                    sACompact,
+                    sBCompact,
+                    sSFA,
+                    sSFB,
+                    sAcc,
+                    gD_mn,
+                    tidx,
+                    thr_mma,
+                    a_shape,
+                    b_shape,
+                    acc_shape,
+                    accum_atom,
+                    store_atom,
+                    scales_per_k_tile,
+                    k_tile,
+                    True,
+                    False,
+                )
+            read_state = self.mma_blockscaled_one_k_tile_accumulate_smem(
+                ab_pipeline,
+                read_state,
+                tiled_mma,
+                sA,
+                sB,
+                sACompact,
+                sBCompact,
+                sSFA,
+                sSFB,
+                sAcc,
+                gD_mn,
+                tidx,
+                thr_mma,
+                a_shape,
+                b_shape,
+                acc_shape,
+                accum_atom,
+                store_atom,
+                scales_per_k_tile,
+                k_tile_count - 1,
+                True,
+                True,
+            )
+
+    @cute.jit
+    def mma_blockscaled_one_k_tile_accumulate_smem(
+        self,
+        ab_pipeline: pipeline.PipelineAsync,
+        read_state: pipeline.PipelineState,
+        tiled_mma: cute.TiledMma,
+        sA: cute.Tensor,
+        sB: cute.Tensor,
+        sACompact: cute.Tensor,
+        sBCompact: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+        sAcc: cute.Tensor,
+        gD_mn: cute.Tensor,
+        tidx: cutlass.Int32,
+        thr_mma: cute.TiledMmaThrVal,
+        a_shape: cute.Shape,
+        b_shape: cute.Shape,
+        acc_shape: cute.Shape,
+        accum_atom: cute.CopyAtom,
+        store_atom: cute.CopyAtom,
+        scales_per_k_tile: cutlass.Constexpr[int],
+        k_tile: cutlass.Int32,
+        add_existing: cutlass.Constexpr[bool],
+        store_final: cutlass.Constexpr[bool],
+    ) -> pipeline.PipelineState:
+        peek_ab_full_status = ab_pipeline.consumer_try_wait(read_state)
+        ab_pipeline.consumer_wait(read_state, peek_ab_full_status)
+        _expand_compact_fp4_to_sm120_ldmatrix_smem(
+            sACompact[None, None, read_state.index],
+            sA[None, None, read_state.index],
+            128,
+        )
+        _expand_compact_fp4_to_sm120_ldmatrix_smem(
+            sBCompact[None, None, read_state.index],
+            sB[None, None, read_state.index],
+            128,
+        )
+        cute.arch.sync_warp()
+        scale_base = k_tile * scales_per_k_tile
+        scale_page = scale_base // 16
+        scale_page_offset = scale_base - scale_page * 16
+        for m_atom in cutlass.range_constexpr(8):
+            for n_atom in cutlass.range_constexpr(16):
+                acc = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+                acc.fill(0.0)
+                self.mma_blockscaled_tile_k64_accumulate(
+                    tiled_mma,
+                    acc,
+                    sA[None, None, read_state.index],
+                    sB[None, None, read_state.index],
+                    sSFA,
+                    sSFB,
+                    read_state.index,
+                    scale_page_offset,
+                    cutlass.Int32(m_atom * 16),
+                    cutlass.Int32(n_atom * 8),
+                    tidx,
+                    a_shape,
+                    b_shape,
+                )
+                self.store_blockscaled_accum_smem_atom(
+                    thr_mma,
+                    accum_atom,
+                    acc,
+                    sAcc,
+                    store_atom,
+                    gD_mn,
+                    m_atom,
+                    n_atom,
+                    add_existing,
+                    store_final,
+                )
+        cute.arch.fence_view_async_shared()
+        cute.arch.sync_warp()
+        ab_pipeline.consumer_release(read_state)
+        read_state.advance()
+        return read_state
+
+    @cute.jit
+    def mma_blockscaled(
+        self,
+        tiled_mma: cute.TiledMma,
+        acc: cute.Tensor,
+        sA_stage: cute.Tensor,
+        sB_stage: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+        stage: cutlass.Int32,
+        m_atom_base: cutlass.Int32,
+        n_atom_base: cutlass.Int32,
+        k_scale_base: cutlass.Int32,
+        tidx: cutlass.Int32,
+        a_shape: cute.Shape,
+        b_shape: cute.Shape,
+    ) -> None:
+        sA_atom = cute.domain_offset((m_atom_base, None), sA_stage)
+        sB_atom = cute.domain_offset((n_atom_base, None), sB_stage)
+        copy_atom = cute.make_copy_atom(
+            warp.LdMatrix8x16x8bOp(num_matrices=1, unpack_bits=4),
+            cutlass.Int8,
+        )
+        tiled_copy_a = cute.make_tiled_copy_A(copy_atom, tiled_mma)
+        tiled_copy_b = cute.make_tiled_copy_B(copy_atom, tiled_mma)
+        a0, a1, a2, a3 = warp.sm120_mxf4nvf4_ldmatrix_A_regs(
+            tiled_copy_a,
+            tidx,
+            _make_sm120_fp4_ldmatrix_smem_view(sA_atom, 16),
+        )
+        b0, b1 = warp.sm120_mxf4nvf4_ldmatrix_B_regs(
+            tiled_copy_b,
+            tidx,
+            _make_sm120_fp4_ldmatrix_smem_view(sB_atom, 8),
+        )
+        a = cute.make_rmem_tensor(a_shape, cutlass.Float4E2M1FN)
+        b = cute.make_rmem_tensor(b_shape, cutlass.Float4E2M1FN)
+        a_i32 = cute.recast_tensor(a, cutlass.Int32)
+        b_i32 = cute.recast_tensor(b, cutlass.Int32)
+        # The asymmetric SM120 blockscaled tests catch this placement.
+        a_i32[0] = a0
+        a_i32[1] = a2
+        a_i32[2] = a1
+        a_i32[3] = a3
+        b_i32[0] = b0
+        b_i32[1] = b1
+        sfa, sfb = _load_sm120_blockscaled_selector0_scale_fragments(
+            sSFA,
+            sSFB,
+            stage,
+            m_atom_base,
+            n_atom_base,
+            k_scale_base,
+            self.sf_vec_size,
+            self.sf_dtype,
+        )
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    @cute.jit
+    def mma_blockscaled_tile_k64_accumulate(
+        self,
+        tiled_mma: cute.TiledMma,
+        acc: cute.Tensor,
+        sA: cute.Tensor,
+        sB: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+        stage: cutlass.Int32,
+        scale_page_offset: cutlass.Int32,
+        m_atom_base: cutlass.Int32,
+        n_atom_base: cutlass.Int32,
+        tidx: cutlass.Int32,
+        a_shape: cute.Shape,
+        b_shape: cute.Shape,
+    ) -> None:
+        del tiled_mma
+        if const_expr(self.sf_vec_size == 16):
+            mma_op = warp.MmaMXF4NVF4Op(cutlass.Float4E2M1FN, cutlass.Float32, self.sf_dtype)
+        else:
+            mma_op = warp.MmaMXF4Op(cutlass.Float4E2M1FN, cutlass.Float32, self.sf_dtype)
+        local_tiled_mma = cute.make_tiled_mma(mma_op)
+        self.mma_blockscaled(
+            local_tiled_mma,
+            acc,
+            sA,
+            sB,
+            sSFA,
+            sSFB,
+            stage,
+            m_atom_base,
+            n_atom_base,
+            scale_page_offset,
+            tidx,
+            a_shape,
+            b_shape,
+        )
+
+    @cute.jit
+    def store_blockscaled_accum_smem_atom(
+        self,
+        thr_mma: cute.TiledMmaThrVal,
+        accum_atom: cute.CopyAtom,
+        acc: cute.Tensor,
+        sAcc: cute.Tensor,
+        store_atom: cute.CopyAtom,
+        mD_mn: cute.Tensor,
+        m_atom: cutlass.Constexpr[int],
+        n_atom: cutlass.Constexpr[int],
+        add_existing: cutlass.Constexpr[bool],
+        store_final: cutlass.Constexpr[bool],
+    ) -> None:
+        sAcc_atom = cute.local_tile(sAcc, (16, 8), (m_atom, n_atom))
+        tCsAcc = thr_mma.partition_C(sAcc_atom)
+        if const_expr(add_existing):
+            tCrPrev = cute.make_rmem_tensor(acc.layout, cutlass.Float32)
+            cute.copy(accum_atom, tCsAcc, tCrPrev)
+            acc.store(acc.load() + tCrPrev.load())
+        if const_expr(store_final):
+            gD_atom = cute.local_tile(mD_mn, (16, 8), (m_atom, n_atom))
+            tCgD = thr_mma.partition_C(gD_atom)
+            tCrD = cute.make_rmem_tensor(acc.layout, mD_mn.element_type)
+            tCrD.store(acc.load().to(mD_mn.element_type))
+            cute.copy(store_atom, tCrD, tCgD)
+        else:
+            cute.copy(accum_atom, acc, tCsAcc)
 
     @cute.kernel
     def kernel(

--- a/tests/test_gemm_blockscaled.py
+++ b/tests/test_gemm_blockscaled.py
@@ -4,24 +4,38 @@ import torch
 import cutlass
 
 from quack.blockscaled_gemm_utils import (
+    FP4_E2M1FN_VALUES,
     blockscaled_gemm_reference,
     compile_blockscaled_gemm_tvm_ffi,
     create_blockscaled_operand_quantized,
     create_blockscaled_operand_tensor,
     create_blockscaled_scale_tensor,
+    create_sm120_blockscaled_scale_tensor,
     create_blockscaled_varlen_k_operands,
     create_blockscaled_varlen_m_operands,
     scale_blocked_for_cublas,
     scale_view_for_kernel,
 )
-from quack.gemm_default_epi import GemmDefaultSm100
+from quack.compile_utils import make_fake_tensor as fake_tensor
+from quack.gemm_default_epi import GemmDefaultSm100, GemmDefaultSm120
+from quack.varlen_utils import VarlenArguments
 from quack.mx_utils import to_blocked
 
 
 def _skip_if_not_sm100():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
     major = torch.cuda.get_device_properties(0).major
-    if major < 10:
-        pytest.skip("SM100+ required")
+    if major not in (10, 11):
+        pytest.skip("SM100/SM110 required")
+
+
+def _skip_if_not_sm120():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    major = torch.cuda.get_device_properties(0).major
+    if major != 12:
+        pytest.skip("SM120 required")
 
 
 def _compile_blockscaled_gemm(
@@ -158,6 +172,99 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
+
+
+def test_sm120_blockscaled_validation():
+    assert GemmDefaultSm120.can_implement_blockscaled(
+        cutlass.Float4E2M1FN,
+        cutlass.Float8E4M3FN,
+        16,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        (1, 1),
+        128,
+        128,
+        64,
+        1,
+        "k",
+        "k",
+        "n",
+    )
+    assert GemmDefaultSm120.can_implement_blockscaled(
+        cutlass.Float4E2M1FN,
+        cutlass.Float8E8M0FNU,
+        32,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        (1, 1),
+        256,
+        256,
+        128,
+        1,
+        "k",
+        "k",
+        "n",
+    )
+    assert not GemmDefaultSm120.can_implement_blockscaled(
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E8M0FNU,
+        32,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        (1, 1),
+        128,
+        128,
+        64,
+        1,
+        "k",
+        "k",
+        "n",
+    )
+    assert not GemmDefaultSm120.can_implement_blockscaled(
+        cutlass.Int8,
+        cutlass.Float8E8M0FNU,
+        32,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        (1, 1),
+        128,
+        128,
+        64,
+        1,
+        "k",
+        "k",
+        "n",
+    )
+    assert not GemmDefaultSm120.can_implement_blockscaled(
+        cutlass.Float4E2M1FN,
+        cutlass.Float8E4M3FN,
+        32,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        (1, 1),
+        128,
+        128,
+        64,
+        1,
+        "k",
+        "k",
+        "n",
+    )
+    assert not GemmDefaultSm120.can_implement_blockscaled(
+        cutlass.Float4E2M1FN,
+        cutlass.Float8E4M3FN,
+        16,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        (1, 1),
+        128,
+        128,
+        96,
+        1,
+        "k",
+        "k",
+        "n",
+    )
     assert not GemmDefaultSm100.can_implement_blockscaled(
         cutlass.Float8E4M3FN,
         cutlass.Float8E8M0FNU,
@@ -233,6 +340,65 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
+
+
+def test_sm120_blockscaled_class_call_validation():
+    m = n = 128
+    k = 64
+    l = 1
+    gemm = GemmDefaultSm120(
+        cutlass.Float32,
+        cutlass.Float4E2M1FN,
+        (128, 128, 64),
+        (1, 1, 1),
+        is_persistent=False,
+        sf_vec_size=16,
+        sf_dtype=cutlass.Float8E4M3FN,
+    )
+    mA = fake_tensor(cutlass.Float4E2M1FN, (m, k, l), leading_dim=1, divisibility=4)
+    mB = fake_tensor(cutlass.Float4E2M1FN, (n, k, l), leading_dim=1, divisibility=4)
+    mD = fake_tensor(cutlass.BFloat16, (m, n, l), leading_dim=1, divisibility=8)
+    mSFA = fake_tensor(cutlass.Float8E4M3FN, (m, 16, l), leading_dim=1, divisibility=4)
+    mSFB = fake_tensor(cutlass.Float8E4M3FN, (n, 16, l), leading_dim=1, divisibility=4)
+
+    assert (
+        gemm._validate_blockscaled_call(
+            mA,
+            mB,
+            mD,
+            None,
+            mSFA,
+            mSFB,
+            gemm.EpilogueArguments(),
+            None,
+            None,
+            None,
+        )
+        == VarlenArguments()
+    )
+    with pytest.raises(ValueError, match="requires SFA and SFB"):
+        gemm._validate_blockscaled_call(
+            mA, mB, mD, None, None, mSFB, gemm.EpilogueArguments(), None, None, None
+        )
+    with pytest.raises(NotImplementedError, match="C/beta"):
+        gemm._validate_blockscaled_call(
+            mA, mB, mD, mD, mSFA, mSFB, gemm.EpilogueArguments(), None, None, None
+        )
+    packed_k_a = fake_tensor(cutlass.Float4E2M1FN, (m, k // 2, l), leading_dim=1, divisibility=4)
+    packed_k_b = fake_tensor(cutlass.Float4E2M1FN, (n, k // 2, l), leading_dim=1, divisibility=4)
+    with pytest.raises(ValueError, match="expects logical Float4E2M1FN K extent"):
+        gemm._validate_blockscaled_call(
+            packed_k_a,
+            packed_k_b,
+            mD,
+            None,
+            mSFA,
+            mSFB,
+            gemm.EpilogueArguments(),
+            None,
+            None,
+            None,
+        )
 
 
 @pytest.mark.parametrize(
@@ -483,6 +649,228 @@ def test_scale_layout_matches_cublas(mn, sf_k, l):
         )
         ref = to_blocked(scale_2d[li])
         assert torch.equal(ours, ref), f"to_blocked mismatch at l={li}"
+
+
+@pytest.mark.parametrize(
+    "k,sf_vec_size,expected_cols",
+    [
+        (64, 16, 16),
+        (128, 16, 16),
+        (256, 16, 16),
+        (384, 16, 32),
+        (64, 32, 16),
+        (256, 32, 16),
+        (576, 32, 32),
+    ],
+)
+def test_sm120_blockscaled_padded_scale_layout(k, sf_vec_size, expected_cols):
+    _skip_if_not_sm120()
+    mn, l = 128, 1
+    sf_dtype = cutlass.Float8E4M3FN if sf_vec_size == 16 else cutlass.Float8E8M0FNU
+    ref, physical = create_sm120_blockscaled_scale_tensor(l, mn, k, sf_vec_size, sf_dtype)
+    assert tuple(physical.shape) == (mn, expected_cols, l)
+    assert tuple(ref.shape) == (mn, k, l)
+
+    logical_cols = (k + sf_vec_size - 1) // sf_vec_size
+    if expected_cols > logical_cols:
+        padding = physical[:, logical_cols:, :].view(torch.uint8)
+        assert torch.any(padding != 0)
+
+
+def test_sm120_blockscaled_scale_helper_validation():
+    _skip_if_not_sm120()
+    with pytest.raises(ValueError, match="K divisible by 64"):
+        create_sm120_blockscaled_scale_tensor(1, 128, 96, 16, cutlass.Float8E4M3FN)
+    with pytest.raises(ValueError, match="sf_vec_size 16 or 32"):
+        create_sm120_blockscaled_scale_tensor(1, 128, 64, 8, cutlass.Float8E4M3FN)
+    with pytest.raises(ValueError, match="sf_vec_size=16 requires"):
+        create_sm120_blockscaled_scale_tensor(1, 128, 64, 16, cutlass.Float8E8M0FNU)
+    with pytest.raises(ValueError, match="sf_vec_size=32 requires"):
+        create_sm120_blockscaled_scale_tensor(1, 128, 64, 32, cutlass.Float8E4M3FN)
+
+
+def _pack_sm120_fp4_codes(codes: torch.Tensor) -> torch.Tensor:
+    packed = torch.empty(
+        (codes.shape[0], codes.shape[1] // 2, 1),
+        device=codes.device,
+        dtype=torch.float4_e2m1fn_x2,
+    )
+    packed.view(torch.uint8).copy_(codes[:, 0::2, None] | (codes[:, 1::2, None] << 4))
+    return packed
+
+
+def _sm120_fp4_blockscaled_reference(
+    a_codes: torch.Tensor,
+    b_codes: torch.Tensor,
+    sfa: torch.Tensor,
+    sfb: torch.Tensor,
+    sf_vec_size: int,
+) -> torch.Tensor:
+    table = torch.tensor(FP4_E2M1FN_VALUES, dtype=torch.float32, device=a_codes.device)
+    scale_k = torch.arange(a_codes.shape[1], device=a_codes.device) // sf_vec_size
+    a = table[a_codes.long()] * sfa.float()[:, scale_k, 0]
+    b = table[b_codes.long()] * sfb.float()[:, scale_k, 0]
+    return torch.einsum("mk,nk->mn", a, b).unsqueeze(-1)
+
+
+def _make_sm120_scales(mn, k, sf_vec_size, sf_dtype, row_or_col_sensitive=True):
+    _, scales = create_sm120_blockscaled_scale_tensor(1, mn, k, sf_vec_size, sf_dtype)
+    logical_cols = (k + sf_vec_size - 1) // sf_vec_size
+    if sf_dtype == cutlass.Float8E8M0FNU:
+        base = torch.tensor([1.0, 2.0], device="cuda", dtype=torch.float32)
+    else:
+        base = torch.tensor([1.0, 2.0, 0.5, 1.5], device="cuda", dtype=torch.float32)
+    for idx in range(mn):
+        values = base[torch.arange(logical_cols, device="cuda") % base.numel()]
+        if row_or_col_sensitive:
+            values = values * (1.0 + 0.125 * (idx % 4))
+        scales[idx, :logical_cols, 0] = values.to(scales.dtype)
+    return scales
+
+
+def _compile_sm120_blockscaled_gemm(ab_dtype, sf_dtype, sf_vec_size, m, n, k, mA, mB):
+    l = 1
+    _, mD = create_blockscaled_operand_tensor(l, m, n, False, cutlass.BFloat16, init="empty")
+    mSFA = _make_sm120_scales(m, k, sf_vec_size, sf_dtype)
+    mSFB = _make_sm120_scales(n, k, sf_vec_size, sf_dtype)
+    compiled = compile_blockscaled_gemm_tvm_ffi(
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        cutlass.BFloat16,
+        (128, 128),
+        (1, 1),
+        mA,
+        mB,
+        mD,
+        mSFA,
+        mSFB,
+    )
+    return compiled, (mA, mB, mD, mSFA, mSFB)
+
+
+@pytest.mark.parametrize(
+    "sf_dtype,sf_vec_size,m,n,k",
+    [
+        (cutlass.Float8E4M3FN, 16, 128, 128, 64),
+        (cutlass.Float8E4M3FN, 16, 256, 128, 128),
+        (cutlass.Float8E4M3FN, 16, 128, 128, 320),
+        (cutlass.Float8E8M0FNU, 32, 128, 128, 64),
+    ],
+)
+def test_sm120_blockscaled_scale_correctness(sf_dtype, sf_vec_size, m, n, k):
+    _skip_if_not_sm120()
+    a_codes = torch.full((m, k), 0x2, device="cuda", dtype=torch.uint8)
+    b_codes = torch.full((n, k), 0x2, device="cuda", dtype=torch.uint8)
+    mA = _pack_sm120_fp4_codes(a_codes)
+    mB = _pack_sm120_fp4_codes(b_codes)
+    compiled, args = _compile_sm120_blockscaled_gemm(
+        cutlass.Float4E2M1FN, sf_dtype, sf_vec_size, m, n, k, mA, mB
+    )
+    _run_blockscaled_gemm(compiled, args)
+
+    _, _, d_torch, mSFA, mSFB = args
+    ref = _sm120_fp4_blockscaled_reference(a_codes, b_codes, mSFA, mSFB, sf_vec_size).to(
+        torch.bfloat16
+    )
+    err = (d_torch.float() - ref).abs().max().item()
+    assert err < 1e-1, f"max_err={err}"
+
+
+def test_sm120_blockscaled_k_loop_accumulates_before_bf16_store():
+    _skip_if_not_sm120()
+    m = n = 128
+    k = 384
+    sf_vec_size = 16
+    sf_dtype = cutlass.Float8E4M3FN
+    a_codes = torch.full((m, k), 0x2, device="cuda", dtype=torch.uint8)
+    b_codes = torch.full((n, k), 0x2, device="cuda", dtype=torch.uint8)
+    # Make the first K64 tile very large and the remaining K64 tiles small.
+    # Storing BF16 after each K tile loses the later small partials; true FP32
+    # accumulation keeps them until the final BF16 conversion.
+    a_codes[:, :64] = 0x7
+    b_codes[:, :64] = 0x7
+    mA = _pack_sm120_fp4_codes(a_codes)
+    mB = _pack_sm120_fp4_codes(b_codes)
+    compiled, args = _compile_sm120_blockscaled_gemm(
+        cutlass.Float4E2M1FN, sf_dtype, sf_vec_size, m, n, k, mA, mB
+    )
+    _, _, _, mSFA, mSFB = args
+    logical_cols = k // sf_vec_size
+    mSFA[:, :logical_cols, 0] = torch.tensor(1.0, device="cuda", dtype=mSFA.dtype)
+    mSFB[:, :logical_cols, 0] = torch.tensor(1.0, device="cuda", dtype=mSFB.dtype)
+    mSFA[:, :4, 0] = torch.tensor(3.0, device="cuda", dtype=mSFA.dtype)
+    mSFB[:, :4, 0] = torch.tensor(3.0, device="cuda", dtype=mSFB.dtype)
+    _run_blockscaled_gemm(compiled, args)
+
+    _, _, d_torch, mSFA, mSFB = args
+    ref = _sm120_fp4_blockscaled_reference(a_codes, b_codes, mSFA, mSFB, sf_vec_size).to(
+        torch.bfloat16
+    )
+    torch.testing.assert_close(d_torch.float(), ref.float(), rtol=0, atol=0)
+
+
+def test_sm120_blockscaled_asymmetric_fp4_and_scale_page_crossing():
+    _skip_if_not_sm120()
+    m = n = 128
+    k = 320
+    sf_vec_size = 16
+    sf_dtype = cutlass.Float8E4M3FN
+    ks = torch.arange(k, device="cuda")[None, :]
+    a_codes = torch.where(
+        (ks % 4) < 2,
+        torch.tensor(0x2, device="cuda", dtype=torch.uint8),
+        torch.tensor(0x4, device="cuda", dtype=torch.uint8),
+    ).expand(m, k)
+    b_codes = torch.where(
+        (ks % 8) < 4,
+        torch.tensor(0x3, device="cuda", dtype=torch.uint8),
+        torch.tensor(0x5, device="cuda", dtype=torch.uint8),
+    ).expand(n, k)
+    mA = _pack_sm120_fp4_codes(a_codes)
+    mB = _pack_sm120_fp4_codes(b_codes)
+    compiled, args = _compile_sm120_blockscaled_gemm(
+        cutlass.Float4E2M1FN, sf_dtype, sf_vec_size, m, n, k, mA, mB
+    )
+    _run_blockscaled_gemm(compiled, args)
+
+    _, _, d_torch, mSFA, mSFB = args
+    logical_cols = k // sf_vec_size
+    assert mSFA.shape[1] == 32
+    assert torch.any(mSFA[:, logical_cols:, :].float() != 1.0)
+    ref = _sm120_fp4_blockscaled_reference(a_codes, b_codes, mSFA, mSFB, sf_vec_size).to(
+        torch.bfloat16
+    )
+    err = (d_torch.float() - ref.float()).abs().max().item()
+    assert err < 1e-1, f"max_err={err}"
+
+
+def test_sm120_blockscaled_rejects_compact_scale_layout():
+    _skip_if_not_sm120()
+    l, m, n, k, sf_vec_size = 1, 128, 128, 64, 16
+    ab_dtype = cutlass.Float4E2M1FN
+    sf_dtype = cutlass.Float8E4M3FN
+    _, mA = create_blockscaled_operand_tensor(l, m, k, False, ab_dtype)
+    _, mB = create_blockscaled_operand_tensor(l, n, k, False, ab_dtype)
+    _, mD = create_blockscaled_operand_tensor(l, m, n, False, cutlass.BFloat16, init="empty")
+    mSFA = torch.empty((m, k // sf_vec_size, l), device="cuda", dtype=torch.float8_e4m3fn)
+    mSFB = torch.empty((n, k // sf_vec_size, l), device="cuda", dtype=torch.float8_e4m3fn)
+
+    with pytest.raises(ValueError, match="SFA shape"):
+        runner = compile_blockscaled_gemm_tvm_ffi(
+            ab_dtype,
+            sf_dtype,
+            sf_vec_size,
+            cutlass.BFloat16,
+            (128, 128),
+            (1, 1),
+            mA,
+            mB,
+            mD,
+            mSFA,
+            mSFB,
+        )
+        runner(mA, mB, mD, mSFA, mSFB)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Requires https://github.com/NVIDIA/cutlass/pull/3185


Author: Alecco (& Codex) for Ologan

## Summary

This PR adds the first guarded SM120 blockscaled GEMM path using the existing blockscaled GEMM interface, rather than adding a separate SM120-specific frontend.

**This is a first implementation _not optimized_**. Optimization will be done in a subsequent PR.

Supported SM120 scope:

- A/B: Float4E2M1FN FP4 operands, packed as torch.float4_e2m1fn_x2
- NVFP4 scales: Float8E4M3FN, sf_vec_size=16
- MXFP4 scales: Float8E8M0FNU, sf_vec_size=32
- Accumulator: Float32
- Output: BFloat16
- Shapes: M % 128 == 0, N % 128 == 0, K % 64 == 0, L == 1
- Tile/cluster: tile_shape_mnk=(128,128,64), cluster_shape_mnk=(1,1,1)

Unsupported for this first path:

- C / beta
- varlen
- gather_A
- grouped/sparse kernels
- multicast clusters
- output FP4 quantization
- generic autodispatch
- SM120 FP8/INT8 blockscaled paths

## Implementation Notes

SM120 uses a padded row-major physical scale layout:

logical_scale_cols = ceil(K / sf_vec_size)
physical_scale_cols = round_up(logical_scale_cols, 16)

SFA shape = (M, physical_scale_cols, 1)
SFB shape = (N, physical_scale_cols, 1)

Compact scale rows such as (M, 4) are rejected before launch because SM120 TMA on compact row-major scale pages with row stride below 16 bytes traps. Padding columns are
ignored by the kernel.

For K > 64, K64 partials are accumulated through an FP32 shared-memory scratch tile and D is converted to BF16 only once on the final K tile. This preserves FP32
accumulation semantics instead of rounding through BF16 between K tiles.

The SM120 FFI compile path still calls the JIT-only blockscaled entry directly, after host-side validation, because it compiles logical fake CuTe tensor views over packed
torch storage. The class-level blockscaled_call keeps host validation for logical class-call tensors.

The benchmark path can launch the SM120 blockscaled kernel and build padded scale tensors, but cuBLAS comparison is skipped because the benchmark currently builds QuACK’s
padded row-major scale layout, not the cuBLAS/PyTorch scaled_mm scale layout.

## Tests

Validated with:

python -m compileall quack tests benchmarks
ruff check quack tests benchmarks
CUTE_DSL_ARCH=sm_120a pytest -q tests/test_gemm_blockscaled.py -s -rs
pytest -q 'tests/test_linear.py::test_gemm[960-736-1504-input_dtype0-k-k-m-False]' -s -rs

Current results on SM120:

- tests/test_gemm_blockscaled.py: 22 passed, 52 skipped
- Dense GEMM smoke: 1 passed

The SM120 tests cover:

- supported/rejected can_implement_blockscaled cases
- padded scale layout validation
- compact scale rejection
- direct class-call validation
- scale-sensitive runtime correctness
- K=320 scale-page crossing
- K=384 regression for FP32 accumulation across K64 tiles
- non-constant FP4 K-lane patterns for A/B with scale padding poison present

## Notes

This PR does not claim full arbitrary FP4 operand-pattern coverage yet. Broader row-and-K-varying FP4 correctness, cuBLAS-compatible SM120 scale conversion, and additional
blockscaled features should be follow-up work.

## Agent disclosure

This work was created with OpenAI Codex CLI agent.