### PR TITLE
[minor] pytest asyncio default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,7 @@ ignore = [
     "E741",  # Do not use variables named 'I', 'O', or 'l'
     "F841",  # local variable is assigned to but never used
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
To avoid a lot of warnings, set asyncio_mode aut (as recommended by the warning).