### PR TITLE
[Bug] Tracer

### DIFF
--- a/quack/trace.py
+++ b/quack/trace.py
@@ -85,7 +85,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, Int64, const_expr
 from cutlass.base_dsl.arch import Arch
-from cutlass._mlir.dialects import nvvm
+from cutlass._mlir.dialects import llvm, nvvm
 from cutlass.cutlass_dsl import T
 
 from quack.copy_utils import store, store_v2
@@ -222,16 +222,42 @@ def _buf_total_bytes(total_slots: int, per_warp_cap: int) -> int:
 
 
 def _read_globaltimer():
-    return Int64(nvvm.read_ptx_sreg_globaltimer(T.i64()))
+    return Int64(
+        llvm.inline_asm(
+            T.i64(),
+            [],
+            "mov.u64 $0, %globaltimer;",
+            "=l",
+            has_side_effects=True,
+            is_align_stack=False,
+        )
+    )
 
 
 def _read_clock64():
-    return Int64(nvvm.read_ptx_sreg_clock64(T.i64()))
+    return Int64(
+        llvm.inline_asm(
+            T.i64(),
+            [],
+            "mov.u64 $0, %clock64;",
+            "=l",
+            has_side_effects=True,
+            is_align_stack=False,
+        )
+    )
 
 
 def _read_clock():
-    """Read %clock (32-bit, low half of clock64). Used in the hot path for delta encoding."""
-    return cutlass.Int32(nvvm.read_ptx_sreg_clock(T.i32()))
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [],
+            "mov.u32 $0, %clock;",
+            "=r",
+            has_side_effects=True,
+            is_align_stack=False,
+        )
+    )
 
 
 def _read_smid():

--- a/quack/trace.py
+++ b/quack/trace.py
@@ -215,10 +215,11 @@ def _buf_total_bytes(total_slots: int, per_warp_cap: int) -> int:
 # ---------------------------------------------------------------------------
 # Device-side helpers
 # ---------------------------------------------------------------------------
-# Special register reads use NVVM intrinsics.  Unpredicated stores use
-# cute.arch.store (which wraps nvvm.store_ext with nice pointer/Numeric
-# handling).  Predicated stores still need inline asm since the NVVM store
-# op doesn't support PTX predication.
+# Timer reads use side-effecting inline asm instead of nvvm.read_ptx_sreg_* so
+# MLIR CSE cannot merge adjacent reads and erase elapsed time.
+# Unpredicated stores use cute.arch.store (which wraps nvvm.store_ext with nice
+# pointer/Numeric handling).  Predicated stores still need inline asm since the
+# NVVM store op doesn't support PTX predication.
 
 
 def _read_globaltimer():


### PR DESCRIPTION
When I used the tracer i observed strange issue that the `examples/example_trace.py` recorded all events at 0 ns.
<img width="539" height="554" alt="Screenshot 2026-05-07 at 21 09 11" src="https://github.com/user-attachments/assets/49806861-01c2-414a-8d1f-b2b109e10e8d" />
<img width="198" height="349" alt="Screenshot 2026-05-07 at 21 12 09" src="https://github.com/user-attachments/assets/ff686d6f-8c83-48c4-8670-2fe55d21ae62" />
Using inline PTX instead of NVVM wrapper resolved the issue
<img width="1258" height="315" alt="Screenshot 2026-05-07 at 21 11 20" src="https://github.com/user-attachments/assets/19d69012-1864-4bbe-97df-033300919815" />
<img width="305" height="323" alt="Screenshot 2026-05-07 at 21 12 32" src="https://github.com/user-attachments/assets/0b5073b5-b11a-4081-8789-c6199b6e609c" />

Environment:
```
OS: Ubuntu 24.04.3 LTS, Linux 6.8.x, x86_64
CPU/RAM: AMD EPYC 9575F, 120 CPUs reported, 723 GiB RAM
GPU: 4x NVIDIA B200, compute capability 10.0, ~183 GiB VRAM each
Driver/CUDA: NVIDIA driver 590.48.01, CUDA 13.1, nvcc 13.1
Python: 3.12.3
QuACK / quack-kernels: 0.4.1
PyTorch: 2.11.0+cu130
Triton: 3.6.0
CUTLASS DSL: 4.4.2 / cu13 libs 4.5.0
```
Installed via 
```
uv pip install 'quack-kernels[dev,cu13]'
```