### PR TITLE
RMS Norm Bwd: Optimize for GB200 w/ TMA loads, reload_x, separate output dtype, new launch configs

### DIFF
--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -8,7 +8,9 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, const_expr
+import cutlass.pipeline as pipeline
+from cutlass import Float32, Int32, Int64, const_expr
+from cutlass.cute.nvgpu import cpasync
 
 import torch
 from torch import Tensor
@@ -22,6 +24,7 @@ from quack.reduce import row_reduce
 from quack.reduction_base import ReductionBase
 from quack.cache_utils import jit_cache
 from quack.cute_dsl_utils import torch2cute_dtype_map
+from quack.rmsnorm_config import RmsNormConfig, get_sm_count
 from cutlass.base_dsl.arch import Arch
 
 
@@ -502,23 +505,47 @@ def rmsnorm_bwd_ref(x, w, dout, rstd, eps=1e-6):
 
 
 class RMSNormBackward(ReductionBase):
-    def __init__(self, dtype: cutlass.Numeric, N: int):
+    def __init__(
+        self,
+        dtype: cutlass.Numeric,
+        N: int,
+        dout_dtype: Optional[Type[cutlass.Numeric]] = None,
+        T_hint: int = 0,
+        per_head: bool = False,
+    ):
         # 2 stages for double buffering when computing mean of x_hat * wdy
         super().__init__(dtype, N, stage=2, reduction_dtype=Float32)
-        self.reload_wdy = None if N <= 16 * 1024 else "smem"
+        dout_width = dout_dtype.width if dout_dtype is not None else dtype.width
+        arch_major = (
+            torch.cuda.get_device_capability(torch.cuda.current_device())[0]
+            if torch.cuda.is_available()
+            else 0
+        )
+        config = RmsNormConfig.select(N, dtype.width, dout_width, arch_major, T_hint)
+        self.config = config
+        self.reload_wdy = config.reload_wdy
+        self.reload_x = config.reload_x
+        self.per_head = per_head
+        self._num_threads_val = config.num_threads
+        self._threads_per_row_val = config.threads_per_row
+        self._cluster_n_val = config.cluster_n
+        self._tma_stages_val = config.tma_stages
+        tile_n = N // max(1, config.cluster_n)
+        row_bytes_x = tile_n * dtype.width // 8
+        row_bytes_do = tile_n * dout_width // 8
+        self.USE_TMA = (
+            config.use_tma and not per_head and row_bytes_x % 16 == 0 and row_bytes_do % 16 == 0
+        )
+        self._can_use_tma = self.USE_TMA
         if self.N > 128 * 1024 and self.dtype.width >= 32:
             # Not enough smem
             raise ValueError("RMSNormBackward does not support N > 128k with dtype >= 32 bits")
 
     def _num_threads(self):
-        return 128 if self.N <= 4096 else 256
+        return self._num_threads_val
 
     def _threads_per_row(self):
-        N = self.N
-        for limit, threads in [(64, 8), (128, 16), (256, 32), (512, 64), (4096, 128)]:
-            if N <= limit:
-                return threads
-        return 256
+        return self._threads_per_row_val
 
     def _set_cluster_n(self):
         arch = cutlass.base_dsl.BaseDSL._get_dsl().get_arch_enum()
@@ -526,19 +553,8 @@ class RMSNormBackward(ReductionBase):
         if arch < Arch.sm_90:
             self.cluster_n = 1
             return
-        # SM12x supports cluster up to 8
         max_cluster = 8 if arch.major == 12 else 16
-        N = self.N
-        if arch.major == 12 and const_expr(self.dtype.width >= 32):
-            # SM12x 99 KB SMEM: fp32 bwd double-buffers 2 tensors, needs much tighter clustering
-            thresholds = [(1024, 1), (8 * 1024, 2), (16 * 1024, 4), (32 * 1024, 8)]
-        else:
-            thresholds = [(8 * 1024, 1), (16 * 1024, 2), (32 * 1024, 4), (64 * 1024, 8)]
-        for limit, cluster in thresholds:
-            if N <= limit:
-                self.cluster_n = cluster
-                return
-        self.cluster_n = max_cluster
+        self.cluster_n = min(self._cluster_n_val, max_cluster)
 
     @cute.jit
     def __call__(
@@ -566,10 +582,35 @@ class RMSNormBackward(ReductionBase):
         mW = (
             layout_utils.expand(mW, dim=0, size=tiler_mn[0]) if const_expr(mW is not None) else None
         )
+        use_tma = const_expr(self.USE_TMA)
+        if const_expr(use_tma):
+            tma_smem_layout = cute.make_ordered_layout(tiler_mn, order=(1, 0))
+            tma_op = cpasync.CopyBulkTensorTileG2SOp()
+            tma_atom_X, mX_tma = cpasync.make_tiled_tma_atom(tma_op, mX, tma_smem_layout, tiler_mn)
+            tma_atom_dO, mdO_tma = cpasync.make_tiled_tma_atom(
+                tma_op, mdO, tma_smem_layout, tiler_mn
+            )
+        else:
+            tma_atom_X, mX_tma, tma_atom_dO, mdO_tma = None, None, None, None
         num_blocks = sm_count
-        num_heads = mX.shape[1] if const_expr(cute.rank(mX) == 3) else 1
+        num_heads = mX.shape[1] if const_expr(self.per_head) else 1
         self.kernel(
-            mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes, tiler_mn, tiled_copy, threads_per_row
+            mX,
+            mW,
+            mdO,
+            mdResO,
+            mRstd,
+            mdX,
+            mdW,
+            mdB,
+            mdRes,
+            tma_atom_X,
+            mX_tma,
+            tma_atom_dO,
+            mdO_tma,
+            tiler_mn,
+            tiled_copy,
+            threads_per_row,
         ).launch(
             grid=[num_blocks, self.cluster_n, num_heads],
             block=[num_threads, 1, 1],
@@ -589,18 +630,26 @@ class RMSNormBackward(ReductionBase):
         mdW: Optional[cute.Tensor],
         mdB: Optional[cute.Tensor],
         mdRes: Optional[cute.Tensor],
+        tma_atom_X: Optional[cute.CopyAtom],
+        mX_tma: Optional[cute.Tensor],
+        tma_atom_dO: Optional[cute.CopyAtom],
+        mdO_tma: Optional[cute.Tensor],
         tiler_mn: cute.Shape,
         tiled_copy: cute.TiledCopy,
         threads_per_row: cutlass.Constexpr[int],
     ):
         tidx, _, _ = cute.arch.thread_idx()
-        bidx_start, _, bidz = cute.arch.block_idx()
+        warp_idx_uniform = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        if const_expr(self.per_head):
+            bidx_start, _, bidz = cute.arch.block_idx()
+        else:
+            bidx_start, _, _ = cute.arch.block_idx()
         gdim, _, _ = cute.arch.grid_dim()
         cluster_y = const_expr(0) if const_expr(self.cluster_n == 1) else cute.arch.block_idx()[1]
         tv_layout = tiled_copy.layout_tv_tiled
 
         # Slice per head
-        if const_expr(cute.rank(mX) == 3):
+        if const_expr(self.per_head):
             mX, mW, mdO, mdResO, mdX, mdW, mdB, mdRes = [
                 mT[None, bidz, None] if const_expr(mT is not None) else None
                 for mT in (mX, mW, mdO, mdResO, mdX, mdW, mdB, mdRes)
@@ -608,15 +657,20 @@ class RMSNormBackward(ReductionBase):
             mRstd = mRstd[None, bidz]
 
         shape = mX.shape
-        M, N = shape[0], shape[1]
+        M = shape[0]
         is_even_N = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
 
         idX = cute.make_identity_tensor(shape)
 
         smem = cutlass.utils.SmemAllocator()
-        smem_layout = cute.make_ordered_layout((tiler_mn[0], tiler_mn[1], 2), order=(1, 0, 2))
-        sX = smem.allocate_tensor(mX.element_type, smem_layout, byte_alignment=16)
-        sdO = smem.allocate_tensor(mdO.element_type, smem_layout, byte_alignment=16)
+        USE_TMA = const_expr(self.USE_TMA)
+        n_smem_stages = const_expr(self._tma_stages_val if USE_TMA else 2)
+        smem_layout = cute.make_ordered_layout(
+            (tiler_mn[0], tiler_mn[1], n_smem_stages), order=(1, 0, 2)
+        )
+        smem_align = const_expr(128 if USE_TMA else 16)
+        sX = smem.allocate_tensor(mX.element_type, smem_layout, byte_alignment=smem_align)
+        sdO = smem.allocate_tensor(mdO.element_type, smem_layout, byte_alignment=smem_align)
         reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(
             smem, tv_layout, is_persistent=True
         )
@@ -681,6 +735,10 @@ class RMSNormBackward(ReductionBase):
             tXrdB = cute.make_rmem_tensor_like(tXgdB, Float32)
 
         num_warps = cute.size(tiled_copy) // cute.arch.WARP_SIZE
+        NUM_TMA_STAGES = const_expr(self._tma_stages_val)
+
+        if const_expr(USE_TMA):
+            tma_mbar_ptr = smem.allocate_array(Int64, num_elems=NUM_TMA_STAGES * 2)
 
         self._initialize_cluster(tidx, mbar_ptr, num_warps, is_persistent=True)
 
@@ -692,22 +750,48 @@ class RMSNormBackward(ReductionBase):
             if const_expr(not is_even_N):
                 tXrW.fill(0.0)
             copy(tXgW, tXrW)
-
-        # Prefetch the first batch
-        row = tXcX[None, None, None, bidx_start][0][0]
-        if row < M:
-            copy(tXgX[None, None, None, bidx_start], tXsX[None, None, None, 0], is_async=True)
-            copy(tXgdO[None, None, None, bidx_start], tXsdO[None, None, None, 0], is_async=True)
-        else:
-            if const_expr(tiler_mn[0] > 1):
-                # Fill with zero, otherwise smem will be uninitialized, and we could read this back
-                # later into registers, causing wrong dW.
-                utils.fill_oob(tXsX[None, None, None, 0], None, fill_value=mX.element_type.zero)
-                utils.fill_oob(tXsdO[None, None, None, 0], None, fill_value=mdO.element_type.zero)
-        cute.arch.cp_async_commit_group()
+            # No-op fp32 round-trip; pins tXrW into stable registers across the loop.
+            tXrW.store((tXrW.load().to(Float32) + Float32(0.0)).to(tXrW.element_type))
 
         if const_expr(self.cluster_n > 1):
             cute.arch.cluster_wait()
+
+        if const_expr(USE_TMA):
+            num_threads_total = cute.size(tiled_copy)
+            producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+            consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_threads_total)
+            tma_bytes_x = const_expr(cute.size(tiler_mn) * mX.element_type.width // 8)
+            tma_bytes_do = const_expr(cute.size(tiler_mn) * mdO.element_type.width // 8)
+            tma_pipeline = pipeline.PipelineTmaAsync.create(
+                barrier_storage=tma_mbar_ptr,
+                num_stages=NUM_TMA_STAGES,
+                producer_group=producer_group,
+                consumer_group=consumer_group,
+                tx_count=tma_bytes_x + tma_bytes_do,
+                cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            )
+            gX_tma = cute.local_tile(mX_tma, tiler_mn, (None, cluster_y))
+            gdO_tma = cute.local_tile(mdO_tma, tiler_mn, (None, cluster_y))
+            tXsX_tma, tXgX_tma = cpasync.tma_partition(
+                tma_atom_X,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sX, 0, 2),
+                cute.group_modes(gX_tma, 0, 2),
+            )
+            tXsdO_tma, tXgdO_tma = cpasync.tma_partition(
+                tma_atom_dO,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sdO, 0, 2),
+                cute.group_modes(gdO_tma, 0, 2),
+            )
+            producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, NUM_TMA_STAGES
+            )
+            consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, NUM_TMA_STAGES
+            )
 
         if const_expr(mdW is not None):
             tXrdW.fill(0.0)
@@ -716,28 +800,101 @@ class RMSNormBackward(ReductionBase):
         stage = Int32(0)
         producer_phase = Int32(1)
         consumer_phase = Int32(0)
-        for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
-            row = tXcX[None, None, None, bidx][0][0]
-            if row + gdim * tiler_mn[0] < M:  # Prefetch the next batch
+
+        M_ceil = cute.ceil_div(M, tiler_mn[0])
+        row = tXcX[None, None, None, bidx_start][0][0]
+        if const_expr(USE_TMA):
+            if warp_idx_uniform == 0:
+                if bidx_start < M_ceil:
+                    tma_pipeline.producer_acquire(producer_state)
+                    pipe_bar = tma_pipeline.producer_get_barrier(producer_state)
+                    cute.copy(
+                        tma_atom_X,
+                        tXgX_tma[None, bidx_start],
+                        tXsX_tma[None, producer_state.index],
+                        tma_bar_ptr=pipe_bar,
+                    )
+                    cute.copy(
+                        tma_atom_dO,
+                        tXgdO_tma[None, bidx_start],
+                        tXsdO_tma[None, producer_state.index],
+                        tma_bar_ptr=pipe_bar,
+                    )
+                    tma_pipeline.producer_commit(producer_state)
+                    producer_state.advance()
+        else:
+            if row < M:
                 copy(
-                    tXgX[None, None, None, bidx + gdim],
-                    tXsX[None, None, None, stage ^ 1],
+                    tXgX[None, None, None, bidx_start],
+                    tXsX[None, None, None, 0],
                     is_async=True,
                 )
                 copy(
-                    tXgdO[None, None, None, bidx + gdim],
-                    tXsdO[None, None, None, stage ^ 1],
+                    tXgdO[None, None, None, bidx_start],
+                    tXsdO[None, None, None, 0],
                     is_async=True,
                 )
             else:
                 if const_expr(tiler_mn[0] > 1):
                     utils.fill_oob(
-                        tXsX[None, None, None, stage ^ 1], None, fill_value=mX.element_type.zero
+                        tXsX[None, None, None, 0],
+                        None,
+                        fill_value=mX.element_type.zero,
                     )
                     utils.fill_oob(
-                        tXsdO[None, None, None, stage ^ 1], None, fill_value=mdO.element_type.zero
+                        tXsdO[None, None, None, 0],
+                        None,
+                        fill_value=mdO.element_type.zero,
                     )
             cute.arch.cp_async_commit_group()
+
+        for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
+            row = tXcX[None, None, None, bidx][0][0]
+            if const_expr(USE_TMA):
+                next_bidx = bidx + gdim
+                if warp_idx_uniform == 0:
+                    if next_bidx < M_ceil:
+                        tma_pipeline.producer_acquire(producer_state)
+                        pipe_bar = tma_pipeline.producer_get_barrier(producer_state)
+                        cute.copy(
+                            tma_atom_X,
+                            tXgX_tma[None, next_bidx],
+                            tXsX_tma[None, producer_state.index],
+                            tma_bar_ptr=pipe_bar,
+                        )
+                        cute.copy(
+                            tma_atom_dO,
+                            tXgdO_tma[None, next_bidx],
+                            tXsdO_tma[None, producer_state.index],
+                            tma_bar_ptr=pipe_bar,
+                        )
+                        tma_pipeline.producer_commit(producer_state)
+                        producer_state.advance()
+            else:
+                if row + gdim * tiler_mn[0] < M:  # Prefetch the next batch
+                    copy(
+                        tXgX[None, None, None, bidx + gdim],
+                        tXsX[None, None, None, stage ^ 1],
+                        is_async=True,
+                    )
+                    copy(
+                        tXgdO[None, None, None, bidx + gdim],
+                        tXsdO[None, None, None, stage ^ 1],
+                        is_async=True,
+                    )
+                else:
+                    if const_expr(tiler_mn[0] > 1):
+                        utils.fill_oob(
+                            tXsX[None, None, None, stage ^ 1],
+                            None,
+                            fill_value=mX.element_type.zero,
+                        )
+                        utils.fill_oob(
+                            tXsdO[None, None, None, stage ^ 1],
+                            None,
+                            fill_value=mdO.element_type.zero,
+                        )
+                cute.arch.cp_async_commit_group()
             rstd = cutlass.Float.zero
             if row < M or tiler_mn[0] == 1:
                 rstd = mRstd[row]
@@ -746,10 +903,15 @@ class RMSNormBackward(ReductionBase):
                     copy(tXgdResO[None, None, None, bidx], tXrdResO)
                 elif tiler_mn[0] > 1:
                     tXrdResO.fill(0.0)
-            cute.arch.cp_async_wait_group(1)
-            cute.autovec_copy(tXsX[None, None, None, stage], tXrX)
+            if const_expr(USE_TMA):
+                tma_pipeline.consumer_wait(consumer_state)
+                smem_stage = consumer_state.index
+            else:
+                cute.arch.cp_async_wait_group(1)
+                smem_stage = stage
+            cute.autovec_copy(tXsX[None, None, None, smem_stage], tXrX)
             x = tXrX.load().to(cute.Float32)
-            cute.autovec_copy(tXsdO[None, None, None, stage], tXrdO)
+            cute.autovec_copy(tXsdO[None, None, None, smem_stage], tXrdO)
             dout = tXrdO.load().to(cute.Float32)
             x_hat = x * rstd
             wdy = dout
@@ -783,11 +945,16 @@ class RMSNormBackward(ReductionBase):
                     )
 
             if const_expr(self.reload_wdy == "smem"):
-                cute.autovec_copy(tXsdO[None, None, None, stage], tXrdO)
+                cute.autovec_copy(tXsdO[None, None, None, smem_stage], tXrdO)
                 dout = tXrdO.load().to(cute.Float32)
                 wdy = dout
                 if const_expr(mW is not None):
                     wdy *= tXrW.load().to(Float32)
+
+            if const_expr(self.reload_x == "smem"):
+                cute.autovec_copy(tXsX[None, None, None, smem_stage], tXrX)
+                x = tXrX.load().to(cute.Float32)
+                x_hat = x * rstd
 
             dx = (wdy - x_hat * mean_xhat_wdy) * rstd
             if const_expr(mdResO is not None):
@@ -803,6 +970,12 @@ class RMSNormBackward(ReductionBase):
                 tXrdW.store(tXrdW.load() + dout * x_hat)
             if const_expr(mdB is not None):
                 tXrdB.store(tXrdB.load() + dout)
+
+            if const_expr(USE_TMA):
+                tma_pipeline.sync_object_empty.arrive(
+                    consumer_state.index, tma_pipeline.consumer_mask
+                )
+                consumer_state.advance()
 
             stage ^= 1
             if stage == 0:
@@ -868,23 +1041,6 @@ class RMSNormBackward(ReductionBase):
             cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
 
 
-def _get_sm_count(N: int, device: torch.device) -> int:
-    # This should be tuned on how many CTAs can be launched on each SM
-    sm_count_multiple = (
-        16 if N <= 256 else (8 if N <= 1024 else (4 if N <= 2048 else (2 if N <= 4096 else 1)))
-    )
-    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
-    # By right, if we're using cluster, this should be cluster_count not sm_count.
-    # But for cluster >= 4, due to quantization we would need to query active max cluster.
-    # Instead we just do sm_count * 2, which is reasonably larger than active_cluster_count to
-    # avoid wave quantization.
-    sm_count = (
-        sm_count * sm_count_multiple if N <= 8192 else sm_count // 2 if N <= 16384 else sm_count * 2
-    )
-
-    return sm_count
-
-
 @cute_op(
     "quack::_rmsnorm_bwd",
     mutates_args={"dx", "dw_partial", "db_partial", "dresidual"},
@@ -941,6 +1097,7 @@ def _rmsnorm_bwd(
         torch2cute_dtype_map[t.dtype] if t is not None else None
         for t in [x, dout, dx, weight, dresidual, dresidual_out]
     ]
+    T_hint = int(x.size(0)) if not isinstance(x.size(0), torch.SymInt) else 0
     _compile_rmsnorm_bwd(
         N,
         dtype,
@@ -952,6 +1109,7 @@ def _rmsnorm_bwd(
         dres_out_dtype,
         dw_partial is not None,
         per_head,
+        T_hint=T_hint,
     )(x, weight, dout, dresidual_out, rstd, dx, dw_partial, dresidual, db_partial, sm_count)
 
 
@@ -967,6 +1125,7 @@ def _compile_rmsnorm_bwd(
     dres_out_dtype,
     has_dw_partial,
     per_head=False,
+    T_hint=0,
 ):
     batch_sym, batch_partial_sym = cute.sym_int(), cute.sym_int()
     head_sym = cute.sym_int() if per_head else None
@@ -984,7 +1143,13 @@ def _compile_rmsnorm_bwd(
     dw_partial_cute = fake_tensor(Float32, dw_shape, div) if has_dw_partial else None
     db_partial_cute = fake_tensor(Float32, dw_shape, div) if has_db_partial else None
     return cute.compile(
-        RMSNormBackward(dtype, N),
+        RMSNormBackward(
+            dtype,
+            N,
+            dout_dtype=dout_dtype,
+            T_hint=T_hint,
+            per_head=per_head,
+        ),
         x_cute,
         weight_cute,
         dout_cute,
@@ -1017,7 +1182,7 @@ def rmsnorm_bwd(
         dresidual = torch.empty_like(x, dtype=dresidual_out.dtype)
     else:
         dresidual = None
-    sm_count = _get_sm_count(N, device)
+    sm_count = get_sm_count(N, device)
     if per_head:
         H = x.size(1)
         sm_count = max(round(sm_count / H), 1)

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -24,7 +24,7 @@ from quack.reduce import row_reduce
 from quack.reduction_base import ReductionBase
 from quack.cache_utils import jit_cache
 from quack.cute_dsl_utils import torch2cute_dtype_map
-from quack.rmsnorm_config import RmsNormConfig, get_sm_count
+from quack.rmsnorm_config import RmsNormBwdConfig, get_sm_count
 from cutlass.base_dsl.arch import Arch
 
 
@@ -521,7 +521,9 @@ class RMSNormBackward(ReductionBase):
             if torch.cuda.is_available()
             else 0
         )
-        config = RmsNormConfig.select(N, dtype.width, dout_width, arch_major, T_hint)
+        config = RmsNormBwdConfig.from_analytical_heuristic(
+            N, dtype.width, dout_width, arch_major, T_hint
+        )
         self.config = config
         self.reload_wdy = config.reload_wdy
         self.reload_x = config.reload_x

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -28,6 +28,21 @@ from quack.rmsnorm_config import RmsNormBwdConfig, get_sm_count
 from cutlass.base_dsl.arch import Arch
 
 
+def _bucket_T_hint(T_hint: int) -> int:
+    """Round ``T_hint`` up to the next power of 2 to bucket the JIT cache key.
+
+    Each base-2 order of magnitude becomes a single bucket so adjacent T
+    values share a compiled binary instead of triggering a recompile per row
+    count. Buckets align with powers of 2 (..., 512, 1024, 2048, ...), which
+    keeps the analytical heuristic thresholds (e.g. ``T_hint <= 1024``) exact
+    at their power-of-2 boundaries. ``T_hint <= 0`` (the "unknown shape"
+    SymInt sentinel) is preserved.
+    """
+    if T_hint <= 0:
+        return 0
+    return 1 << (T_hint - 1).bit_length()
+
+
 def _ensure_contiguous(t):
     """Ensure last-dim stride is 1. Under torch.compile use unconditional .contiguous()
     (dynamo can't inspect strides on fake tensors); otherwise check first to avoid copies.
@@ -1111,7 +1126,7 @@ def _rmsnorm_bwd(
         torch2cute_dtype_map[t.dtype] if t is not None else None
         for t in [x, dout, dx, weight, dresidual, dresidual_out]
     ]
-    T_hint = int(x.size(0)) if not isinstance(x.size(0), torch.SymInt) else 0
+    T_hint = _bucket_T_hint(int(x.size(0)) if not isinstance(x.size(0), torch.SymInt) else 0)
     _compile_rmsnorm_bwd(
         N,
         dtype,

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -529,7 +529,6 @@ class RMSNormBackward(ReductionBase):
         self._num_threads_val = config.num_threads
         self._threads_per_row_val = config.threads_per_row
         self._cluster_n_val = config.cluster_n
-        self._tma_stages_val = config.tma_stages
         tile_n = N // max(1, config.cluster_n)
         row_bytes_x = tile_n * dtype.width // 8
         row_bytes_do = tile_n * dout_width // 8
@@ -639,7 +638,7 @@ class RMSNormBackward(ReductionBase):
         threads_per_row: cutlass.Constexpr[int],
     ):
         tidx, _, _ = cute.arch.thread_idx()
-        warp_idx_uniform = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         if const_expr(self.per_head):
             bidx_start, _, bidz = cute.arch.block_idx()
         else:
@@ -664,7 +663,7 @@ class RMSNormBackward(ReductionBase):
 
         smem = cutlass.utils.SmemAllocator()
         USE_TMA = const_expr(self.USE_TMA)
-        n_smem_stages = const_expr(self._tma_stages_val if USE_TMA else 2)
+        n_smem_stages = const_expr(self.config.smem_stages)
         smem_layout = cute.make_ordered_layout(
             (tiler_mn[0], tiler_mn[1], n_smem_stages), order=(1, 0, 2)
         )
@@ -735,10 +734,10 @@ class RMSNormBackward(ReductionBase):
             tXrdB = cute.make_rmem_tensor_like(tXgdB, Float32)
 
         num_warps = cute.size(tiled_copy) // cute.arch.WARP_SIZE
-        NUM_TMA_STAGES = const_expr(self._tma_stages_val)
+        NUM_PIPE_STAGES = const_expr(self.config.smem_stages)
 
         if const_expr(USE_TMA):
-            tma_mbar_ptr = smem.allocate_array(Int64, num_elems=NUM_TMA_STAGES * 2)
+            tma_mbar_ptr = smem.allocate_array(Int64, num_elems=NUM_PIPE_STAGES * 2)
 
         self._initialize_cluster(tidx, mbar_ptr, num_warps, is_persistent=True)
 
@@ -756,6 +755,12 @@ class RMSNormBackward(ReductionBase):
         if const_expr(self.cluster_n > 1):
             cute.arch.cluster_wait()
 
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, NUM_PIPE_STAGES
+        )
+        consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, NUM_PIPE_STAGES
+        )
         if const_expr(USE_TMA):
             num_threads_total = cute.size(tiled_copy)
             producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
@@ -764,7 +769,7 @@ class RMSNormBackward(ReductionBase):
             tma_bytes_do = const_expr(cute.size(tiler_mn) * mdO.element_type.width // 8)
             tma_pipeline = pipeline.PipelineTmaAsync.create(
                 barrier_storage=tma_mbar_ptr,
-                num_stages=NUM_TMA_STAGES,
+                num_stages=NUM_PIPE_STAGES,
                 producer_group=producer_group,
                 consumer_group=consumer_group,
                 tx_count=tma_bytes_x + tma_bytes_do,
@@ -786,12 +791,6 @@ class RMSNormBackward(ReductionBase):
                 cute.group_modes(sdO, 0, 2),
                 cute.group_modes(gdO_tma, 0, 2),
             )
-            producer_state = pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Producer, NUM_TMA_STAGES
-            )
-            consumer_state = pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Consumer, NUM_TMA_STAGES
-            )
 
         if const_expr(mdW is not None):
             tXrdW.fill(0.0)
@@ -800,101 +799,115 @@ class RMSNormBackward(ReductionBase):
         stage = Int32(0)
         producer_phase = Int32(1)
         consumer_phase = Int32(0)
+        next_wave_work_id = (NUM_PIPE_STAGES - 1) * gdim
+        next_wave_row_id = next_wave_work_id * tiler_mn[0]
 
         M_ceil = cute.ceil_div(M, tiler_mn[0])
-        row = tXcX[None, None, None, bidx_start][0][0]
         if const_expr(USE_TMA):
-            if warp_idx_uniform == 0:
-                if bidx_start < M_ceil:
-                    tma_pipeline.producer_acquire(producer_state)
-                    pipe_bar = tma_pipeline.producer_get_barrier(producer_state)
-                    cute.copy(
-                        tma_atom_X,
-                        tXgX_tma[None, bidx_start],
-                        tXsX_tma[None, producer_state.index],
-                        tma_bar_ptr=pipe_bar,
-                    )
-                    cute.copy(
-                        tma_atom_dO,
-                        tXgdO_tma[None, bidx_start],
-                        tXsdO_tma[None, producer_state.index],
-                        tma_bar_ptr=pipe_bar,
-                    )
-                    tma_pipeline.producer_commit(producer_state)
-                    producer_state.advance()
-        else:
-            if row < M:
-                copy(
-                    tXgX[None, None, None, bidx_start],
-                    tXsX[None, None, None, 0],
-                    is_async=True,
-                )
-                copy(
-                    tXgdO[None, None, None, bidx_start],
-                    tXsdO[None, None, None, 0],
-                    is_async=True,
-                )
-            else:
-                if const_expr(tiler_mn[0] > 1):
-                    utils.fill_oob(
-                        tXsX[None, None, None, 0],
-                        None,
-                        fill_value=mX.element_type.zero,
-                    )
-                    utils.fill_oob(
-                        tXsdO[None, None, None, 0],
-                        None,
-                        fill_value=mdO.element_type.zero,
-                    )
-            cute.arch.cp_async_commit_group()
-
-        for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
-            row = tXcX[None, None, None, bidx][0][0]
-            if const_expr(USE_TMA):
-                next_bidx = bidx + gdim
-                if warp_idx_uniform == 0:
-                    if next_bidx < M_ceil:
+            for prefetch_iter in cutlass.range_constexpr(const_expr(NUM_PIPE_STAGES - 1)):
+                init_bidx = bidx_start + prefetch_iter * gdim
+                if warp_id == 0:
+                    if init_bidx < M_ceil:
                         tma_pipeline.producer_acquire(producer_state)
                         pipe_bar = tma_pipeline.producer_get_barrier(producer_state)
                         cute.copy(
                             tma_atom_X,
-                            tXgX_tma[None, next_bidx],
+                            tXgX_tma[None, init_bidx],
                             tXsX_tma[None, producer_state.index],
                             tma_bar_ptr=pipe_bar,
                         )
                         cute.copy(
                             tma_atom_dO,
-                            tXgdO_tma[None, next_bidx],
+                            tXgdO_tma[None, init_bidx],
+                            tXsdO_tma[None, producer_state.index],
+                            tma_bar_ptr=pipe_bar,
+                        )
+                        tma_pipeline.producer_commit(producer_state)
+                        producer_state.advance()
+        else:
+            # Pre-issue NUM_PIPE_STAGES-1 prefetches into smem stages 0..N-2.
+            # The bidx loop then maintains exactly NUM_PIPE_STAGES groups in flight
+            # via cp_async_wait_group(NUM_PIPE_STAGES - 1).
+            for prefetch_iter in cutlass.range_constexpr(const_expr(NUM_PIPE_STAGES - 1)):
+                init_bidx = bidx_start + prefetch_iter * gdim
+                init_row = tXcX[None, None, None, init_bidx][0][0]
+                if init_row < M:
+                    copy(
+                        tXgX[None, None, None, init_bidx],
+                        tXsX[None, None, None, producer_state.index],
+                        is_async=True,
+                    )
+                    copy(
+                        tXgdO[None, None, None, init_bidx],
+                        tXsdO[None, None, None, producer_state.index],
+                        is_async=True,
+                    )
+                else:
+                    if const_expr(tiler_mn[0] > 1):
+                        utils.fill_oob(
+                            tXsX[None, None, None, producer_state.index],
+                            None,
+                            fill_value=mX.element_type.zero,
+                        )
+                        utils.fill_oob(
+                            tXsdO[None, None, None, producer_state.index],
+                            None,
+                            fill_value=mdO.element_type.zero,
+                        )
+                cute.arch.cp_async_commit_group()
+                producer_state.advance()
+
+        for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
+            row = tXcX[None, None, None, bidx][0][0]
+            if const_expr(USE_TMA):
+                ahead_bidx = bidx + next_wave_work_id
+                if warp_id == 0:
+                    if ahead_bidx < M_ceil:
+                        tma_pipeline.producer_acquire(producer_state)
+                        pipe_bar = tma_pipeline.producer_get_barrier(producer_state)
+                        cute.copy(
+                            tma_atom_X,
+                            tXgX_tma[None, ahead_bidx],
+                            tXsX_tma[None, producer_state.index],
+                            tma_bar_ptr=pipe_bar,
+                        )
+                        cute.copy(
+                            tma_atom_dO,
+                            tXgdO_tma[None, ahead_bidx],
                             tXsdO_tma[None, producer_state.index],
                             tma_bar_ptr=pipe_bar,
                         )
                         tma_pipeline.producer_commit(producer_state)
                         producer_state.advance()
             else:
-                if row + gdim * tiler_mn[0] < M:  # Prefetch the next batch
+                # cp.async: prefetch the (NUM_PIPE_STAGES-1)-ahead batch into the
+                # smem slot we're about to free up.
+                ahead_bidx = bidx + next_wave_work_id
+                if row + next_wave_row_id < M:
                     copy(
-                        tXgX[None, None, None, bidx + gdim],
-                        tXsX[None, None, None, stage ^ 1],
+                        tXgX[None, None, None, ahead_bidx],
+                        tXsX[None, None, None, producer_state.index],
                         is_async=True,
                     )
                     copy(
-                        tXgdO[None, None, None, bidx + gdim],
-                        tXsdO[None, None, None, stage ^ 1],
+                        tXgdO[None, None, None, ahead_bidx],
+                        tXsdO[None, None, None, producer_state.index],
                         is_async=True,
                     )
                 else:
                     if const_expr(tiler_mn[0] > 1):
                         utils.fill_oob(
-                            tXsX[None, None, None, stage ^ 1],
+                            tXsX[None, None, None, producer_state.index],
                             None,
                             fill_value=mX.element_type.zero,
                         )
                         utils.fill_oob(
-                            tXsdO[None, None, None, stage ^ 1],
+                            tXsdO[None, None, None, producer_state.index],
                             None,
                             fill_value=mdO.element_type.zero,
                         )
                 cute.arch.cp_async_commit_group()
+                producer_state.advance()
             rstd = cutlass.Float.zero
             if row < M or tiler_mn[0] == 1:
                 rstd = mRstd[row]
@@ -905,10 +918,9 @@ class RMSNormBackward(ReductionBase):
                     tXrdResO.fill(0.0)
             if const_expr(USE_TMA):
                 tma_pipeline.consumer_wait(consumer_state)
-                smem_stage = consumer_state.index
             else:
-                cute.arch.cp_async_wait_group(1)
-                smem_stage = stage
+                cute.arch.cp_async_wait_group(const_expr(NUM_PIPE_STAGES - 1))
+            smem_stage = consumer_state.index
             cute.autovec_copy(tXsX[None, None, None, smem_stage], tXrX)
             x = tXrX.load().to(cute.Float32)
             cute.autovec_copy(tXsdO[None, None, None, smem_stage], tXrdO)
@@ -975,7 +987,7 @@ class RMSNormBackward(ReductionBase):
                 tma_pipeline.sync_object_empty.arrive(
                     consumer_state.index, tma_pipeline.consumer_mask
                 )
-                consumer_state.advance()
+            consumer_state.advance()
 
             stage ^= 1
             if stage == 0:

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -22,30 +22,36 @@ class RmsNormConfig:
     reload_wdy: Optional[str]
     reload_x: Optional[str]
     use_tma: bool
-    tma_stages: int = 2
-    # 9 = Hopper / pre-Blackwell default path, 10 = Blackwell.
-    device_capacity: int = 9
+    # Number of smem stages used by the prefetch pipeline. Drives both the
+    # cp.async (use_tma=False) and TMA (use_tma=True) paths, which lead by
+    # ``smem_stages - 1`` batches. Larger depths hide more latency at the cost
+    # of smem footprint.
+    smem_stages: int = 2
 
     @classmethod
-    def select(
+    def from_analytical_heuristic(
         cls,
         N: int,
         dtype_width: int,
         dout_width: int,
-        arch_major: int,
+        arch_major: Optional[int] = None,
         T_hint: int = 0,
-    ) -> "RmsNormConfig":
-        """Pick a launch config for the given problem and target architecture.
+    ) -> "RmsNormBwdConfig":
+        """Pick a launch config from the hand-tuned analytical heuristic.
 
+        ``arch_major`` defaults to the current device's capability.
         ``arch_major >= 10`` selects the Blackwell heuristic; anything else
-        uses the legacy/default path that was tuned on Hopper.
+        uses the legacy/default path tuned on Hopper. For autotuning, use
+        :func:`get_all_bwd_configs`.
         """
+        if arch_major is None:
+            arch_major = _detect_arch_major()
         if arch_major >= 10:
-            return _for_blackwell(N, dtype_width, dout_width, T_hint)
-        return _for_hopper(N, dtype_width, arch_major)
+            return _for_blackwell_bwd(N, dtype_width, dout_width, T_hint)
+        return _for_hopper_bwd(N, dtype_width, arch_major)
 
 
-def _for_hopper(N: int, dtype_width: int, arch_major: int) -> RmsNormConfig:
+def _for_hopper_bwd(N: int, dtype_width: int, arch_major: int) -> RmsNormBwdConfig:
     num_threads = 128 if N <= 4096 else 256
     for limit, threads in [(64, 8), (128, 16), (256, 32), (512, 64), (4096, 128)]:
         if N <= limit:
@@ -68,20 +74,19 @@ def _for_hopper(N: int, dtype_width: int, arch_major: int) -> RmsNormConfig:
                 cluster_n = cluster
                 break
 
-    return RmsNormConfig(
+    return RmsNormBwdConfig(
         num_threads=num_threads,
         threads_per_row=threads_per_row,
         cluster_n=cluster_n,
         reload_wdy=None if N <= 16 * 1024 else "smem",
         reload_x=None,
         use_tma=False,
-        device_capacity=9,
     )
 
 
-def _for_blackwell(
+def _for_blackwell_bwd(
     N: int, dtype_width: int, dout_width: int, T_hint: int = 0
-) -> RmsNormConfig:
+) -> RmsNormBwdConfig:
     """Pick a launch config for RMSNorm bwd on Blackwell.
 
     All thresholds are expressed in ``row_bytes = N * max(x, dout)`` so a
@@ -103,14 +108,13 @@ def _for_blackwell(
         threads_per_row = None
 
     if threads_per_row is not None:
-        return RmsNormConfig(
+        return RmsNormBwdConfig(
             num_threads=128,
             threads_per_row=threads_per_row,
             cluster_n=1,
             reload_wdy=None,
             reload_x=None,
             use_tma=False,
-            device_capacity=10,
         )
 
     max_bytes = max(dtype_width, dout_width) // 8
@@ -122,6 +126,14 @@ def _for_blackwell(
         # CTA's tile small enough to fit comfortably in registers.
         cluster_n = 4 if 0 < T_hint <= 1024 and row_bytes <= 64 * 1024 else 8
         num_threads, threads_per_row = 128, 128
+        # Override if this cluster_n would overflow the device's smem budget.
+        cluster_n = _bump_cluster_n_for_smem(
+            cluster_n,
+            N,
+            smem_stages=2,
+            sum_bytes=(dtype_width + dout_width) // 8,
+            max_cluster=_max_cluster_for(10),  # Blackwell
+        )
     elif row_bytes > 16 * 1024:
         # Wider than 128 threads can comfortably handle at cluster_n=1; bump
         # threads/row to keep per-thread fragments small.
@@ -151,14 +163,13 @@ def _for_blackwell(
     # large enough to spill).
     reload_wdy = "smem" if cluster_n >= 4 or bytes_per_thread_frag >= 64 else None
 
-    return RmsNormConfig(
+    return RmsNormBwdConfig(
         num_threads=num_threads,
         threads_per_row=threads_per_row,
         cluster_n=cluster_n,
         reload_wdy=reload_wdy,
         reload_x=reload_x,
         use_tma=use_tma,
-        device_capacity=10,
     )
 
 
@@ -191,3 +202,70 @@ def get_sm_count(N: int, device: torch.device) -> int:
     if props.major >= 10:
         return _get_sm_count_blackwell(N, props.multi_processor_count)
     return _get_sm_count_hopper(N, props.multi_processor_count)
+
+
+_CTA_THREAD_SIZE = (128, 256)
+_THREADS_PER_REDUCTION_DIM = (8, 16, 32, 64, 128, 256)
+
+
+def _max_dynamic_smem_bytes() -> int:
+    """Per-CTA opt-in dynamic smem capacity for the current device.
+
+    Returns 0 when CUDA is unavailable (callers should treat this as "no
+    smem-budget guard"). Falls back to ``shared_memory_per_block`` on older
+    PyTorch builds that lack the ``_optin`` field.
+    """
+    if not torch.cuda.is_available():
+        return 0
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return getattr(props, "shared_memory_per_block_optin", props.shared_memory_per_block)
+
+
+def _bump_cluster_n_for_smem(
+    cluster_n: int,
+    N: int,
+    smem_stages: int,
+    sum_bytes: int,
+    max_cluster: int,
+) -> int:
+    """Raise ``cluster_n`` to the smallest power of 2 such that the bwd's
+    sX+sdO data buffers fit under the device's opt-in dynamic smem.
+
+    Footprint per CTA is ``(N / cluster_n) * smem_stages * sum_bytes`` where
+    ``sum_bytes = x_bytes + dout_bytes``. Snaps up to the next power of 2,
+    floors at the input ``cluster_n`` (never lowers the tuning's choice), and
+    caps at ``max_cluster``. If the required cluster_n exceeds ``max_cluster``
+    the runtime guard in ``RMSNormBackward.__init__`` raises a precise overflow
+    error. Returns the input unchanged if CUDA is unavailable.
+    """
+    # Reserved for row-reduction buffer, mbars, and smem alignment overhead.
+    _BWD_SMEM_RESERVED_BYTES = 4 * 1024
+    smem_max = _max_dynamic_smem_bytes()
+    if smem_max <= 0:
+        return cluster_n
+    budget = max(smem_max - _BWD_SMEM_RESERVED_BYTES, 1)
+    needed = (N * smem_stages * sum_bytes + budget - 1) // budget  # ceil-div
+    pow2 = 1
+    while pow2 < needed:
+        pow2 *= 2
+    return min(max(pow2, cluster_n), max_cluster)
+
+
+def _detect_arch_major() -> int:
+    """Return the major device capability of the current CUDA device.
+
+    Falls back to 0 (no-cluster, no-TMA) when CUDA is unavailable so the
+    autotune search space stays well-defined for CPU-only imports.
+    """
+    if not torch.cuda.is_available():
+        return 0
+    return torch.cuda.get_device_capability(torch.cuda.current_device())[0]
+
+
+def _max_cluster_for(arch_major: int) -> int:
+    """Maximum cluster_n supported on this arch."""
+    if arch_major < 9:
+        return 1
+    # SM12x (RTX 50) supports up to 8; Hopper/Blackwell up to 16.
+    return 8 if arch_major == 12 else 16
+

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+
+"""Launch configuration for the RMSNorm backward kernel.
+
+Mirrors :mod:`quack.gemm_config`: a frozen dataclass that captures the launch
+knobs, plus arch-specific factories that own the heuristics. The forward
+kernel's launch logic is much simpler and stays inline in :class:`RMSNorm`.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class RmsNormConfig:
+    num_threads: int
+    threads_per_row: int
+    cluster_n: int
+    # None = recompute from registers; "smem" = reload from shared memory.
+    reload_wdy: Optional[str]
+    reload_x: Optional[str]
+    use_tma: bool
+    tma_stages: int = 2
+    # 9 = Hopper / pre-Blackwell default path, 10 = Blackwell.
+    device_capacity: int = 9
+
+    @classmethod
+    def select(
+        cls,
+        N: int,
+        dtype_width: int,
+        dout_width: int,
+        arch_major: int,
+        T_hint: int = 0,
+    ) -> "RmsNormConfig":
+        """Pick a launch config for the given problem and target architecture.
+
+        ``arch_major >= 10`` selects the Blackwell heuristic; anything else
+        uses the legacy/default path that was tuned on Hopper.
+        """
+        if arch_major >= 10:
+            return _for_blackwell(N, dtype_width, dout_width, T_hint)
+        return _for_hopper(N, dtype_width, arch_major)
+
+
+def _for_hopper(N: int, dtype_width: int, arch_major: int) -> RmsNormConfig:
+    num_threads = 128 if N <= 4096 else 256
+    for limit, threads in [(64, 8), (128, 16), (256, 32), (512, 64), (4096, 128)]:
+        if N <= limit:
+            threads_per_row = threads
+            break
+    else:
+        threads_per_row = 256
+
+    if arch_major < 9:
+        cluster_n = 1
+    else:
+        max_cluster = 8 if arch_major == 12 else 16
+        if arch_major == 12 and dtype_width >= 32:
+            thresholds = [(1024, 1), (8 * 1024, 2), (16 * 1024, 4), (32 * 1024, 8)]
+        else:
+            thresholds = [(8 * 1024, 1), (16 * 1024, 2), (32 * 1024, 4), (64 * 1024, 8)]
+        cluster_n = max_cluster
+        for limit, cluster in thresholds:
+            if N <= limit:
+                cluster_n = cluster
+                break
+
+    return RmsNormConfig(
+        num_threads=num_threads,
+        threads_per_row=threads_per_row,
+        cluster_n=cluster_n,
+        reload_wdy=None if N <= 16 * 1024 else "smem",
+        reload_x=None,
+        use_tma=False,
+        device_capacity=9,
+    )
+
+
+def _for_blackwell(
+    N: int, dtype_width: int, dout_width: int, T_hint: int = 0
+) -> RmsNormConfig:
+    """Pick a launch config for RMSNorm bwd on Blackwell.
+
+    All thresholds are expressed in ``row_bytes = N * max(x, dout)`` so a
+    single ladder handles bf16, fp32, and mixed-dtype combinations. ``x_bytes``
+    governs the X tile (loads, smem footprint); ``max_bytes`` is the wider
+    side which sets register pressure for the per-thread fragments.
+    """
+    # Safety floor for very narrow rows: keep tpr below 128 so we don't over-
+    # parallelise tiny problems.
+    if N <= 64:
+        threads_per_row = 8
+    elif N <= 128:
+        threads_per_row = 16
+    elif N <= 256:
+        threads_per_row = 32
+    elif N <= 512:
+        threads_per_row = 64
+    else:
+        threads_per_row = None
+
+    if threads_per_row is not None:
+        return RmsNormConfig(
+            num_threads=128,
+            threads_per_row=threads_per_row,
+            cluster_n=1,
+            reload_wdy=None,
+            reload_x=None,
+            use_tma=False,
+            device_capacity=10,
+        )
+
+    max_bytes = max(dtype_width, dout_width) // 8
+    row_bytes = N * max_bytes
+
+    if row_bytes >= 48 * 1024:
+        # Spread the row across a CTA cluster. Step back to cluster_n=4 only
+        # when T is tiny AND the row isn't extreme — otherwise cn=8 keeps each
+        # CTA's tile small enough to fit comfortably in registers.
+        cluster_n = 4 if 0 < T_hint <= 1024 and row_bytes <= 64 * 1024 else 8
+        num_threads, threads_per_row = 128, 128
+    elif row_bytes > 16 * 1024:
+        # Wider than 128 threads can comfortably handle at cluster_n=1; bump
+        # threads/row to keep per-thread fragments small.
+        cluster_n = 1
+        num_threads, threads_per_row = 256, 256
+    else:
+        cluster_n = 1
+        num_threads, threads_per_row = 128, 128
+
+    bytes_per_thread_frag = (N // cluster_n) // threads_per_row * max_bytes
+
+    # TMA pays off when the cluster needs prefetch (cn>=4), and also for
+    # fp32-class single-CTA wide rows where TMA's wider descriptors amortise
+    # setup. Pure bf16 single-CTA cases mostly don't benefit and can lose ~5%.
+    use_tma = cluster_n >= 4 or (max_bytes >= 4 and row_bytes >= 16 * 1024)
+    # reload_x: wide end of the cluster ladder, plus fp32-class single-CTA
+    # cases where the wider X fragments crowd registers across the row
+    # reduction barrier.
+    reload_x = (
+        "smem"
+        if (cluster_n >= 8 and N >= 32 * 1024)
+        or (cluster_n == 1 and max_bytes >= 4 and bytes_per_thread_frag >= 64)
+        else None
+    )
+    # reload_wdy: cluster cases get it for free, plus single-CTA cases where
+    # each thread holds ≥64 bytes of fragment (the wdy register count is then
+    # large enough to spill).
+    reload_wdy = "smem" if cluster_n >= 4 or bytes_per_thread_frag >= 64 else None
+
+    return RmsNormConfig(
+        num_threads=num_threads,
+        threads_per_row=threads_per_row,
+        cluster_n=cluster_n,
+        reload_wdy=reload_wdy,
+        reload_x=reload_x,
+        use_tma=use_tma,
+        device_capacity=10,
+    )
+
+
+def _get_sm_count_hopper(N: int, sm_count: int) -> int:
+    # This should be tuned on how many CTAs can be launched on each SM.
+    sm_count_multiple = (
+        16 if N <= 256 else (8 if N <= 1024 else (4 if N <= 2048 else (2 if N <= 4096 else 1)))
+    )
+    # By right, if we're using cluster, this should be cluster_count not sm_count.
+    # But for cluster >= 4, due to quantization we would need to query active max cluster.
+    # Instead we just do sm_count * 2, which is reasonably larger than active_cluster_count to
+    # avoid wave quantization.
+    return (
+        sm_count * sm_count_multiple if N <= 8192 else sm_count // 2 if N <= 16384 else sm_count * 2
+    )
+
+
+def _get_sm_count_blackwell(N: int, sm_count: int) -> int:
+    if N <= 256:
+        return sm_count * 16
+    if N <= 1024:
+        return sm_count * 8
+    if N <= 2048:
+        return sm_count * 4
+    return sm_count * 2
+
+
+def get_sm_count(N: int, device: torch.device) -> int:
+    props = torch.cuda.get_device_properties(device)
+    if props.major >= 10:
+        return _get_sm_count_blackwell(N, props.multi_processor_count)
+    return _get_sm_count_hopper(N, props.multi_processor_count)

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -14,7 +14,7 @@ import torch
 
 
 @dataclass(frozen=True)
-class RmsNormConfig:
+class RmsNormBwdConfig:
     num_threads: int
     threads_per_row: int
     cluster_n: int
@@ -268,4 +268,3 @@ def _max_cluster_for(arch_major: int) -> int:
         return 1
     # SM12x (RTX 50) supports up to 8; Hopper/Blackwell up to 16.
     return 8 if arch_major == 12 else 16
-


### PR DESCRIPTION
Various optimizations and enhancements to RMSNormBwd kernel for GB200

## Kernel additions

- TMA 1D or 2D loads for X / dY load path depending on the CTA tilers. Helps reduce register pressure for larger reduction dims without having to bump up the cluster shapes.
- Refactored persistent-loop loads: refactors the load loop to allow `consumer_state.index` (TMA) and `stage` (cp.async), share the same compute body.
- TMA uses the same smem stage count as LDGSTS.
- Runtime TMA-eligibility guard: `USE_TMA = config.use_tma and not per_head and row_bytes_x % 16 == 0 and row_bytes_do % 16 == 0` - silently falls back to cp.async when row bytes aren't 16-B aligned.
- `reload_x="smem"` knob mirroring the existing `reload_wdy`: after the row reduction barrier, X is reloaded from sX and `x_hat` recomputed, freeing the X registers that would otherwise sit live across the barrier.
- Configurable smem stage count: `n_smem_stages = self._tma_stages_val if USE_TMA else 2`, lifting the previously hardcoded 2-stage layout, and bumping smem alignment to 128 B when TMA is enabled.
- Prevent W fragment rematerialization: a no-op fp32 round-trip (`tXrW.store((tXrW.load().to(Float32) + Float32(0.0)).to(tXrW.element_type))`) after the gmem load - value-preserving, but the SSA boundary forces the compiler to keep tXrW register-resident across the persistent loop instead of re-emitting the gmem load on each iteration.

## New launch config class and GB200 specific heuristics

- `T_hint`: row count drives the heuristic but we keep the kernel body's `M` as a runtime symbol so the kernel itself isn't templated on every T value. `T_hint` enters only the `_compile_rmsnorm_bwd` cache key ; adjacent T values that hash to the same config bucket share a compiled binary; T values that pick different config buckets get separate compiles.
- `get_sm_count` lifted out of `rmsnorm.py`: arch-aware (Hopper vs Blackwell) wave-count formulas now live alongside the launch config in the new module.
- Adds separate output dtype to the class ctor for better heuristics selection.
- Config module - `quack/rmsnorm_config.py` mirrors `quack.gemm_config`. A frozen `RmsNormConfig` dataclass holds every launch knob; `RmsNormConfig.select(N, dtype_width, dout_width, arch_major, T_hint)` dispatches to `_for_blackwell` / `_for_hopper`. The Blackwell rule is a single byte-driven ladder over `row_bytes = N * max(x_bytes, dout_bytes)`:

```
row_bytes <= 16K       -> cluster_n=1, layout 128/128
16K < row_bytes < 48K  -> cluster_n=1, layout 256/256
row_bytes => 48K       -> cluster across CTAs:
                          cluster_n=4 if 0 < T <= 1024 AND row_bytes <= 64K
                          cluster_n=8 otherwise

use_tma    = cn=>4  OR  (max_bytes => 4 AND row_bytes => 16K)
reload_x   = "smem" if (cn=>8 AND N => 32K)
                        OR (cn=1 AND max_bytes => 4 AND bytes_per_thread_frag => 64)
reload_wdy = "smem" if cn=>4 OR bytes_per_thread_frag => 64
```

## Benchmarks on GB200

Measured on a single GB200 (NVIDIA HBM3e) across 256 shapes - `T x D in {1K, 2K, 4K, 8K, 12K, 16K, 24K, 32K}` x 4 dtype combos `{bf16/bf16, fp32/fp32, bf16/fp32, fp32/bf16}`.

Each shape captures 10 CUDA graphs over rotating input sets (graph count auto-trimmed to fit GPU memory at the largest shapes - 4 graphs for fp32 32Kx32K) and replays them in round-robin for 500 iters per shape, back to-back. The following heatmap shows the speedup distribution across the four input/output dtype combinations:

<img width="1982" height="1759" alt="image" src="https://github.com/user-attachments/assets/fe818bad-d94f-4fa2-a2ce-1c076531cc8e" />

- Geomean: **+19.7%** speedup vs `quack/master`
- Median: **+12.7%**
- Max: **+90.2%** (T=32K, D=12K, bf16/bf16)
- Min: **-17.1%** (T=24K, D=2K, fp32/fp32)
- Overall: 193 / 256 shapes faster, 13 shapes regressing > 10%, 14 shapes regressing 5–10%

Per-dtype geomean: bf16/bf16 **+28.5%**, fp32/bf16 **+21.9%** (0 regressions), bf16/fp32 **+17.0%**, fp32/fp32 **+12.0%**. The 13 regressions > 10% concentrate in three clear corners of the grid:

- **fp32/fp32 at D=2048**: 5 cells (T ∈ {8K..32K}) regress 15–17%. Same small-N pure-fp32 corner flagged before — the rewritten kernel body has measurable per-call overhead that no heuristic config can recover; master's simpler bwd kernel runs ~15% faster at this T-N corner regardless.
- **bf16/bf16 at D=4096**: 6 cells (T ∈ {4K..32K}) regress 10–13%. New regression band — master's bf16/bf16 kernel for this medium-N row was tuned more tightly than the new heuristic ladder lands on. This is the most likely first target if we extend the analytical heuristic.
- **bf16/fp32 at D=16384, T=2048**: 1 isolated cell at −15%.

fp32/bf16 has zero regressions across all 64 of its shapes; bf16/bf16 still posts the biggest single win at **+90.2%** (T=32K, D=12K).

### %SOL utilization before and after

The same 256-shape grid expressed as **% of GB200 HBM3e peak (8 TB/s per GPU)**, on a fixed 0–100 RdYlGn scale so the two plots are directly comparable cell-by-cell.

quack master:

<img width="1945" height="1759" alt="image" src="https://github.com/user-attachments/assets/6d220d1f-84ff-453a-8dd9-0fdd17b51a9c" />

| dtype combo | geomean %SOL | peak %SOL |
|---|---|---|
| bf16/bf16 | 33 | 62 |
| fp32/fp32 | 52 | 81 |
| bf16/fp32 | 41 | 74 |
| fp32/bf16 | 45 | 74 |

This MR:

<img width="1945" height="1759" alt="image" src="https://github.com/user-attachments/assets/166b975a-e077-40c5-8cdd-ed18a2924a50" />

| dtype combo | geomean %SOL | peak %SOL |
|---|---|---|
| bf16/bf16 | 42 | 82 |
| fp32/fp32 | 58 | 88 |
| bf16/fp32 | 49 | 83 |
| fp32/bf16 | 55 | 85 |

On master only fp32/fp32 ever crosses 80% SOL, and only in its top-right corner; the other three dtype combos cap at ~74% even at the largest shapes. This MR pushes every dtype combo above 80% SOL at its peak (82–88%) and widens the saturated band to most of D≥8K, T≥8K. The bottom rows (D≤2K) stay red on both plots — they remain latency-bound.

## TODOs for future MRs:

- Port TMA usage to the fwd kernel and see if it helps there?
- Port the `RMSNormConfig` to the fwd kernel too and use it consistently
- Implement `gemm_tuned()` like autotuning for the RMS norm kernels (and all other reduction like kernels too)
- See if the regressions at FP32→FP32 D=2048 and at the new BF16→BF16 D=4096 band are worth extending the default analytical launch configs for.
