### PR TITLE
Fix exception chaining in CuTeDSL ELF patch

### DIFF
--- a/quack/cute_dsl_elf_fix.py
+++ b/quack/cute_dsl_elf_fix.py
@@ -74,7 +74,7 @@ def patch() -> None:
                 with open(file_path, "rb") as f:
                     object_file_content = f.read()
             except Exception as e:
-                raise DSLRuntimeError(f"Failed to read object file {file_path}: {e}")
+                raise DSLRuntimeError(f"Failed to read object file {file_path}: {e}") from e
 
         useJitLink = not enable_tvm_ffi
         if not useJitLink and object_file_content:


### PR DESCRIPTION
## Summary
- Chain the caught exception when wrapping object-file read failures in DSLRuntimeError
- Keeps the original OS error available to debuggers and satisfies Ruff B904

## Test
- ruff check --select B904 quack/cute_dsl_elf_fix.py