### PR TITLE
Add LayerNorm Backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install 'quack-kernels[heuristics]'
 - 🦆 RMSNorm forward + backward
 - 🦆 Softmax forward + backward
 - 🦆 Cross entropy forward + backward
-- 🦆 Layernorm forward
+- 🦆 Layernorm forward + backward
 - 🦆 Hopper gemm + epilogue
 - 🦆 Blackwell gemm + epilogue
 - 🦆 Blackwell GeForce gemm + epilogue

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -538,9 +538,11 @@ def rmsnorm_bwd_ref(x, w, dout, rstd, eps=1e-6):
 
 
 class RMSNormBackward(ReductionBase):
-    def __init__(self, dtype: cutlass.Numeric, N: int):
-        # 2 stages for double buffering when computing mean of x_hat * wdy
-        super().__init__(dtype, N, stage=2, reduction_dtype=Float32)
+    def __init__(self, dtype: cutlass.Numeric, N: int, is_layernorm: bool = False):
+        # LN bwd needs 2 row reductions (mean(wdy), mean(x_hat*wdy)) so
+        # 2 reduction slots per row, doubled for row pipelining => stage=4.
+        self.is_layernorm = is_layernorm
+        super().__init__(dtype, N, stage=4 if is_layernorm else 2, reduction_dtype=Float32)
         self.reload_wdy = None if N <= 16 * 1024 else "smem"
         if self.N > 128 * 1024 and self.dtype.width >= 32:
             # Not enough smem
@@ -584,6 +586,7 @@ class RMSNormBackward(ReductionBase):
         mdO: cute.Tensor,
         mdResO: Optional[cute.Tensor],
         mRstd: cute.Tensor,
+        mMean: Optional[cute.Tensor],
         mdX: cute.Tensor,
         mdW: Optional[cute.Tensor],
         mdRes: Optional[cute.Tensor],
@@ -592,6 +595,8 @@ class RMSNormBackward(ReductionBase):
         stream: cuda.CUstream,
     ):
         assert mX.element_type == self.dtype
+        if const_expr(self.is_layernorm):
+            assert mMean is not None
         self._set_cluster_n()
         largest_dtype_width = const_expr(
             max(*(t.element_type.width for t in [mX, mW, mdO, mdResO, mdX, mdRes] if t is not None))
@@ -605,7 +610,19 @@ class RMSNormBackward(ReductionBase):
         num_blocks = sm_count
         num_heads = mX.shape[1] if const_expr(cute.rank(mX) == 3) else 1
         self.kernel(
-            mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes, tiler_mn, tiled_copy, threads_per_row
+            mX,
+            mW,
+            mdO,
+            mdResO,
+            mRstd,
+            mMean,
+            mdX,
+            mdW,
+            mdB,
+            mdRes,
+            tiler_mn,
+            tiled_copy,
+            threads_per_row,
         ).launch(
             grid=[num_blocks, self.cluster_n, num_heads],
             block=[num_threads, 1, 1],
@@ -621,6 +638,7 @@ class RMSNormBackward(ReductionBase):
         mdO: cute.Tensor,
         mdResO: Optional[cute.Tensor],
         mRstd: cute.Tensor,
+        mMean: Optional[cute.Tensor],
         mdX: cute.Tensor,
         mdW: Optional[cute.Tensor],
         mdB: Optional[cute.Tensor],
@@ -642,6 +660,8 @@ class RMSNormBackward(ReductionBase):
                 for mT in (mX, mW, mdO, mdResO, mdX, mdW, mdB, mdRes)
             ]
             mRstd = mRstd[None, bidz]
+            if const_expr(mMean is not None):
+                mMean = mMean[None, bidz]
 
         shape = mX.shape
         M, N = shape[0], shape[1]
@@ -657,7 +677,7 @@ class RMSNormBackward(ReductionBase):
             smem, tv_layout, is_persistent=True
         )
         if const_expr(mbar_ptr is not None):
-            mbar_full_ptr, mbar_empty_ptr = mbar_ptr, mbar_ptr + 2
+            mbar_full_ptr, mbar_empty_ptr = mbar_ptr, mbar_ptr + self.stage
         else:
             mbar_full_ptr, mbar_empty_ptr = None, None
 
@@ -749,7 +769,10 @@ class RMSNormBackward(ReductionBase):
             tXrdW.fill(0.0)
         if const_expr(mdB is not None):
             tXrdB.fill(0.0)
-        stage = Int32(0)
+        # smem prefetch is always 2-stage; reduction stage advances by
+        # K_REDUCE per row (1 for RMS, 2 for LN).
+        red_stage = Int32(0)
+        smem_stage = Int32(0)
         producer_phase = Int32(1)
         consumer_phase = Int32(0)
         for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
@@ -757,49 +780,61 @@ class RMSNormBackward(ReductionBase):
             if row + gdim * tiler_mn[0] < M:  # Prefetch the next batch
                 copy(
                     tXgX[None, None, None, bidx + gdim],
-                    tXsX[None, None, None, stage ^ 1],
+                    tXsX[None, None, None, smem_stage ^ 1],
                     is_async=True,
                 )
                 copy(
                     tXgdO[None, None, None, bidx + gdim],
-                    tXsdO[None, None, None, stage ^ 1],
+                    tXsdO[None, None, None, smem_stage ^ 1],
                     is_async=True,
                 )
             else:
                 if const_expr(tiler_mn[0] > 1):
                     utils.fill_oob(
-                        tXsX[None, None, None, stage ^ 1], None, fill_value=mX.element_type.zero
+                        tXsX[None, None, None, smem_stage ^ 1],
+                        None,
+                        fill_value=mX.element_type.zero,
                     )
                     utils.fill_oob(
-                        tXsdO[None, None, None, stage ^ 1], None, fill_value=mdO.element_type.zero
+                        tXsdO[None, None, None, smem_stage ^ 1],
+                        None,
+                        fill_value=mdO.element_type.zero,
                     )
             cute.arch.cp_async_commit_group()
             rstd = cutlass.Float.zero
+            mean_v = cutlass.Float.zero
             if row < M or tiler_mn[0] == 1:
                 rstd = mRstd[row]
+                if const_expr(self.is_layernorm):
+                    mean_v = mMean[row]
             if const_expr(mdResO is not None):
                 if row < M or tiler_mn[0] == 1:
                     copy(tXgdResO[None, None, None, bidx], tXrdResO)
                 elif tiler_mn[0] > 1:
                     tXrdResO.fill(0.0)
             cute.arch.cp_async_wait_group(1)
-            cute.autovec_copy(tXsX[None, None, None, stage], tXrX)
+            cute.autovec_copy(tXsX[None, None, None, smem_stage], tXrX)
             x = tXrX.load().to(cute.Float32)
-            cute.autovec_copy(tXsdO[None, None, None, stage], tXrdO)
+            cute.autovec_copy(tXsdO[None, None, None, smem_stage], tXrdO)
             dout = tXrdO.load().to(cute.Float32)
-            x_hat = x * rstd
+            if const_expr(self.is_layernorm):
+                x_hat = (x - mean_v) * rstd
+            else:
+                x_hat = x * rstd
             wdy = dout
             if const_expr(mW is not None):
                 wdy *= tXrW.load().to(Float32)
+
+            stage_a = red_stage
             if const_expr(self.cluster_n > 1):
-                cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
+                cute.arch.mbarrier_wait(mbar_empty_ptr + stage_a, producer_phase)
             mean_xhat_wdy = (
                 row_reduce(
                     x_hat * wdy,
                     cute.ReductionOp.ADD,
                     threads_per_row,
-                    reduction_buffer[None, None, stage],
-                    (mbar_full_ptr + stage if const_expr(self.cluster_n > 1) else None),
+                    reduction_buffer[None, None, stage_a],
+                    (mbar_full_ptr + stage_a if const_expr(self.cluster_n > 1) else None),
                     phase=consumer_phase,
                     init_val=0.0,
                 )
@@ -807,25 +842,51 @@ class RMSNormBackward(ReductionBase):
             )
 
             if const_expr(self.cluster_n > 1):
-                # Need this fence since the STAS from the producer is using the async proxy.
                 cute.arch.fence_view_async_shared()
-                # It's faster to have 1 lane per warp to signal the mbar, rather than all lanes
-                # Requires adjusting the thread_count when initializing the mbar
                 cute.arch.sync_warp()
                 lane_idx = cute.arch.lane_idx()
                 if lane_idx < self.cluster_n:
                     cute.arch.mbarrier_arrive(
-                        mbar_empty_ptr + stage, peer_cta_rank_in_cluster=lane_idx
+                        mbar_empty_ptr + stage_a, peer_cta_rank_in_cluster=lane_idx
                     )
 
+            mean_wdy = cutlass.Float.zero
+            if const_expr(self.is_layernorm):
+                stage_b = red_stage + 1
+                if const_expr(self.cluster_n > 1):
+                    cute.arch.mbarrier_wait(mbar_empty_ptr + stage_b, producer_phase)
+                mean_wdy = (
+                    row_reduce(
+                        wdy,
+                        cute.ReductionOp.ADD,
+                        threads_per_row,
+                        reduction_buffer[None, None, stage_b],
+                        (mbar_full_ptr + stage_b if const_expr(self.cluster_n > 1) else None),
+                        phase=consumer_phase,
+                        init_val=0.0,
+                    )
+                    / shape[1]
+                )
+                if const_expr(self.cluster_n > 1):
+                    cute.arch.fence_view_async_shared()
+                    cute.arch.sync_warp()
+                    lane_idx = cute.arch.lane_idx()
+                    if lane_idx < self.cluster_n:
+                        cute.arch.mbarrier_arrive(
+                            mbar_empty_ptr + stage_b, peer_cta_rank_in_cluster=lane_idx
+                        )
+
             if const_expr(self.reload_wdy == "smem"):
-                cute.autovec_copy(tXsdO[None, None, None, stage], tXrdO)
+                cute.autovec_copy(tXsdO[None, None, None, smem_stage], tXrdO)
                 dout = tXrdO.load().to(cute.Float32)
                 wdy = dout
                 if const_expr(mW is not None):
                     wdy *= tXrW.load().to(Float32)
 
-            dx = (wdy - x_hat * mean_xhat_wdy) * rstd
+            if const_expr(self.is_layernorm):
+                dx = (wdy - mean_wdy - x_hat * mean_xhat_wdy) * rstd
+            else:
+                dx = (wdy - x_hat * mean_xhat_wdy) * rstd
             if const_expr(mdResO is not None):
                 dx += tXrdResO.load().to(cute.Float32)
             tXrdX.store(dx.to(tXrdX.element_type))
@@ -840,8 +901,12 @@ class RMSNormBackward(ReductionBase):
             if const_expr(mdB is not None):
                 tXrdB.store(tXrdB.load() + dout)
 
-            stage ^= 1
-            if stage == 0:
+            smem_stage ^= 1
+            if const_expr(self.is_layernorm):
+                red_stage = (red_stage + 2) & 3  # 0 -> 2 -> 0 -> 2
+            else:
+                red_stage ^= 1
+            if red_stage == 0:
                 consumer_phase ^= 1
                 producer_phase ^= 1
 
@@ -896,12 +961,17 @@ class RMSNormBackward(ReductionBase):
                 copy(tXrdB, tXgdB)
 
         if const_expr(self.cluster_n > 1):  # Prevent cluster from exiting early
-            # Assume state contains that next useful buffer
-            # So we only need to advance to num_stages - 1 times to last used buffer
-            stage ^= 1
-            if stage == 0:
-                producer_phase ^= 1
-            cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
+            if const_expr(self.is_layernorm):
+                red_stage = (red_stage + 2) & 3
+                if red_stage == 0:
+                    producer_phase ^= 1
+                cute.arch.mbarrier_wait(mbar_empty_ptr + red_stage, producer_phase)
+                cute.arch.mbarrier_wait(mbar_empty_ptr + red_stage + 1, producer_phase)
+            else:
+                red_stage ^= 1
+                if red_stage == 0:
+                    producer_phase ^= 1
+                cute.arch.mbarrier_wait(mbar_empty_ptr + red_stage, producer_phase)
 
 
 def _get_sm_count(N: int, device: torch.device) -> int:
@@ -988,7 +1058,7 @@ def _rmsnorm_bwd(
         dres_out_dtype,
         dw_partial is not None,
         per_head,
-    )(x, weight, dout, dresidual_out, rstd, dx, dw_partial, dresidual, db_partial, sm_count)
+    )(x, weight, dout, dresidual_out, rstd, None, dx, dw_partial, dresidual, db_partial, sm_count)
 
 
 @_rmsnorm_bwd.register_fake
@@ -1042,6 +1112,7 @@ def _compile_rmsnorm_bwd(
     dres_out_dtype,
     has_dw_partial,
     per_head=False,
+    is_layernorm=False,
 ):
     batch_sym, batch_partial_sym = cute.sym_int(), cute.sym_int()
     head_sym = cute.sym_int() if per_head else None
@@ -1055,16 +1126,18 @@ def _compile_rmsnorm_bwd(
     weight_shape = (head_sym, N) if per_head else (N,)
     weight_cute = fake_tensor(weight_dtype, weight_shape, div)
     rstd_cute = fake_tensor(Float32, batch_shape)
+    mean_cute = fake_tensor(Float32, batch_shape) if is_layernorm else None
     dw_shape = (batch_partial_sym, head_sym, N) if per_head else (batch_partial_sym, N)
     dw_partial_cute = fake_tensor(Float32, dw_shape, div) if has_dw_partial else None
     db_partial_cute = fake_tensor(Float32, dw_shape, div) if has_db_partial else None
     return cute.compile(
-        RMSNormBackward(dtype, N),
+        RMSNormBackward(dtype, N, is_layernorm=is_layernorm),
         x_cute,
         weight_cute,
         dout_cute,
         dres_out_cute,
         rstd_cute,
+        mean_cute,
         dx_cute,
         dw_partial_cute,
         dres_cute,
@@ -1121,6 +1194,100 @@ def rmsnorm_bwd(
     if has_residual and dresidual is None:
         dresidual = dx
     return dx, dw, db, dresidual
+
+
+@torch.library.custom_op(
+    "quack::_layernorm_bwd",
+    mutates_args={"dx", "dw_partial", "db_partial"},
+    device_types="cuda",
+    schema="(Tensor x, Tensor weight, Tensor dout, Tensor rstd, Tensor mean, "
+    "Tensor(a5!) dx, Tensor(a6!) dw_partial, Tensor(a7!) db_partial, "
+    "int? sm_count) -> ()",
+)
+def _layernorm_bwd(
+    x: Tensor,
+    weight: Tensor,
+    dout: Tensor,
+    rstd: Tensor,
+    mean: Tensor,
+    dx: Tensor,
+    dw_partial: Tensor,
+    db_partial: Tensor,
+    sm_count: Optional[int] = None,
+) -> None:
+    assert x.dim() in (2, 3), "Input must be 2D or 3D"
+    supported_types = {torch.float16, torch.bfloat16, torch.float32}
+    assert x.dtype in supported_types
+    assert weight.dtype == torch.float32
+    per_head = x.dim() == 3
+    N = x.size(-1)
+    if sm_count is None:
+        sm_count = dw_partial.shape[0]
+    dtype, dout_dtype, dx_dtype, weight_dtype = [
+        torch2cute_dtype_map[t.dtype] for t in [x, dout, dx, weight]
+    ]
+    _compile_rmsnorm_bwd(
+        N,
+        dtype,
+        dout_dtype,
+        dx_dtype,
+        weight_dtype,
+        True,
+        None,
+        None,
+        True,
+        per_head,
+        is_layernorm=True,
+    )(x, weight, dout, None, rstd, mean, dx, dw_partial, None, db_partial, sm_count)
+
+
+@_layernorm_bwd.register_fake
+def _layernorm_bwd_fake(x, weight, dout, rstd, mean, dx, dw_partial, db_partial, sm_count=None):
+    return None
+
+
+def layernorm_bwd(
+    x: Tensor,
+    weight: Tensor,
+    dout: Tensor,
+    rstd: Tensor,
+    mean: Tensor,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """LayerNorm backward.
+
+    Args:
+        x: Input tensor of shape (M, N) or (M, H, N).
+        weight: Weight of shape (N,) or (H, N). Must be float32.
+        dout: Upstream gradient of same shape as x.
+        rstd: Reciprocal stddev of shape (M,) or (M, H), float32.
+        mean: Mean of shape (M,) or (M, H), float32.
+
+    Returns:
+        (dx, dw, db): same shapes as x, weight, weight respectively;
+        dw and db are cast to weight.dtype.
+    """
+    assert weight.dtype == torch.float32, "Weight must be float32"
+    device = x.device
+    N = x.size(-1)
+    per_head = x.dim() == 3
+    sm_count = _get_sm_count(N, device)
+    if per_head:
+        H = x.size(1)
+        sm_count = max(round(sm_count / H), 1)
+        partial_shape = (sm_count, H, N)
+    else:
+        partial_shape = (sm_count, N)
+    dx = torch.empty_like(x)
+    dw_partial = torch.empty(partial_shape, device=device, dtype=torch.float32)
+    db_partial = torch.empty(partial_shape, device=device, dtype=torch.float32)
+    if x.numel() > 0:
+        _layernorm_bwd(x, weight, dout, rstd, mean, dx, dw_partial, db_partial, sm_count)
+        dw = dw_partial.sum(dim=0).to(weight.dtype)
+        db = db_partial.sum(dim=0).to(weight.dtype)
+    else:
+        dw = torch.zeros_like(weight)
+        db = torch.zeros_like(weight)
+    return dx, dw, db
 
 
 class RMSNormFunction(torch.autograd.Function):

--- a/tests/test_layernorm.py
+++ b/tests/test_layernorm.py
@@ -3,7 +3,13 @@
 import pytest
 import torch
 
-from quack.rmsnorm import layernorm_fwd, layernorm_ref, layernorm_rstd_ref, layernorm_mean_ref
+from quack.rmsnorm import (
+    layernorm_bwd,
+    layernorm_fwd,
+    layernorm_mean_ref,
+    layernorm_ref,
+    layernorm_rstd_ref,
+)
 
 
 @pytest.mark.parametrize("eps", [1e-5, 1e-6])
@@ -56,6 +62,66 @@ def test_layernorm_forward(M, N, input_dtype, eps):
     torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
     torch.testing.assert_close(rstd, rstd_ref_val, atol=6e-4, rtol=6e-4)
     torch.testing.assert_close(mean, mean_ref_val, atol=6e-4, rtol=6e-4)
+
+
+@pytest.mark.parametrize("eps", [1e-5, 1e-6])
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("M", [1, 37, 199])
+@pytest.mark.parametrize(
+    "N", [256, 512, 760, 1024, 1128, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144]
+)
+def test_layernorm_backward(M, N, input_dtype, eps):
+    """Test LayerNorm backward against torch autograd."""
+    device = "cuda"
+    # RMSNormBackward rejects N > 128k with >=32-bit dtype (smem limit).
+    if N > 128 * 1024 and input_dtype == torch.float32:
+        pytest.skip("RMSNormBackward: N > 128k unsupported for fp32")
+    major, _ = torch.cuda.get_device_capability()
+    if major == 12:
+        smem_n_limit = 131072 if input_dtype == torch.float32 else 262144
+        if N > smem_n_limit:
+            pytest.skip("SM12x: exceeds 99 KB SMEM")
+
+    if input_dtype == torch.bfloat16:
+        atol, rtol = 2e-2, 2e-2
+    elif input_dtype == torch.float16:
+        atol, rtol = 5e-3, 5e-3
+    else:
+        atol, rtol = 1e-4, 1e-4
+
+    torch.random.manual_seed(0)
+    x = torch.randn(M, N, device=device, dtype=input_dtype, requires_grad=True)
+    # F.layer_norm requires weight/bias dtype to match input; QuACK requires fp32 weight.
+    w_ref = torch.randn(N, device=device, dtype=input_dtype, requires_grad=True)
+    b_ref = torch.randn(N, device=device, dtype=input_dtype, requires_grad=True)
+    w_f32 = w_ref.detach().to(torch.float32).contiguous()
+
+    y_ref = torch.nn.functional.layer_norm(x, (N,), w_ref, b_ref, eps=eps)
+    dy = torch.randn_like(y_ref)
+    y_ref.backward(dy)
+    dx_ref = x.grad.detach()
+    dw_ref = w_ref.grad.detach()
+    db_ref = b_ref.grad.detach()
+
+    mean = x.detach().to(torch.float32).mean(dim=-1)
+    rstd = (x.detach().to(torch.float32).var(dim=-1, unbiased=False) + eps).rsqrt()
+
+    dx, dw, db = layernorm_bwd(x.detach(), w_f32, dy, rstd, mean)
+
+    assert dx.shape == x.shape and dx.dtype == input_dtype
+    assert dw.shape == (N,) and dw.dtype == torch.float32
+    assert db.shape == (N,) and db.dtype == torch.float32
+
+    torch.testing.assert_close(dx, dx_ref, atol=atol, rtol=rtol)
+    # dw/db accumulate across rows so absolute error scales with M; use relative.
+    rel_dw = (dw.float() - dw_ref.float()).abs().max().item() / max(
+        dw_ref.float().abs().mean().item(), 1e-6
+    )
+    rel_db = (db.float() - db_ref.float()).abs().max().item() / max(
+        db_ref.float().abs().mean().item(), 1e-6
+    )
+    assert rel_dw < 0.05, f"dw rel err {rel_dw}"
+    assert rel_db < 0.05, f"db rel err {rel_db}"
 
 
 @pytest.mark.parametrize("return_rstd", [True, False])


### PR DESCRIPTION
This PR adds LayerNorm backward to QuACK. Instead of forking a new kernel, I extended the existing `RMSNormBackward` with an `is_layernorm` flag, since the two ops share the same memory pattern and only differ in the math at the row-reduction step. RMSNorm bwd needs one row reduction (`mean(x_hat * wdy)`) and writes only `dW`.

LayerNorm needs a second one (`mean(wdy)`), uses `x_hat = (x - mean) * rstd` instead  of `x * rstd`, and additionally writes `db = sum_rows(wdy)`. The dx formula becomes `(wdy - mean(wdy) - x_hat * mean(x_hat * wdy)) * rstd`, and `db` reuses the same `(sm_count, N)` fp32 workspace + host-reduce pattern that `dw` already uses, so we still avoid atomics. To carry two row reductions per row through the cluster pipeline, the reduction buffer goes from `stage=2` to `stage=4` (two slots × double-buffered for row pipelining). The rmsnorm path passes `mMean=None` and keeps the original 2-stage layout, so existing rmsnorm tests are untouched.

### What's Added

- A public `layernorm_bwd(x, weight, dout, rstd, mean)` API that mirrors `rmsnorm_bwd`, returning `(dx, dw, db)`. It wraps a `torch.library.custom_op` (`quack::_layernorm_bwd`) and requires fp32 weight (same constraint as the rest of the bwd path).
- Changed `RMSNormBackward` to accept `is_layernorm`, take an optional `mMean` tensor, and switch on the LN dx formula and second row reduction when set.
- Separated the reduction-buffer stage from the smem prefetch stage in the kernel so the LN path can run with `stage=4` reductions and `stage=2` prefetch without OOB writes.
- Added backward tests in `tests/test_layernorm.py` next to the forward tests, with the same `(M, N, dtype, eps)` parametrization (`M ∈ {1, 37, 199}`, N up to 262144, bf16/fp16/fp32). They validate against `F.layer_norm` autograd and skip the `N > 128k && fp32` combo that `RMSNormBackward` already rejects on smem grounds.

### Benchmark (B200)

| M | N | dtype | quack ms | GB/s | torch ms | GB/s | speedup |
|-------|-------|----------|----------|------|----------|------|---------|
| 64 | 256 | bfloat16 | 0.0057 | 71 | 0.0792 | 1 | 13.87x |
| 64 | 256 | float16 | 0.0060 | 67 | 0.0807 | 1 | 13.49x |
| 64 | 256 | float32 | 0.0056 | 90 | 0.0779 | 3 | 13.99x |
| 128 | 1024 | bfloat16 | 0.0054 | 371 | 0.0789 | 10 | 14.59x |
| 128 | 1024 | float16 | 0.0059 | 341 | 0.0877 | 9 | 14.92x |
| 128 | 1024 | float32 | 0.0054 | 520 | 0.0790 | 20 | 14.72x |
| 1024 | 4096 | bfloat16 | 0.0101 | 2981 | 0.0843 | 299 | 8.37x |
| 1024 | 4096 | float16 | 0.0104 | 2880 | 0.0832 | 303 | 7.98x |
| 1024 | 4096 | float32 | 0.0125 | 4419 | 0.0867 | 581 | 6.94x |
| 4096 | 8192 | bfloat16 | 0.0533 | 3957 | 0.1058 | 1904 | 1.98x |
| 4096 | 8192 | float16 | 0.0544 | 3878 | 0.1059 | 1902 | 1.94x |
| 4096 | 8192 | float32 | 0.0783 | 5269 | 0.1552 | 2594 | 1.98x |
| 4096 | 16384 | bfloat16 | 0.1549 | 2725 | 0.2062 | 1953 | 1.33x |
| 4096 | 16384 | float16 | 0.1551 | 2722 | 0.2062 | 1954 | 1.33x |
| 4096 | 16384 | float32 | 0.1892 | 4360 | 0.3257 | 2473 | 1.72x |
| 8192 | 16384 | bfloat16 | 0.2992 | 2757 | 0.3927 | 2051 | 1.31x |
| 8192 | 16384 | float16 | 0.2988 | 2760 | 0.3917 | 2056 | 1.31x |
| 8192 | 16384 | float32 | 0.3648 | 4468 | 0.5986 | 2691 | 1.64x |
| 32768 | 4096 | bfloat16 | 0.2562 | 3163 | 0.4761 | 1692 | 1.86x |
| 32768 | 4096 | float16 | 0.2605 | 3111 | 0.4715 | 1708 | 1.81x |
| 32768 | 4096 | float32 | 0.3912 | 4130 | 0.6431 | 2505 | 1.64x |
| 32768 | 8192 | bfloat16 | 0.3741 | 4332 | 0.6942 | 2320 | 1.86x |
| 32768 | 8192 | float16 | 0.3820 | 4242 | 0.6917 | 2329 | 1.81x |
| 32768 | 8192 | float32 | 0.5600 | 5770 | 1.1174 | 2883 | 2.00x |

cc: @tridao @GarlGuo @JackCharlesZhang would appreciate your eyes on this when you get a chance