### PR TITLE
[RMSNorm] Support autotuning of RMSNorm{Fwd|Bwd} via config classes

### DIFF
--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -81,24 +81,30 @@ def _l2_cold_cuda_graph_bench(
     arg_sets,
     kwarg_sets,
     extra_kwargs,
-    n_warmup_calls: int = 50,
+    warmup_target_ms: float = 200.0,
     n_timed_calls: int = 200,
     quantiles=None,
 ):
     """L2-cold single-replay CUDA-graph benchmark.
 
-    Warmup runs ``n_warmup_calls`` kernel invocations round-robin over the
-    pre-cloned ``(arg_sets[i], kwarg_sets[i])`` pairs as a plain Python loop
-    (drains P-state transitions and warms the launch path / kernel compile /
-    smem alloc). The timed window is a single ``graph.replay()`` of a
-    captured CUDA graph whose body records ``n_timed_calls`` round-robin
-    invocations — no Python loop, no per-launch CPU overhead — so the
-    measurement is just GPU work / total recorded calls.
+    Warmup is time-based: probe a single kernel launch to estimate the
+    per-call cost, then iterate round-robin over the pre-cloned
+    ``(arg_sets[i], kwarg_sets[i])`` pairs as a plain Python loop for
+    ``warmup_target_ms`` of wall-clock GPU work. Heavy pipelined configs
+    (TMA + smem_stages=3) need enough warmup to drain the pipeline-fill
+    phase or the timed window catches them artificially fast - a fixed
+    count of warmup launches underwarms heavy configs while overpaying
+    for cheap ones.
 
-    Round-robin over fresh tensor sets defeats the L2-resident caching that
-    inflates short-kernel timing under ``triton.testing.do_bench`` (which
-    calls the kernel on the same single tensor each iteration). For
-    cache-cold production workloads the round-robin number predicts
+    The timed window is a single ``graph.replay()`` of a captured CUDA
+    graph whose body records ``n_timed_calls`` round-robin invocations -
+    no Python loop, no per-launch CPU overhead - so the measurement is
+    just GPU work / total recorded calls.
+
+    Round-robin over fresh tensor sets defeats the L2-resident caching
+    that inflates short-kernel timing under ``triton.testing.do_bench``
+    (which calls the kernel on the same single tensor each iteration).
+    For cache-cold production workloads the round-robin number predicts
     real-world latency; the L2-hot number favours wider layouts / deeper
     smem stages that don't actually win once data has to come from HBM.
 
@@ -114,6 +120,23 @@ def _l2_cold_cuda_graph_bench(
     # Round timed-call count to a multiple of n_sets for even L2 turnover.
     rounds_timed = max(1, n_timed_calls // n_sets)
     total_timed_calls = rounds_timed * n_sets
+
+    # A few priming launches so the probe doesn't catch first-launch
+    # driver / kernel-load overhead.
+    for _ in range(3):
+        fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs)
+    torch.cuda.synchronize()
+
+    # Probe a single launch to estimate per-call ms; size the warmup loop
+    # to hit ``warmup_target_ms`` of GPU work regardless of kernel cost.
+    probe_start = torch.cuda.Event(enable_timing=True)
+    probe_end = torch.cuda.Event(enable_timing=True)
+    probe_start.record()
+    fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs)
+    probe_end.record()
+    torch.cuda.synchronize()
+    est_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
+    n_warmup_calls = max(50, int(warmup_target_ms / est_ms))
 
     # Warmup: plain Python loop over rotating sets, no graph capture.
     for i in range(n_warmup_calls):

--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -13,6 +13,11 @@ import json
 from pathlib import Path
 from functools import cached_property, partial
 from typing import Dict, Tuple, List, Optional, Any
+from quack.bench.bench_utils import (
+    _bench_cuda_graph_l2_rotate,
+    _clone_l2_rotate_inputs,
+    _pick_l2_rotate_count,
+)
 
 import torch
 from torch import Tensor
@@ -74,146 +79,6 @@ class FileCacheManager(triton.runtime.cache.FileCacheManager):
 def _base32(key):
     # Assume key is a hex string.
     return base64.b32encode(bytes.fromhex(key)).decode("utf-8").rstrip("=")
-
-
-def _l2_cold_cuda_graph_bench(
-    fn,
-    arg_sets,
-    kwarg_sets,
-    extra_kwargs,
-    warmup_target_ms: float = 200.0,
-    n_timed_calls: int = 200,
-    quantiles=None,
-):
-    """L2-cold single-replay CUDA-graph benchmark.
-
-    Warmup is time-based: probe a single kernel launch to estimate the
-    per-call cost, then iterate round-robin over the pre-cloned
-    ``(arg_sets[i], kwarg_sets[i])`` pairs as a plain Python loop for
-    ``warmup_target_ms`` of wall-clock GPU work. Heavy pipelined configs
-    (TMA + smem_stages=3) need enough warmup to drain the pipeline-fill
-    phase or the timed window catches them artificially fast - a fixed
-    count of warmup launches underwarms heavy configs while overpaying
-    for cheap ones.
-
-    The timed window is a single ``graph.replay()`` of a captured CUDA
-    graph whose body records ``n_timed_calls`` round-robin invocations -
-    no Python loop, no per-launch CPU overhead - so the measurement is
-    just GPU work / total recorded calls.
-
-    Round-robin over fresh tensor sets defeats the L2-resident caching
-    that inflates short-kernel timing under ``triton.testing.do_bench``
-    (which calls the kernel on the same single tensor each iteration).
-    For cache-cold production workloads the round-robin number predicts
-    real-world latency; the L2-hot number favours wider layouts / deeper
-    smem stages that don't actually win once data has to come from HBM.
-
-    ``fn`` is called as ``fn(*arg_sets[i], **kwarg_sets[i], **extra_kwargs)``
-    once per recorded launch. ``extra_kwargs`` holds the per-config kwargs
-    (e.g. ``{"config": <RmsNormBwdConfig>}``) which don't need cloning;
-    keys in ``extra_kwargs`` must not overlap with ``kwarg_sets[i]``.
-    Returns ms/call, or a ``len(quantiles)``-list replicating that value
-    when ``quantiles`` is provided (for API parity with
-    ``triton.testing.do_bench``).
-    """
-    n_sets = len(arg_sets)
-    # Round timed-call count to a multiple of n_sets for even L2 turnover.
-    rounds_timed = max(1, n_timed_calls // n_sets)
-    total_timed_calls = rounds_timed * n_sets
-
-    # A few priming launches so the probe doesn't catch first-launch
-    # driver / kernel-load overhead.
-    for _ in range(3):
-        fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs)
-    torch.cuda.synchronize()
-
-    # Probe a single launch to estimate per-call ms; size the warmup loop
-    # to hit ``warmup_target_ms`` of GPU work regardless of kernel cost.
-    probe_start = torch.cuda.Event(enable_timing=True)
-    probe_end = torch.cuda.Event(enable_timing=True)
-    probe_start.record()
-    fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs)
-    probe_end.record()
-    torch.cuda.synchronize()
-    est_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
-    n_warmup_calls = max(50, int(warmup_target_ms / est_ms))
-
-    # Warmup: plain Python loop over rotating sets, no graph capture.
-    for i in range(n_warmup_calls):
-        idx = i % n_sets
-        fn(*arg_sets[idx], **kwarg_sets[idx], **extra_kwargs)
-    torch.cuda.synchronize()
-
-    # Capture timed graph: a single replay covers all timed kernel launches.
-    timed_graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(timed_graph):
-        for _ in range(rounds_timed):
-            for i in range(n_sets):
-                fn(*arg_sets[i], **kwarg_sets[i], **extra_kwargs)
-    torch.cuda.synchronize()
-
-    start_evt = torch.cuda.Event(enable_timing=True)
-    end_evt = torch.cuda.Event(enable_timing=True)
-    start_evt.record()
-    timed_graph.replay()
-    end_evt.record()
-    torch.cuda.synchronize()
-    ms = start_evt.elapsed_time(end_evt) / total_timed_calls
-
-    if quantiles:
-        return [ms for _ in quantiles]
-    return ms
-
-
-def _build_l2_cold_tensor_sets(args, kwargs, n_graphs: int):
-    """Clone tensor args AND tensor kwargs ``n_graphs`` times.
-
-    Returns ``(arg_sets, kwarg_sets)``: ``arg_sets[i]`` is a tuple matching
-    ``args``' positional shape with tensors cloned to fresh memory;
-    ``kwarg_sets[i]`` is a dict matching ``kwargs``' keys with tensor values
-    cloned. Non-tensor values (ints, strings, None, dataclasses, etc.) are
-    shared across all sets (no clone).
-
-    Both args and kwargs are cloned so that every recorded launch in the
-    L2-cold round-robin CUDA graph touches distinct GMEM addresses,
-    including for write-target kwargs like ``dw_partial`` / ``dx``.
-    """
-    arg_sets = []
-    kwarg_sets = []
-    for _ in range(n_graphs):
-        arg_sets.append(tuple(a.clone() if isinstance(a, Tensor) else a for a in args))
-        kwarg_sets.append({
-            k: v.clone() if isinstance(v, Tensor) else v for k, v in kwargs.items()
-        })
-    return arg_sets, kwarg_sets
-
-
-def _pick_n_graphs_for_l2_cold(
-    args, kwargs, target_ratio: int = 3, min_graphs: int = 4, max_graphs: int = 16
-):
-    """Pick ``n_graphs`` so cloned input bytes per round exceed
-    ``target_ratio * L2_size`` (defeats L2 reuse), capped by HBM headroom and
-    [min_graphs, max_graphs]. Counts tensor bytes across both ``args`` and
-    ``kwargs`` so write-target kwargs (``dw_partial``, ``dx``, etc.) are
-    included in the L2-turnover calculation.
-    """
-    if not torch.cuda.is_available():
-        return min_graphs
-    tensor_bytes = sum(
-        a.numel() * a.element_size() for a in args if isinstance(a, Tensor)
-    ) + sum(
-        v.numel() * v.element_size() for v in kwargs.values() if isinstance(v, Tensor)
-    )
-    if tensor_bytes == 0:
-        return min_graphs
-    props = torch.cuda.get_device_properties(torch.cuda.current_device())
-    l2_size = props.L2_cache_size
-    n_by_l2 = (target_ratio * l2_size + tensor_bytes - 1) // tensor_bytes
-    free_bytes, _ = torch.cuda.mem_get_info()
-    # Leave half of free memory headroom for the kernel's own scratch + the
-    # user's other allocations.
-    n_by_mem = max(1, int(free_bytes * 0.5) // tensor_bytes)
-    return max(min_graphs, min(max_graphs, min(n_by_l2, n_by_mem)))
 
 
 def _gpu_warmup(duration_ms=200):
@@ -466,7 +331,7 @@ class Autotuner:
 
         if use_l2_cold:
             try:
-                return _l2_cold_cuda_graph_bench(
+                return _bench_cuda_graph_l2_rotate(
                     self.fn,
                     l2_cold_arg_sets,
                     l2_cold_kwarg_sets,
@@ -581,10 +446,8 @@ class Autotuner:
                     has_hooks = self.pre_hook is not None or self.post_hook is not None
                     if self._do_bench is None and not has_hooks:
                         try:
-                            n_graphs = _pick_n_graphs_for_l2_cold(args, kwargs)
-                            arg_sets, kwarg_sets = _build_l2_cold_tensor_sets(
-                                args, kwargs, n_graphs
-                            )
+                            n_buffers = _pick_l2_rotate_count(args, kwargs)
+                            arg_sets, kwarg_sets = _clone_l2_rotate_inputs(args, kwargs, n_buffers)
                             self._l2_cold_arg_sets = arg_sets
                             self._l2_cold_kwarg_sets = kwarg_sets
                         except (RuntimeError, MemoryError):
@@ -607,9 +470,7 @@ class Autotuner:
                         self._l2_cold_arg_sets = None
                         self._l2_cold_kwarg_sets = None
                     bench_end = time.time()
-                    verbose = (
-                        os.getenv(f"{PACKAGE_NAME.upper()}_PRINT_AUTOTUNING", None) == "1"
-                    )
+                    verbose = os.getenv(f"{PACKAGE_NAME.upper()}_PRINT_AUTOTUNING", None) == "1"
                     if verbose:
                         for config, time_ in timings.items():
                             print(f"[{config}] -> {time_[0]:.3f}ms")

--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -75,6 +75,101 @@ def _base32(key):
     return base64.b32encode(bytes.fromhex(key)).decode("utf-8").rstrip("=")
 
 
+def _l2_cold_cuda_graph_bench(
+    fn,
+    tensor_sets,
+    current_kwargs,
+    n_warmup_calls: int = 50,
+    n_timed_calls: int = 200,
+    quantiles=None,
+):
+    """L2-cold single-replay CUDA-graph benchmark.
+
+    Warmup runs ``n_warmup_calls`` kernel invocations round-robin over the
+    pre-cloned ``tensor_sets`` as a plain Python loop (drains P-state
+    transitions and warms the launch path / kernel compile / smem alloc).
+    The timed window is a single ``graph.replay()`` of a captured CUDA graph
+    whose body records ``n_timed_calls`` round-robin invocations — no Python
+    loop, no per-launch CPU overhead — so the measurement is just GPU work /
+    total recorded calls.
+
+    Round-robin over fresh tensor sets defeats the L2-resident caching that
+    inflates short-kernel timing under ``triton.testing.do_bench`` (which
+    calls the kernel on the same single tensor each iteration). For
+    cache-cold production workloads the round-robin number predicts
+    real-world latency; the L2-hot number favours wider layouts / deeper
+    smem stages that don't actually win once data has to come from HBM.
+
+    ``fn`` is called as ``fn(*ts, **current_kwargs)`` once per recorded call.
+    Returns ms/call, or a ``len(quantiles)``-list replicating that value
+    when ``quantiles`` is provided (for API parity with
+    ``triton.testing.do_bench``).
+    """
+    n_sets = len(tensor_sets)
+    # Round timed-call count to a multiple of n_sets for even L2 turnover.
+    rounds_timed = max(1, n_timed_calls // n_sets)
+    total_timed_calls = rounds_timed * n_sets
+
+    # Warmup: plain Python loop over rotating sets, no graph capture.
+    for i in range(n_warmup_calls):
+        fn(*tensor_sets[i % n_sets], **current_kwargs)
+    torch.cuda.synchronize()
+
+    # Capture timed graph: a single replay covers all timed kernel launches.
+    timed_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(timed_graph):
+        for _ in range(rounds_timed):
+            for ts in tensor_sets:
+                fn(*ts, **current_kwargs)
+    torch.cuda.synchronize()
+
+    start_evt = torch.cuda.Event(enable_timing=True)
+    end_evt = torch.cuda.Event(enable_timing=True)
+    start_evt.record()
+    timed_graph.replay()
+    end_evt.record()
+    torch.cuda.synchronize()
+    ms = start_evt.elapsed_time(end_evt) / total_timed_calls
+
+    if quantiles:
+        return [ms for _ in quantiles]
+    return ms
+
+
+def _build_l2_cold_tensor_sets(args, n_graphs: int):
+    """Clone tensor args ``n_graphs`` times; pass through non-tensor args.
+
+    Returns a list of ``n_graphs`` arg-tuples sharing layout/dtype/contents
+    with ``args`` but at distinct memory addresses.
+    """
+    sets = []
+    for _ in range(n_graphs):
+        sets.append(tuple(a.clone() if isinstance(a, Tensor) else a for a in args))
+    return sets
+
+
+def _pick_n_graphs_for_l2_cold(args, target_ratio: int = 3, min_graphs: int = 4, max_graphs: int = 16):
+    """Pick ``n_graphs`` so cloned input bytes per round exceed
+    ``target_ratio * L2_size`` (defeats L2 reuse), capped by HBM headroom and
+    [min_graphs, max_graphs].
+    """
+    if not torch.cuda.is_available():
+        return min_graphs
+    tensor_bytes = sum(
+        a.numel() * a.element_size() for a in args if isinstance(a, Tensor)
+    )
+    if tensor_bytes == 0:
+        return min_graphs
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    l2_size = props.L2_cache_size
+    n_by_l2 = (target_ratio * l2_size + tensor_bytes - 1) // tensor_bytes
+    free_bytes, _ = torch.cuda.mem_get_info()
+    # Leave half of free memory headroom for the kernel's own scratch + the
+    # user's other allocations.
+    n_by_mem = max(1, int(free_bytes * 0.5) // tensor_bytes)
+    return max(min_graphs, min(max_graphs, min(n_by_l2, n_by_mem)))
+
+
 def _gpu_warmup(duration_ms=200):
     """Saturate the GPU to reach thermal steady-state before benchmarking.
 
@@ -306,6 +401,35 @@ class Autotuner:
         current = dict(meta, **config.all_kwargs())
         full_nargs = {**self.nargs, **current}
 
+        # Default path: L2-cold CUDA-graph round-robin bench. ``__call__``
+        # sets ``self._l2_cold_tensor_sets`` to a list of cloned input-arg
+        # tuples once per shape (reused across all configs). Triton's default
+        # do_bench is L2-hot and systematically picks configs that win at
+        # cache-resident workloads but lose under production cache-cold
+        # patterns. The L2-cold bench fixes that.
+        l2_cold_sets = getattr(self, "_l2_cold_tensor_sets", None)
+        has_hooks = self.pre_hook is not None or self.post_hook is not None
+        use_l2_cold = (
+            self._do_bench is None and l2_cold_sets is not None and not has_hooks
+        )
+
+        if use_l2_cold:
+            try:
+                return _l2_cold_cuda_graph_bench(
+                    self.fn,
+                    l2_cold_sets,
+                    current_kwargs=current,
+                    quantiles=(0.5, 0.2, 0.8),
+                )
+            except Exception as e:
+                if verbose:
+                    print(f"Autotuning failed with {e}")
+                return [float("inf"), float("inf"), float("inf")]
+
+        # Legacy path: triton.testing.do_bench or user-supplied do_bench.
+        # Used when (a) a custom do_bench was passed via the decorator's
+        # ``do_bench=`` arg, or (b) pre/post hooks are configured (the
+        # clone/restore inside hooks doesn't work under CUDA graph capture).
         def kernel_call():
             if self.pre_hook is not None:
                 self.pre_hook(full_nargs)
@@ -394,11 +518,32 @@ class Autotuner:
                 def benchmark():
                     self._precompile(*args, configs=pruned_configs, **kwargs)
                     _gpu_warmup()
+                    # Pre-allocate cloned input sets for L2-cold CUDA-graph
+                    # bench. One allocation reused across all configs for this
+                    # shape (~400 configs / shape would otherwise re-clone for
+                    # each). Skipped when hooks are present or a custom
+                    # do_bench was supplied (see _bench fall-back).
+                    has_hooks = self.pre_hook is not None or self.post_hook is not None
+                    if self._do_bench is None and not has_hooks:
+                        try:
+                            n_graphs = _pick_n_graphs_for_l2_cold(args)
+                            self._l2_cold_tensor_sets = _build_l2_cold_tensor_sets(args, n_graphs)
+                        except (RuntimeError, torch.cuda.OutOfMemoryError):
+                            # Cloning failed (likely OOM at extreme N); the
+                            # legacy do_bench path will be used instead.
+                            self._l2_cold_tensor_sets = None
+                    else:
+                        self._l2_cold_tensor_sets = None
                     bench_start = time.time()
-                    timings = {
-                        config: self._bench(*args, config=config, **kwargs)
-                        for config in pruned_configs
-                    }
+                    try:
+                        timings = {
+                            config: self._bench(*args, config=config, **kwargs)
+                            for config in pruned_configs
+                        }
+                    finally:
+                        # Free the cloned sets before persisting the cache so
+                        # the user's subsequent .fn(...) call has full HBM.
+                        self._l2_cold_tensor_sets = None
                     bench_end = time.time()
                     if os.getenv(f"{PACKAGE_NAME.upper()}_PRINT_AUTOTUNING", None) == "1":
                         for config, time_ in timings.items():

--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import os
+import sys
 import time
 import inspect
 import base64
@@ -77,8 +78,9 @@ def _base32(key):
 
 def _l2_cold_cuda_graph_bench(
     fn,
-    tensor_sets,
-    current_kwargs,
+    arg_sets,
+    kwarg_sets,
+    extra_kwargs,
     n_warmup_calls: int = 50,
     n_timed_calls: int = 200,
     quantiles=None,
@@ -86,12 +88,12 @@ def _l2_cold_cuda_graph_bench(
     """L2-cold single-replay CUDA-graph benchmark.
 
     Warmup runs ``n_warmup_calls`` kernel invocations round-robin over the
-    pre-cloned ``tensor_sets`` as a plain Python loop (drains P-state
-    transitions and warms the launch path / kernel compile / smem alloc).
-    The timed window is a single ``graph.replay()`` of a captured CUDA graph
-    whose body records ``n_timed_calls`` round-robin invocations — no Python
-    loop, no per-launch CPU overhead — so the measurement is just GPU work /
-    total recorded calls.
+    pre-cloned ``(arg_sets[i], kwarg_sets[i])`` pairs as a plain Python loop
+    (drains P-state transitions and warms the launch path / kernel compile /
+    smem alloc). The timed window is a single ``graph.replay()`` of a
+    captured CUDA graph whose body records ``n_timed_calls`` round-robin
+    invocations — no Python loop, no per-launch CPU overhead — so the
+    measurement is just GPU work / total recorded calls.
 
     Round-robin over fresh tensor sets defeats the L2-resident caching that
     inflates short-kernel timing under ``triton.testing.do_bench`` (which
@@ -100,27 +102,31 @@ def _l2_cold_cuda_graph_bench(
     real-world latency; the L2-hot number favours wider layouts / deeper
     smem stages that don't actually win once data has to come from HBM.
 
-    ``fn`` is called as ``fn(*ts, **current_kwargs)`` once per recorded call.
+    ``fn`` is called as ``fn(*arg_sets[i], **kwarg_sets[i], **extra_kwargs)``
+    once per recorded launch. ``extra_kwargs`` holds the per-config kwargs
+    (e.g. ``{"config": <RmsNormBwdConfig>}``) which don't need cloning;
+    keys in ``extra_kwargs`` must not overlap with ``kwarg_sets[i]``.
     Returns ms/call, or a ``len(quantiles)``-list replicating that value
     when ``quantiles`` is provided (for API parity with
     ``triton.testing.do_bench``).
     """
-    n_sets = len(tensor_sets)
+    n_sets = len(arg_sets)
     # Round timed-call count to a multiple of n_sets for even L2 turnover.
     rounds_timed = max(1, n_timed_calls // n_sets)
     total_timed_calls = rounds_timed * n_sets
 
     # Warmup: plain Python loop over rotating sets, no graph capture.
     for i in range(n_warmup_calls):
-        fn(*tensor_sets[i % n_sets], **current_kwargs)
+        idx = i % n_sets
+        fn(*arg_sets[idx], **kwarg_sets[idx], **extra_kwargs)
     torch.cuda.synchronize()
 
     # Capture timed graph: a single replay covers all timed kernel launches.
     timed_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(timed_graph):
         for _ in range(rounds_timed):
-            for ts in tensor_sets:
-                fn(*ts, **current_kwargs)
+            for i in range(n_sets):
+                fn(*arg_sets[i], **kwarg_sets[i], **extra_kwargs)
     torch.cuda.synchronize()
 
     start_evt = torch.cuda.Event(enable_timing=True)
@@ -136,27 +142,44 @@ def _l2_cold_cuda_graph_bench(
     return ms
 
 
-def _build_l2_cold_tensor_sets(args, n_graphs: int):
-    """Clone tensor args ``n_graphs`` times; pass through non-tensor args.
+def _build_l2_cold_tensor_sets(args, kwargs, n_graphs: int):
+    """Clone tensor args AND tensor kwargs ``n_graphs`` times.
 
-    Returns a list of ``n_graphs`` arg-tuples sharing layout/dtype/contents
-    with ``args`` but at distinct memory addresses.
+    Returns ``(arg_sets, kwarg_sets)``: ``arg_sets[i]`` is a tuple matching
+    ``args``' positional shape with tensors cloned to fresh memory;
+    ``kwarg_sets[i]`` is a dict matching ``kwargs``' keys with tensor values
+    cloned. Non-tensor values (ints, strings, None, dataclasses, etc.) are
+    shared across all sets (no clone).
+
+    Both args and kwargs are cloned so that every recorded launch in the
+    L2-cold round-robin CUDA graph touches distinct GMEM addresses,
+    including for write-target kwargs like ``dw_partial`` / ``dx``.
     """
-    sets = []
+    arg_sets = []
+    kwarg_sets = []
     for _ in range(n_graphs):
-        sets.append(tuple(a.clone() if isinstance(a, Tensor) else a for a in args))
-    return sets
+        arg_sets.append(tuple(a.clone() if isinstance(a, Tensor) else a for a in args))
+        kwarg_sets.append({
+            k: v.clone() if isinstance(v, Tensor) else v for k, v in kwargs.items()
+        })
+    return arg_sets, kwarg_sets
 
 
-def _pick_n_graphs_for_l2_cold(args, target_ratio: int = 3, min_graphs: int = 4, max_graphs: int = 16):
+def _pick_n_graphs_for_l2_cold(
+    args, kwargs, target_ratio: int = 3, min_graphs: int = 4, max_graphs: int = 16
+):
     """Pick ``n_graphs`` so cloned input bytes per round exceed
     ``target_ratio * L2_size`` (defeats L2 reuse), capped by HBM headroom and
-    [min_graphs, max_graphs].
+    [min_graphs, max_graphs]. Counts tensor bytes across both ``args`` and
+    ``kwargs`` so write-target kwargs (``dw_partial``, ``dx``, etc.) are
+    included in the L2-turnover calculation.
     """
     if not torch.cuda.is_available():
         return min_graphs
     tensor_bytes = sum(
         a.numel() * a.element_size() for a in args if isinstance(a, Tensor)
+    ) + sum(
+        v.numel() * v.element_size() for v in kwargs.values() if isinstance(v, Tensor)
     )
     if tensor_bytes == 0:
         return min_graphs
@@ -402,28 +425,38 @@ class Autotuner:
         full_nargs = {**self.nargs, **current}
 
         # Default path: L2-cold CUDA-graph round-robin bench. ``__call__``
-        # sets ``self._l2_cold_tensor_sets`` to a list of cloned input-arg
-        # tuples once per shape (reused across all configs). Triton's default
-        # do_bench is L2-hot and systematically picks configs that win at
-        # cache-resident workloads but lose under production cache-cold
-        # patterns. The L2-cold bench fixes that.
-        l2_cold_sets = getattr(self, "_l2_cold_tensor_sets", None)
+        # sets ``self._l2_cold_arg_sets`` / ``self._l2_cold_kwarg_sets`` to
+        # pre-cloned (args, kwargs) sets once per shape (reused across all
+        # configs). Round-robin over fresh sets keeps the kernel measured
+        # under the cache-cold conditions that match production access
+        # patterns, so the autotuner picks configs that win at the same
+        # workload the user actually runs.
+        l2_cold_arg_sets = getattr(self, "_l2_cold_arg_sets", None)
+        l2_cold_kwarg_sets = getattr(self, "_l2_cold_kwarg_sets", None)
         has_hooks = self.pre_hook is not None or self.post_hook is not None
         use_l2_cold = (
-            self._do_bench is None and l2_cold_sets is not None and not has_hooks
+            self._do_bench is None
+            and l2_cold_arg_sets is not None
+            and l2_cold_kwarg_sets is not None
+            and not has_hooks
         )
 
         if use_l2_cold:
             try:
                 return _l2_cold_cuda_graph_bench(
                     self.fn,
-                    l2_cold_sets,
-                    current_kwargs=current,
+                    l2_cold_arg_sets,
+                    l2_cold_kwarg_sets,
+                    extra_kwargs=config.all_kwargs(),
                     quantiles=(0.5, 0.2, 0.8),
                 )
-            except Exception as e:
+            except (RuntimeError, MemoryError) as e:
+                # Narrow catch: only swallow GPU-side failures (smem
+                # overflow, kernel launch errors, OOM). Programming errors
+                # (TypeError, AssertionError, ValueError from conflict check
+                # above) propagate so the user sees them.
                 if verbose:
-                    print(f"Autotuning failed with {e}")
+                    print(f"Autotuning failed with {type(e).__name__}: {e}")
                 return [float("inf"), float("inf"), float("inf")]
 
         # Legacy path: triton.testing.do_bench or user-supplied do_bench.
@@ -518,22 +551,27 @@ class Autotuner:
                 def benchmark():
                     self._precompile(*args, configs=pruned_configs, **kwargs)
                     _gpu_warmup()
-                    # Pre-allocate cloned input sets for L2-cold CUDA-graph
-                    # bench. One allocation reused across all configs for this
-                    # shape (~400 configs / shape would otherwise re-clone for
-                    # each). Skipped when hooks are present or a custom
-                    # do_bench was supplied (see _bench fall-back).
+                    # Pre-allocate cloned (args, kwargs) sets once per shape;
+                    # the same sets are reused across all configs to avoid
+                    # ~400x re-cloning. Skipped when hooks are present or a
+                    # custom do_bench was supplied (legacy fallback in _bench).
                     has_hooks = self.pre_hook is not None or self.post_hook is not None
                     if self._do_bench is None and not has_hooks:
                         try:
-                            n_graphs = _pick_n_graphs_for_l2_cold(args)
-                            self._l2_cold_tensor_sets = _build_l2_cold_tensor_sets(args, n_graphs)
-                        except (RuntimeError, torch.cuda.OutOfMemoryError):
-                            # Cloning failed (likely OOM at extreme N); the
-                            # legacy do_bench path will be used instead.
-                            self._l2_cold_tensor_sets = None
+                            n_graphs = _pick_n_graphs_for_l2_cold(args, kwargs)
+                            arg_sets, kwarg_sets = _build_l2_cold_tensor_sets(
+                                args, kwargs, n_graphs
+                            )
+                            self._l2_cold_arg_sets = arg_sets
+                            self._l2_cold_kwarg_sets = kwarg_sets
+                        except (RuntimeError, MemoryError):
+                            # Cloning failed (likely OOM at extreme N); legacy
+                            # do_bench path will be used by _bench.
+                            self._l2_cold_arg_sets = None
+                            self._l2_cold_kwarg_sets = None
                     else:
-                        self._l2_cold_tensor_sets = None
+                        self._l2_cold_arg_sets = None
+                        self._l2_cold_kwarg_sets = None
                     bench_start = time.time()
                     try:
                         timings = {
@@ -543,11 +581,25 @@ class Autotuner:
                     finally:
                         # Free the cloned sets before persisting the cache so
                         # the user's subsequent .fn(...) call has full HBM.
-                        self._l2_cold_tensor_sets = None
+                        self._l2_cold_arg_sets = None
+                        self._l2_cold_kwarg_sets = None
                     bench_end = time.time()
-                    if os.getenv(f"{PACKAGE_NAME.upper()}_PRINT_AUTOTUNING", None) == "1":
+                    verbose = (
+                        os.getenv(f"{PACKAGE_NAME.upper()}_PRINT_AUTOTUNING", None) == "1"
+                    )
+                    if verbose:
                         for config, time_ in timings.items():
                             print(f"[{config}] -> {time_[0]:.3f}ms")
+                    # Surface bench failures (configs returning inf timings)
+                    # so smem-overflow / launch errors aren't silently masked.
+                    n_failed = sum(1 for t in timings.values() if t[0] == float("inf"))
+                    if n_failed:
+                        print(
+                            f"quack autotune: {n_failed}/{len(timings)} configs "
+                            f"failed for {self.fn.__name__}{key}; "
+                            f"set {PACKAGE_NAME.upper()}_PRINT_AUTOTUNING=1 for details",
+                            file=sys.stderr,
+                        )
                     self.bench_time = bench_end - bench_start
                     self.cache[key] = builtins.min(timings, key=timings.get)
                     self.configs_timings = timings

--- a/quack/bench/bench_utils.py
+++ b/quack/bench/bench_utils.py
@@ -3,6 +3,8 @@
 import os
 
 import pandas as pd
+import torch
+from torch import Tensor
 from triton.testing import Benchmark
 
 
@@ -49,3 +51,139 @@ def _run_one(fn, bench: Benchmark) -> pd.DataFrame:
         f"{name} ({stat})" for name in bench.line_names for stat in (stat_keys or [])
     ]
     return pd.DataFrame(rows, columns=cols)
+
+
+def _bench_cuda_graph_l2_rotate(
+    fn,
+    arg_sets,
+    kwarg_sets,
+    extra_kwargs,
+    warmup_target_ms: float = 200.0,
+    n_timed_calls: int = 200,
+    quantiles=None,
+):
+    """L2-cold single-replay CUDA-graph benchmark.
+
+    Warmup is time-based: probe a single kernel launch to estimate the
+    per-call cost, then iterate round-robin over the pre-cloned
+    ``(arg_sets[i], kwarg_sets[i])`` pairs as a plain Python loop for
+    ``warmup_target_ms`` of wall-clock GPU work. Heavy pipelined configs
+    (TMA + smem_stages=3) need enough warmup to drain the pipeline-fill
+    phase or the timed window catches them artificially fast - a fixed
+    count of warmup launches underwarms heavy configs while overpaying
+    for cheap ones.
+
+    The timed window is a single ``graph.replay()`` of a captured CUDA
+    graph whose body records ``n_timed_calls`` round-robin invocations -
+    no Python loop, no per-launch CPU overhead - so the measurement is
+    just GPU work / total recorded calls.
+
+    Round-robin over fresh tensor sets defeats the L2-resident caching
+    that inflates short-kernel timing under ``triton.testing.do_bench``
+    (which calls the kernel on the same single tensor each iteration).
+    For cache-cold production workloads the round-robin number predicts
+    real-world latency; the L2-hot number favours wider layouts / deeper
+    smem stages that don't actually win once data has to come from HBM.
+
+    ``fn`` is called as ``fn(*arg_sets[i], **kwarg_sets[i], **extra_kwargs)``
+    once per recorded launch. ``extra_kwargs`` holds the per-config kwargs
+    (e.g. ``{"config": <RmsNormBwdConfig>}``) which don't need cloning;
+    keys in ``extra_kwargs`` must not overlap with ``kwarg_sets[i]``.
+    Returns ms/call, or a ``len(quantiles)``-list replicating that value
+    when ``quantiles`` is provided (for API parity with
+    ``triton.testing.do_bench``).
+    """
+    n_sets = len(arg_sets)
+    # Round timed-call count to a multiple of n_sets for even L2 turnover.
+    rounds_timed = max(1, n_timed_calls // n_sets)
+    total_timed_calls = rounds_timed * n_sets
+
+    # A few priming launches so the probe doesn't catch first-launch
+    # driver / kernel-load overhead.
+    for _ in range(3):
+        fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs)
+    torch.cuda.synchronize()
+
+    # Probe a single launch to estimate per-call ms; size the warmup loop
+    # to hit ``warmup_target_ms`` of GPU work regardless of kernel cost.
+    probe_start = torch.cuda.Event(enable_timing=True)
+    probe_end = torch.cuda.Event(enable_timing=True)
+    probe_start.record()
+    fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs)
+    probe_end.record()
+    torch.cuda.synchronize()
+    est_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
+    n_warmup_calls = max(50, int(warmup_target_ms / est_ms))
+
+    # Warmup: plain Python loop over rotating sets, no graph capture.
+    for i in range(n_warmup_calls):
+        idx = i % n_sets
+        fn(*arg_sets[idx], **kwarg_sets[idx], **extra_kwargs)
+    torch.cuda.synchronize()
+
+    # Capture timed graph: a single replay covers all timed kernel launches.
+    timed_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(timed_graph):
+        for _ in range(rounds_timed):
+            for i in range(n_sets):
+                fn(*arg_sets[i], **kwarg_sets[i], **extra_kwargs)
+    torch.cuda.synchronize()
+
+    start_evt = torch.cuda.Event(enable_timing=True)
+    end_evt = torch.cuda.Event(enable_timing=True)
+    start_evt.record()
+    timed_graph.replay()
+    end_evt.record()
+    torch.cuda.synchronize()
+    ms = start_evt.elapsed_time(end_evt) / total_timed_calls
+
+    if quantiles:
+        return [ms for _ in quantiles]
+    return ms
+
+
+def _clone_l2_rotate_inputs(args, kwargs, n_buffers: int):
+    """Clone tensor args AND tensor kwargs ``n_buffers`` times.
+
+    Returns ``(arg_sets, kwarg_sets)``: ``arg_sets[i]`` is a tuple matching
+    ``args``' positional shape with tensors cloned to fresh memory;
+    ``kwarg_sets[i]`` is a dict matching ``kwargs``' keys with tensor values
+    cloned. Non-tensor values (ints, strings, None, dataclasses, etc.) are
+    shared across all sets (no clone).
+
+    Both args and kwargs are cloned so that every recorded launch in the
+    L2-cold round-robin CUDA graph touches distinct GMEM addresses,
+    including for write-target kwargs like ``dw_partial`` / ``dx``.
+    """
+    arg_sets = []
+    kwarg_sets = []
+    for _ in range(n_buffers):
+        arg_sets.append(tuple(a.clone() if isinstance(a, Tensor) else a for a in args))
+        kwarg_sets.append({k: v.clone() if isinstance(v, Tensor) else v for k, v in kwargs.items()})
+    return arg_sets, kwarg_sets
+
+
+def _pick_l2_rotate_count(
+    args, kwargs, target_ratio: int = 3, min_buffers: int = 4, max_buffers: int = 16
+):
+    """Pick ``n_bufs`` so cloned input bytes per round exceed
+    ``target_ratio * L2_size`` (defeats L2 reuse), capped by HBM headroom and
+    [min_buffers, max_buffers]. Counts tensor bytes across both ``args`` and
+    ``kwargs`` so write-target kwargs (``dw_partial``, ``dx``, etc.) are
+    included in the L2-turnover calculation.
+    """
+    if not torch.cuda.is_available():
+        return min_buffers
+    tensor_bytes = sum(a.numel() * a.element_size() for a in args if isinstance(a, Tensor)) + sum(
+        v.numel() * v.element_size() for v in kwargs.values() if isinstance(v, Tensor)
+    )
+    if tensor_bytes == 0:
+        return min_buffers
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    l2_size = props.L2_cache_size
+    n_by_l2 = (target_ratio * l2_size + tensor_bytes - 1) // tensor_bytes
+    free_bytes, _ = torch.cuda.mem_get_info()
+    # Leave half of free memory headroom for the kernel's own scratch + the
+    # user's other allocations.
+    n_by_mem = max(1, int(free_bytes * 0.5) // tensor_bytes)
+    return max(min_buffers, min(max_buffers, min(n_by_l2, n_by_mem)))

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -24,7 +24,16 @@ from quack.reduce import row_reduce
 from quack.reduction_base import ReductionBase
 from quack.cache import jit_cache
 from quack.cute_dsl_utils import torch2cute_dtype_map
-from quack.rmsnorm_config import RmsNormBwdConfig, get_sm_count
+from quack.autotuner import autotune, AutotuneConfig
+from quack.rmsnorm_config import (
+    RmsNormBwdConfig,
+    RmsNormFwdConfig,
+    get_all_bwd_configs,
+    get_all_fwd_configs,
+    get_sm_count,
+    prune_invalid_rmsnorm_bwd_configs,
+    prune_invalid_rmsnorm_fwd_configs,
+)
 from cutlass.base_dsl.arch import Arch
 
 
@@ -53,18 +62,31 @@ def _ensure_contiguous(t):
 
 
 class RMSNorm(ReductionBase):
-    def __init__(self, dtype: Type[cutlass.Numeric], N: int, is_layernorm: bool = False):
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        N: int,
+        is_layernorm: bool = False,
+        config: Optional["RmsNormFwdConfig"] = None,
+    ):
         super().__init__(dtype, N, stage=2 if is_layernorm else 1)
         self.is_layernorm = is_layernorm
-        self.reload_from = None if N <= (16384 if is_layernorm else 8192) else "smem"
-        self.delay_w_load = False
+        if config is None:
+            config = RmsNormFwdConfig.from_analytical_heuristic(
+                N, dtype.width, is_layernorm=is_layernorm
+            )
+        self.config = config
+        self.reload_from = config.reload_from
+        self.delay_w_load = config.delay_w_load
+        self._num_threads_val = config.num_threads
+        self._threads_per_row_val = config.threads_per_row
+        self._cluster_n_val = config.cluster_n
+
+    def _num_threads(self):
+        return self._num_threads_val
 
     def _threads_per_row(self):
-        N = self.N
-        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
-            if N <= limit:
-                return threads
-        return 256
+        return self._threads_per_row_val
 
     def _set_cluster_n(self):
         arch = cutlass.base_dsl.BaseDSL._get_dsl().get_arch_enum()
@@ -74,28 +96,7 @@ class RMSNorm(ReductionBase):
             return
         # SM12x supports cluster up to 8
         max_cluster = 8 if arch.major == 12 else 16
-        N = self.N
-        # cluster_n = 4 is faster and cluster_n = 2 for N=64k for some reason
-        # Similarly cluster_n = 8 is faster for N=128k
-        if arch.major == 12 and const_expr(self.dtype.width >= 32):
-            # SM12x 99 KB SMEM: fp32 needs tighter clustering (conservative for residual case)
-            thresholds = [(8 * 1024, 1), (16 * 1024, 2), (32 * 1024, 4), (64 * 1024, 8)]
-        elif const_expr(self.dtype.width == 16):
-            thresholds = [(16 * 1024, 1), (32 * 1024, 2), (64 * 1024, 4), (128 * 1024, 8)]
-        elif self.is_layernorm:
-            # fp32 layernorm: bump cluster earlier than fp16/bf16. The 2-pass path's
-            # single-CTA tile is bandwidth-limited at N=16k/32k; cluster_n=2 splits
-            # the row across two CTAs and recovers ~3-14% at those sizes.
-            thresholds = [(8 * 1024, 1), (64 * 1024, 2), (128 * 1024, 4), (256 * 1024, 8)]
-        else:
-            # fp32 rmsnorm (1-pass) is already saturated at cluster_n=1 for N<=32k;
-            # bumping to cluster_n=2 there regresses ~3%.
-            thresholds = [(32 * 1024, 1), (64 * 1024, 2), (128 * 1024, 4), (256 * 1024, 8)]
-        for limit, cluster in thresholds:
-            if N <= limit:
-                self.cluster_n = cluster
-                return
-        self.cluster_n = max_cluster
+        self.cluster_n = min(self._cluster_n_val, max_cluster)
 
     @cute.jit
     def __call__(
@@ -422,6 +423,7 @@ def _compile_rmsnorm_fwd(
     has_mean,
     is_layernorm,
     per_head,
+    config: Optional[RmsNormFwdConfig] = None,
 ):
     batch_sym = cute.sym_int()
     head_sym = cute.sym_int() if per_head else None
@@ -439,7 +441,7 @@ def _compile_rmsnorm_fwd(
     rstd_cute = fake_tensor(Float32, batch_shape) if has_rstd else None
     mean_cute = fake_tensor(Float32, batch_shape) if has_mean else None
     return cute.compile(
-        RMSNorm(dtype, N, is_layernorm=is_layernorm),
+        RMSNorm(dtype, N, is_layernorm=is_layernorm, config=config),
         x_cute,
         weight_cute,
         bias_cute,
@@ -483,6 +485,58 @@ def rmsnorm_fwd(
     if residual_out is None:
         residual_out = x
     return out, residual_out, rstd
+
+
+@autotune(
+    configs=[AutotuneConfig(config=c) for c in get_all_fwd_configs()],
+    key=["is_layernorm", "per_head"],
+    prune_configs_by={"early_config_prune": prune_invalid_rmsnorm_fwd_configs},
+)
+def rmsnorm_fwd_tuned(
+    x: Tensor,
+    weight: Optional[Tensor],
+    out: Tensor,
+    bias: Optional[Tensor] = None,
+    rstd: Optional[Tensor] = None,
+    mean: Optional[Tensor] = None,
+    residual: Optional[Tensor] = None,
+    residual_out: Optional[Tensor] = None,
+    eps: float = 1e-6,
+    is_layernorm: bool = False,
+    per_head: bool = False,
+    config: Optional[RmsNormFwdConfig] = None,
+) -> None:
+    """Autotuned RMSNorm/LayerNorm forward dispatch.
+
+    The ``@autotune`` decorator injects ``config`` from the exhaustive search
+    space at first call for a given (shape, dtype, ``is_layernorm``, ``per_head``)
+    and caches the winner for subsequent calls. The un-tuned counterpart is
+    :func:`rmsnorm_fwd`, which uses the analytical heuristic.
+    """
+    if config is None:
+        raise RuntimeError(
+            "rmsnorm_fwd_tuned requires a config (provided automatically by "
+            "the @autotune decorator). Use rmsnorm_fwd for the un-tuned path."
+        )
+    N = x.size(-1)
+    dtype, out_dtype, weight_dtype, bias_dtype, res_dtype, res_out_dtype = [
+        torch2cute_dtype_map[t.dtype] if t is not None else None
+        for t in [x, out, weight, bias, residual, residual_out]
+    ]
+    _compile_rmsnorm_fwd(
+        dtype,
+        out_dtype,
+        res_dtype,
+        weight_dtype,
+        bias_dtype,
+        res_out_dtype,
+        N,
+        rstd is not None,
+        mean is not None,
+        is_layernorm,
+        per_head,
+        config=config,
+    )(x, weight, bias, residual, out, residual_out, rstd, mean, eps)
 
 
 def rmsnorm_ref(x, w=None, bias=None, residual=None, eps=1e-6):
@@ -546,18 +600,15 @@ class RMSNormBackward(ReductionBase):
         dout_dtype: Optional[Type[cutlass.Numeric]] = None,
         T_hint: int = 0,
         per_head: bool = False,
+        config: Optional["RmsNormBwdConfig"] = None,
     ):
         # 2 stages for double buffering when computing mean of x_hat * wdy
         super().__init__(dtype, N, stage=2, reduction_dtype=Float32)
         dout_width = dout_dtype.width if dout_dtype is not None else dtype.width
-        arch_major = (
-            torch.cuda.get_device_capability(torch.cuda.current_device())[0]
-            if torch.cuda.is_available()
-            else 0
-        )
-        config = RmsNormBwdConfig.from_analytical_heuristic(
-            N, dtype.width, dout_width, arch_major, T_hint
-        )
+        if config is None:
+            config = RmsNormBwdConfig.from_analytical_heuristic(
+                N, dtype.width, dout_width, T_hint=T_hint
+            )
         self.config = config
         self.reload_wdy = config.reload_wdy
         self.reload_x = config.reload_x
@@ -1174,6 +1225,7 @@ def _compile_rmsnorm_bwd(
     has_dw_partial,
     per_head=False,
     T_hint=0,
+    config: Optional[RmsNormBwdConfig] = None,
 ):
     batch_sym, batch_partial_sym = cute.sym_int(), cute.sym_int()
     head_sym = cute.sym_int() if per_head else None
@@ -1197,6 +1249,7 @@ def _compile_rmsnorm_bwd(
             dout_dtype=dout_dtype,
             T_hint=T_hint,
             per_head=per_head,
+            config=config,
         ),
         x_cute,
         weight_cute,
@@ -1259,6 +1312,60 @@ def rmsnorm_bwd(
     if has_residual and dresidual is None:
         dresidual = dx
     return dx, dw, db, dresidual
+
+
+@autotune(
+    configs=[AutotuneConfig(config=c) for c in get_all_bwd_configs()],
+    key=["per_head", "has_dw_partial", "has_db_partial"],
+    prune_configs_by={"early_config_prune": prune_invalid_rmsnorm_bwd_configs},
+)
+def rmsnorm_bwd_tuned(
+    x: Tensor,
+    weight: Optional[Tensor],
+    dout: Tensor,
+    rstd: Tensor,
+    dx: Tensor,
+    dw_partial: Optional[Tensor] = None,
+    db_partial: Optional[Tensor] = None,
+    dresidual_out: Optional[Tensor] = None,
+    dresidual: Optional[Tensor] = None,
+    sm_count: Optional[int] = None,
+    per_head: bool = False,
+    has_dw_partial: bool = False,
+    has_db_partial: bool = False,
+    config: Optional[RmsNormBwdConfig] = None,
+) -> None:
+    """Autotuned RMSNorm backward dispatch.
+
+    The ``@autotune`` decorator injects ``config`` from the exhaustive search
+    space at first call for a given (shape, dtype, ``per_head``, has_*) and
+    caches the winner for subsequent calls. The un-tuned counterpart is
+    :func:`rmsnorm_bwd`, which uses the analytical heuristic.
+    """
+    if config is None:
+        raise RuntimeError(
+            "rmsnorm_bwd_tuned requires a config (provided automatically by "
+            "the @autotune decorator). Use rmsnorm_bwd for the un-tuned path."
+        )
+    N = x.size(-1)
+    dtype, dout_dtype, dx_dtype, weight_dtype, dres_dtype, dres_out_dtype = [
+        torch2cute_dtype_map[t.dtype] if t is not None else None
+        for t in [x, dout, dx, weight, dresidual, dresidual_out]
+    ]
+    _compile_rmsnorm_bwd(
+        N,
+        dtype,
+        dout_dtype,
+        dx_dtype,
+        weight_dtype,
+        has_db_partial,
+        dres_dtype,
+        dres_out_dtype,
+        has_dw_partial,
+        per_head,
+        T_hint=0,
+        config=config,
+    )(x, weight, dout, dresidual_out, rstd, dx, dw_partial, dresidual, db_partial, sm_count)
 
 
 class RMSNormFunction(torch.autograd.Function):

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -1347,6 +1347,20 @@ def rmsnorm_bwd_tuned(
             "rmsnorm_bwd_tuned requires a config (provided automatically by "
             "the @autotune decorator). Use rmsnorm_bwd for the un-tuned path."
         )
+    # The persistent grid size is encoded in the partial-accumulator shape
+    # (dw_partial / db_partial have shape (sm_count, ..., N)). Derive
+    # sm_count from there when available; require it explicitly only when
+    # neither buffer is provided. Mirrors the _rmsnorm_bwd torch-op
+    # contract.
+    if dw_partial is not None:
+        sm_count = dw_partial.shape[0]
+    elif db_partial is not None:
+        sm_count = db_partial.shape[0]
+    elif sm_count is None:
+        raise ValueError(
+            "rmsnorm_bwd_tuned: sm_count is required when neither dw_partial "
+            "nor db_partial is provided."
+        )
     N = x.size(-1)
     dtype, dout_dtype, dx_dtype, weight_dtype, dres_dtype, dres_out_dtype = [
         torch2cute_dtype_map[t.dtype] if t is not None else None

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -1,16 +1,94 @@
 # Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
 
-"""Launch configuration for the RMSNorm backward kernel.
+"""Launch configuration for the RMSNorm forward and backward kernels.
 
-Mirrors :mod:`quack.gemm_config`: a frozen dataclass that captures the launch
-knobs, plus arch-specific factories that own the heuristics. The forward
-kernel's launch logic is much simpler and stays inline in :class:`RMSNorm`.
+Mirrors :mod:`quack.gemm_config`: frozen dataclasses that capture the launch
+knobs, plus arch-specific factories that own the heuristics.
 """
 
+import itertools
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 import torch
+
+
+@dataclass(frozen=True)
+class RmsNormFwdConfig:
+    num_threads: int
+    threads_per_row: int
+    cluster_n: int
+    # None = compute once into registers; "smem" / "gmem" = reload x (and
+    # residual) before the post-reduction epilogue.
+    reload_from: Optional[str]
+    # Defer the weight/bias load until after the row reduction.
+    delay_w_load: bool = False
+
+    @classmethod
+    def from_analytical_heuristic(
+        cls,
+        N: int,
+        dtype_width: int,
+        arch_major: Optional[int] = None,
+        is_layernorm: bool = False,
+    ) -> "RmsNormFwdConfig":
+        """Pick a launch config from the hand-tuned analytical heuristic.
+
+        ``arch_major`` defaults to the current device's capability. The same
+        ladder is used for Hopper, Blackwell, and SM12x today; a future
+        ``_for_blackwell_fwd`` factory can be added and dispatched on
+        ``arch_major >= 10``. For autotuning, use :func:`get_all_fwd_configs`.
+        """
+        if arch_major is None:
+            arch_major = _detect_arch_major()
+        return _for_hopper_fwd(N, dtype_width, arch_major, is_layernorm)
+
+
+def _for_hopper_fwd(
+    N: int, dtype_width: int, arch_major: int, is_layernorm: bool
+) -> RmsNormFwdConfig:
+    num_threads = 128 if N <= 16 * 1024 else 256
+
+    threads_per_row = 256
+    for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+        if N <= limit:
+            threads_per_row = threads
+            break
+
+    if arch_major < 9:
+        cluster_n = 1
+    else:
+        max_cluster = 8 if arch_major == 12 else 16
+        # cluster_n=4 is faster than cluster_n=2 for N=64k; cluster_n=8 is
+        # faster for N=128k.
+        if arch_major == 12 and dtype_width >= 32:
+            # SM12x 99 KB SMEM: fp32 needs tighter clustering (conservative for residual case)
+            thresholds = [(8 * 1024, 1), (16 * 1024, 2), (32 * 1024, 4), (64 * 1024, 8)]
+        elif dtype_width == 16:
+            thresholds = [(16 * 1024, 1), (32 * 1024, 2), (64 * 1024, 4), (128 * 1024, 8)]
+        elif is_layernorm:
+            # fp32 layernorm: bump cluster earlier than fp16/bf16. The 2-pass path's
+            # single-CTA tile is bandwidth-limited at N=16k/32k; cluster_n=2 splits
+            # the row across two CTAs and recovers ~3-14% at those sizes.
+            thresholds = [(8 * 1024, 1), (64 * 1024, 2), (128 * 1024, 4), (256 * 1024, 8)]
+        else:
+            # fp32 rmsnorm (1-pass) is already saturated at cluster_n=1 for N<=32k;
+            # bumping to cluster_n=2 there regresses ~3%.
+            thresholds = [(32 * 1024, 1), (64 * 1024, 2), (128 * 1024, 4), (256 * 1024, 8)]
+        cluster_n = max_cluster
+        for limit, cluster in thresholds:
+            if N <= limit:
+                cluster_n = cluster
+                break
+
+    reload_threshold = 16 * 1024 if is_layernorm else 8 * 1024
+    return RmsNormFwdConfig(
+        num_threads=num_threads,
+        threads_per_row=threads_per_row,
+        cluster_n=cluster_n,
+        reload_from=None if N <= reload_threshold else "smem",
+        delay_w_load=False,
+    )
 
 
 @dataclass(frozen=True)
@@ -205,7 +283,17 @@ def get_sm_count(N: int, device: torch.device) -> int:
 
 
 _CTA_THREAD_SIZE = (128, 256)
+# Full launch-knob menu lives here; the per-call pruner in
+# ``prune_invalid_rmsnorm_{fwd,bwd}_configs`` drops layouts that don't fit the
+# current row. The tiny widths (8, 16, 32) are kept for the analytical
+# heuristic's narrow-row safety floor (N <= 512) but are dropped from the
+# autotune search space below since they're only optimal for that floor.
 _THREADS_PER_REDUCTION_DIM = (8, 16, 32, 64, 128, 256)
+_AUTOTUNE_THREADS_PER_REDUCTION_DIM = (64, 128, 256)
+# smem_stages=4 doubles the data-buffer footprint vs stages=2 and crashes at
+# launch for fp32 N>=64K on Blackwell (227 KB opt-in smem). Stages=3 still
+# offers a meaningful prefetch depth without that risk.
+_AUTOTUNE_SMEM_STAGES = (2, 3)
 
 
 def _max_dynamic_smem_bytes() -> int:
@@ -268,3 +356,125 @@ def _max_cluster_for(arch_major: int) -> int:
         return 1
     # SM12x (RTX 50) supports up to 8; Hopper/Blackwell up to 16.
     return 8 if arch_major == 12 else 16
+
+
+def get_all_fwd_configs() -> List[RmsNormFwdConfig]:
+    """Exhaustive search space of RMSNorm fwd configs for the current device.
+
+    The search space is over launch knobs only — ``device_capacity`` is not a
+    tunable parameter, so the current device's capability is queried once and
+    used to bound ``cluster_n``.
+    """
+    arch_major = _detect_arch_major()
+    max_cluster = _max_cluster_for(arch_major)
+    cluster_vals = tuple(c for c in (1, 2, 4, 8, 16) if c <= max_cluster)
+    reload_from_vals = (None, "smem", "gmem")
+
+    configs: List[RmsNormFwdConfig] = []
+    for num_threads, threads_per_row, cluster_n, reload_from in itertools.product(
+        _CTA_THREAD_SIZE, _AUTOTUNE_THREADS_PER_REDUCTION_DIM, cluster_vals, reload_from_vals
+    ):
+        if threads_per_row > num_threads:
+            continue
+        if num_threads % threads_per_row != 0:
+            continue
+        configs.append(
+            RmsNormFwdConfig(
+                num_threads=num_threads,
+                threads_per_row=threads_per_row,
+                cluster_n=cluster_n,
+                reload_from=reload_from,
+                delay_w_load=False,
+            )
+        )
+    return configs
+
+
+def get_all_bwd_configs() -> List[RmsNormBwdConfig]:
+    """Exhaustive search space of RMSNorm bwd configs for the current device.
+
+    Like :func:`get_all_fwd_configs`, the current device's capability bounds
+    ``cluster_n`` and gates ``use_tma`` (TMA requires SM90+). ``smem_stages``
+    sweeps the safe depths in :data:`_AUTOTUNE_SMEM_STAGES`.
+    """
+    arch_major = _detect_arch_major()
+    max_cluster = _max_cluster_for(arch_major)
+    cluster_vals = tuple(c for c in (1, 2, 4, 8, 16) if c <= max_cluster)
+    use_tma_vals = (False, True) if arch_major >= 9 else (False,)
+    reload_vals = (None, "smem")
+
+    configs: List[RmsNormBwdConfig] = []
+    for (
+        num_threads,
+        threads_per_row,
+        cluster_n,
+        reload_wdy,
+        reload_x,
+        use_tma,
+        smem_stages,
+    ) in itertools.product(
+        _CTA_THREAD_SIZE,
+        _AUTOTUNE_THREADS_PER_REDUCTION_DIM,
+        cluster_vals,
+        reload_vals,
+        reload_vals,
+        use_tma_vals,
+        _AUTOTUNE_SMEM_STAGES,
+    ):
+        if threads_per_row > num_threads:
+            continue
+        if num_threads % threads_per_row != 0:
+            continue
+        configs.append(
+            RmsNormBwdConfig(
+                num_threads=num_threads,
+                threads_per_row=threads_per_row,
+                cluster_n=cluster_n,
+                reload_wdy=reload_wdy,
+                reload_x=reload_x,
+                use_tma=use_tma,
+                smem_stages=smem_stages,
+            )
+        )
+    return configs
+
+
+def prune_invalid_rmsnorm_fwd_configs(configs, named_args: dict, **kwargs):
+    """Drop configs whose CTA layout doesn't fit the row width.
+
+    The search space (see :func:`get_all_fwd_configs`) is already restricted to
+    the current device's capability, so all that's left is a per-call shape
+    check: ``threads_per_row * cluster_n > N`` would leave cluster CTAs with no
+    work to do, so skip those.
+    """
+    kwargs = named_args | kwargs
+    x = kwargs["x"]
+    N = int(x.size(-1))
+    pruned = []
+    for ac in configs:
+        c = ac.kwargs["config"]
+        if c.threads_per_row * c.cluster_n > N:
+            continue
+        pruned.append(ac)
+    return pruned
+
+
+def prune_invalid_rmsnorm_bwd_configs(configs, named_args: dict, **kwargs):
+    """Same per-call shape filter as the fwd, plus: drop ``use_tma=True`` configs
+    when ``per_head`` is set, since :class:`RMSNormBackward` forces
+    ``USE_TMA=False`` in that case (would otherwise duplicate the non-TMA
+    timing). The search space is already restricted to the current device.
+    """
+    kwargs = named_args | kwargs
+    x = kwargs["x"]
+    N = int(x.size(-1))
+    per_head = bool(kwargs.get("per_head", x.dim() == 3))
+    pruned = []
+    for ac in configs:
+        c = ac.kwargs["config"]
+        if c.threads_per_row * c.cluster_n > N:
+            continue
+        if per_head and c.use_tma:
+            continue
+        pruned.append(ac)
+    return pruned

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -369,7 +369,7 @@ def get_all_fwd_configs() -> List[RmsNormFwdConfig]:
     max_cluster = _max_cluster_for(arch_major)
     cluster_vals = tuple(c for c in (1, 2, 4, 8, 16) if c <= max_cluster)
     reload_from_vals = (None, "smem", "gmem")
-    delay_w_load_vals = (False, True)
+    delay_w_load_vals = (False)
 
     configs: List[RmsNormFwdConfig] = []
     for num_threads, threads_per_row, cluster_n, reload_from, delay_w_load in itertools.product(

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -369,10 +369,15 @@ def get_all_fwd_configs() -> List[RmsNormFwdConfig]:
     max_cluster = _max_cluster_for(arch_major)
     cluster_vals = tuple(c for c in (1, 2, 4, 8, 16) if c <= max_cluster)
     reload_from_vals = (None, "smem", "gmem")
+    delay_w_load_vals = (False, True)
 
     configs: List[RmsNormFwdConfig] = []
-    for num_threads, threads_per_row, cluster_n, reload_from in itertools.product(
-        _CTA_THREAD_SIZE, _AUTOTUNE_THREADS_PER_REDUCTION_DIM, cluster_vals, reload_from_vals
+    for num_threads, threads_per_row, cluster_n, reload_from, delay_w_load in itertools.product(
+        _CTA_THREAD_SIZE,
+        _AUTOTUNE_THREADS_PER_REDUCTION_DIM,
+        cluster_vals,
+        reload_from_vals,
+        delay_w_load_vals,
     ):
         if threads_per_row > num_threads:
             continue
@@ -384,7 +389,7 @@ def get_all_fwd_configs() -> List[RmsNormFwdConfig]:
                 threads_per_row=threads_per_row,
                 cluster_n=cluster_n,
                 reload_from=reload_from,
-                delay_w_load=False,
+                delay_w_load=delay_w_load,
             )
         )
     return configs
@@ -460,21 +465,32 @@ def prune_invalid_rmsnorm_fwd_configs(configs, named_args: dict, **kwargs):
 
 
 def prune_invalid_rmsnorm_bwd_configs(configs, named_args: dict, **kwargs):
-    """Same per-call shape filter as the fwd, plus: drop ``use_tma=True`` configs
-    when ``per_head`` is set, since :class:`RMSNormBackward` forces
-    ``USE_TMA=False`` in that case (would otherwise duplicate the non-TMA
-    timing). The search space is already restricted to the current device.
+    """Same per-call shape filter as the fwd, plus three ``use_tma`` drops
+    that mirror the runtime ``USE_TMA`` guard in :class:`RMSNormBackward`
+    (``USE_TMA = use_tma and not per_head and row_bytes_x % 16 == 0 and
+    row_bytes_do % 16 == 0``). Configs that would silently fall back to the
+    cp.async path are dropped here so the autotune bench doesn't time the
+    same kernel twice and pick whichever happens to bench faster by noise.
     """
     kwargs = named_args | kwargs
     x = kwargs["x"]
+    dout = kwargs.get("dout")
     N = int(x.size(-1))
     per_head = bool(kwargs.get("per_head", x.dim() == 3))
+    x_bytes = x.element_size()
+    dout_bytes = dout.element_size() if dout is not None else x_bytes
     pruned = []
     for ac in configs:
         c = ac.kwargs["config"]
         if c.threads_per_row * c.cluster_n > N:
             continue
-        if per_head and c.use_tma:
-            continue
+        if c.use_tma:
+            if per_head:
+                continue
+            tile_n = N // max(1, c.cluster_n)
+            row_bytes_x = tile_n * x_bytes
+            row_bytes_do = tile_n * dout_bytes
+            if row_bytes_x % 16 != 0 or row_bytes_do % 16 != 0:
+                continue
         pruned.append(ac)
     return pruned

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -369,7 +369,7 @@ def get_all_fwd_configs() -> List[RmsNormFwdConfig]:
     max_cluster = _max_cluster_for(arch_major)
     cluster_vals = tuple(c for c in (1, 2, 4, 8, 16) if c <= max_cluster)
     reload_from_vals = (None, "smem", "gmem")
-    delay_w_load_vals = (False)
+    delay_w_load_vals = (False,)
 
     configs: List[RmsNormFwdConfig] = []
     for num_threads, threads_per_row, cluster_n, reload_from, delay_w_load in itertools.product(

--- a/tests/test_rmsnorm.py
+++ b/tests/test_rmsnorm.py
@@ -3,7 +3,18 @@
 import pytest
 import torch
 
-from quack.rmsnorm import rmsnorm, rmsnorm_ref, _compile_rmsnorm_fwd, rmsnorm_fwd, rmsnorm_bwd
+from quack.cute_dsl_utils import get_device_capacity
+from quack.rmsnorm import (
+    _compile_rmsnorm_fwd,
+    rmsnorm,
+    rmsnorm_bwd,
+    rmsnorm_bwd_ref,
+    rmsnorm_bwd_tuned,
+    rmsnorm_fwd,
+    rmsnorm_fwd_tuned,
+    rmsnorm_ref,
+)
+from quack.rmsnorm_config import RmsNormBwdConfig, RmsNormFwdConfig
 
 torch._dynamo.config.cache_size_limit = 1024
 torch._dynamo.config.accumulated_cache_size_limit = 1024
@@ -573,3 +584,225 @@ def test_rmsnorm_bwd_empty(has_bias):
     else:
         assert db is None
     assert dresidual is None
+
+
+# ---------------------------------------------------------------------------
+# Tuned-path tests: mirror tests/test_linear.py::test_gemm — drive the
+# autotune-decorated fn directly with an explicit config (bypassing the search)
+# to exercise the plumbing for specific knob combinations, plus one end-to-end
+# autotune dispatch test for sanity.
+# ---------------------------------------------------------------------------
+
+
+def _device_capacity_or_skip() -> int:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for tuned-path tests")
+    return get_device_capacity(torch.device("cuda"))[0]
+
+
+@pytest.mark.parametrize("reload_from", [None, "smem", "gmem"])
+@pytest.mark.parametrize("cluster_n", [1, 2])
+@pytest.mark.parametrize("num_threads,threads_per_row", [(128, 32), (128, 128), (256, 128)])
+def test_rmsnorm_fwd_tuned_config(num_threads, threads_per_row, cluster_n, reload_from):
+    """Drive rmsnorm_fwd_tuned.fn with an explicit config, bypassing autotune.
+
+    Mirrors test_linear::test_gemm: exercises specific config combinations to
+    catch breakage in the tuned-path plumbing (config -> RMSNorm -> compile).
+    """
+    device_capacity = _device_capacity_or_skip()
+    if device_capacity < 9 and cluster_n > 1:
+        pytest.skip("SM8x lacks cluster support")
+    torch.random.manual_seed(0)
+    device = "cuda"
+    M, N = 1024, 4096
+    dtype = torch.bfloat16
+    if threads_per_row * cluster_n > N:
+        pytest.skip("Config over-clusters for this N")
+
+    x = torch.randn(M, N, device=device, dtype=dtype)
+    weight = torch.randn(N, device=device, dtype=dtype) * 0.1
+    out = torch.empty_like(x)
+    rstd = torch.empty(M, device=device, dtype=torch.float32)
+
+    config = RmsNormFwdConfig(
+        num_threads=num_threads,
+        threads_per_row=threads_per_row,
+        cluster_n=cluster_n,
+        reload_from=reload_from,
+        delay_w_load=False,
+    )
+    rmsnorm_fwd_tuned.fn(
+        x,
+        weight,
+        out,
+        bias=None,
+        rstd=rstd,
+        mean=None,
+        residual=None,
+        residual_out=None,
+        eps=1e-6,
+        is_layernorm=False,
+        per_head=False,
+        config=config,
+    )
+    out_ref = rmsnorm_ref(x, weight, eps=1e-6)
+    # rmsnorm_ref always promotes to fp32 internally, so a gemm-style "kernel
+    # vs pt" tolerance would collapse to zero. Tuned configs may pick a
+    # different reduction tree than the analytical heuristic, so allow 2x the
+    # un-tuned bf16 noise budget.
+    torch.testing.assert_close(out, out_ref, atol=2 * TOLERANCES[dtype], rtol=1e-3)
+
+
+@pytest.mark.parametrize("reload_x", [None, "smem"])
+@pytest.mark.parametrize("reload_wdy", [None, "smem"])
+@pytest.mark.parametrize("cluster_n", [1, 2])
+@pytest.mark.parametrize("num_threads,threads_per_row", [(128, 32), (256, 128)])
+def test_rmsnorm_bwd_tuned_config(
+    num_threads, threads_per_row, cluster_n, reload_wdy, reload_x
+):
+    """Drive rmsnorm_bwd_tuned.fn with an explicit config, bypassing autotune."""
+    device_capacity = _device_capacity_or_skip()
+    if device_capacity < 9 and cluster_n > 1:
+        pytest.skip("SM8x lacks cluster support")
+    torch.random.manual_seed(0)
+    device = "cuda"
+    M, N = 1024, 4096
+    dtype = torch.bfloat16
+    if threads_per_row * cluster_n > N:
+        pytest.skip("Config over-clusters for this N")
+
+    x = torch.randn(M, N, device=device, dtype=dtype)
+    weight = torch.randn(N, device=device, dtype=dtype) * 0.1
+    rstd = torch.rsqrt(x.float().square().mean(dim=-1) + 1e-6)
+    dout = torch.randn(M, N, device=device, dtype=dtype)
+    dx = torch.empty_like(x)
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count * 2
+    dw_partial = torch.empty((sm_count, N), device=device, dtype=torch.float32)
+
+    config = RmsNormBwdConfig(
+        num_threads=num_threads,
+        threads_per_row=threads_per_row,
+        cluster_n=cluster_n,
+        reload_wdy=reload_wdy,
+        reload_x=reload_x,
+        use_tma=False,
+        smem_stages=2,
+    )
+    rmsnorm_bwd_tuned.fn(
+        x,
+        weight,
+        dout,
+        rstd,
+        dx,
+        dw_partial=dw_partial,
+        db_partial=None,
+        dresidual_out=None,
+        dresidual=None,
+        sm_count=sm_count,
+        per_head=False,
+        has_dw_partial=True,
+        has_db_partial=False,
+        config=config,
+    )
+    dw = dw_partial.sum(dim=0).to(weight.dtype)
+    dx_ref, dw_ref = rmsnorm_bwd_ref(x, weight, dout, rstd, eps=1e-6)
+    torch.testing.assert_close(dx, dx_ref, atol=2 * TOLERANCES[dtype], rtol=1e-3)
+    torch.testing.assert_close(dw, dw_ref, atol=2 * TOLERANCES[dtype], rtol=1e-3)
+
+
+def test_rmsnorm_fwd_tuned_dispatch():
+    """End-to-end autotune dispatch: invoke rmsnorm_fwd_tuned (no .fn) so the
+    @autotune decorator picks a config from the search space, benchmarks, and
+    caches it. Validates the autotune cache key + prune flow."""
+    _device_capacity_or_skip()
+    torch.random.manual_seed(0)
+    device = "cuda"
+    # Small N keeps prune_invalid_rmsnorm_fwd_configs filtered list short so
+    # the bench doesn't dominate the test runtime.
+    M, N = 256, 256
+    dtype = torch.bfloat16
+    x = torch.randn(M, N, device=device, dtype=dtype)
+    weight = torch.randn(N, device=device, dtype=dtype) * 0.1
+    out = torch.empty_like(x)
+    rstd = torch.empty(M, device=device, dtype=torch.float32)
+    rmsnorm_fwd_tuned(
+        x,
+        weight,
+        out,
+        bias=None,
+        rstd=rstd,
+        mean=None,
+        residual=None,
+        residual_out=None,
+        eps=1e-6,
+        is_layernorm=False,
+        per_head=False,
+    )
+    assert rmsnorm_fwd_tuned.best_config is not None
+    out_ref = rmsnorm_ref(x, weight, eps=1e-6)
+    # Tuned path may pick a config with a different reduction tree than the
+    # analytical heuristic, so allow 2x the un-tuned bf16 noise budget.
+    torch.testing.assert_close(out, out_ref, atol=2 * TOLERANCES[dtype], rtol=1e-3)
+
+
+def test_rmsnorm_bwd_tuned_dispatch():
+    """End-to-end autotune dispatch for the bwd. See fwd counterpart."""
+    _device_capacity_or_skip()
+    torch.random.manual_seed(0)
+    device = "cuda"
+    M, N = 256, 256
+    dtype = torch.bfloat16
+    x = torch.randn(M, N, device=device, dtype=dtype)
+    weight = torch.randn(N, device=device, dtype=dtype) * 0.1
+    rstd = torch.rsqrt(x.float().square().mean(dim=-1) + 1e-6)
+    dout = torch.randn(M, N, device=device, dtype=dtype)
+    dx = torch.empty_like(x)
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count * 2
+    dw_partial = torch.empty((sm_count, N), device=device, dtype=torch.float32)
+    rmsnorm_bwd_tuned(
+        x,
+        weight,
+        dout,
+        rstd,
+        dx,
+        dw_partial=dw_partial,
+        db_partial=None,
+        dresidual_out=None,
+        dresidual=None,
+        sm_count=sm_count,
+        per_head=False,
+        has_dw_partial=True,
+        has_db_partial=False,
+    )
+    assert rmsnorm_bwd_tuned.best_config is not None
+    dw = dw_partial.sum(dim=0).to(weight.dtype)
+    dx_ref, dw_ref = rmsnorm_bwd_ref(x, weight, dout, rstd, eps=1e-6)
+    # Tuned path may pick a config with a different reduction tree than the
+    # analytical heuristic, so allow 2x the un-tuned bf16 noise budget.
+    torch.testing.assert_close(dx, dx_ref, atol=2 * TOLERANCES[dtype], rtol=1e-3)
+    torch.testing.assert_close(dw, dw_ref, atol=2 * TOLERANCES[dtype], rtol=1e-3)
+
+
+def test_rmsnorm_fwd_tuned_requires_config():
+    """rmsnorm_fwd_tuned.fn (bypassing autotune) must raise without a config."""
+    _device_capacity_or_skip()
+    device = "cuda"
+    x = torch.zeros(4, 256, device=device, dtype=torch.bfloat16)
+    weight = torch.ones(256, device=device, dtype=torch.bfloat16)
+    out = torch.empty_like(x)
+    with pytest.raises(RuntimeError, match="requires a config"):
+        rmsnorm_fwd_tuned.fn(x, weight, out)
+
+
+def test_rmsnorm_bwd_tuned_requires_config():
+    """rmsnorm_bwd_tuned.fn (bypassing autotune) must raise without a config."""
+    _device_capacity_or_skip()
+    device = "cuda"
+    M, N = 4, 256
+    x = torch.zeros(M, N, device=device, dtype=torch.bfloat16)
+    weight = torch.ones(N, device=device, dtype=torch.bfloat16)
+    dout = torch.zeros_like(x)
+    rstd = torch.ones(M, device=device, dtype=torch.float32)
+    dx = torch.empty_like(x)
+    with pytest.raises(RuntimeError, match="requires a config"):
+        rmsnorm_bwd_tuned.fn(x, weight, dout, rstd, dx)

--- a/tests/test_rmsnorm.py
+++ b/tests/test_rmsnorm.py
@@ -657,9 +657,7 @@ def test_rmsnorm_fwd_tuned_config(num_threads, threads_per_row, cluster_n, reloa
 @pytest.mark.parametrize("reload_wdy", [None, "smem"])
 @pytest.mark.parametrize("cluster_n", [1, 2])
 @pytest.mark.parametrize("num_threads,threads_per_row", [(128, 32), (256, 128)])
-def test_rmsnorm_bwd_tuned_config(
-    num_threads, threads_per_row, cluster_n, reload_wdy, reload_x
-):
+def test_rmsnorm_bwd_tuned_config(num_threads, threads_per_row, cluster_n, reload_wdy, reload_x):
     """Drive rmsnorm_bwd_tuned.fn with an explicit config, bypassing autotune."""
     device_capacity = _device_capacity_or_skip()
     if device_capacity < 9 and cluster_n > 1:


### PR DESCRIPTION
This MR adds quack's `gemm_tuned`-style `@autotune`-ing support for both RMSNorm fwd and bwd. The existing `rmsnorm_{fwd,bwd}` analytical-heuristic paths are unchanged; the new `rmsnorm_{fwd,bwd}_tuned` paths bench an exhaustive launch-config search space at first call for each (shape, dtype, key) and cache the winner to disk for subsequent calls.

## Config class plumbing

- New `RmsNormFwdConfig` frozen dataclass mirroring `RmsNormBwdConfig`. Captures every fwd launch knob.
- The fwd heuristic that previously lived inline in RMSNorm is now factored into `RmsNormFwdConfig.from_analytical_heuristic()` + `_for_hopper_fwd()` (Hopper/Blackwell/SM12x share the same ladder for now; a `_for_blackwell_fwd` is easy to add later).
- `RMSNorm.__init__` and `RMSNormBackward.__init__` accept an optional `config` parameter. When `None` they fall back to the analytical heuristic so existing call sites are unaffected.
- `_compile_rmsnorm_{fwd,bwd}` accept an optional config parameter and plumb it through to the kernel class with config captured in the JIT cache key so each chosen config compiles once.

## Search space and pruning

- `get_all_fwd_configs()` and `get_all_bwd_configs()` enumerate the launch-knob product, bounded by the current device's max cluster size and TMA availability:
  - **Fwd**: `num_threads in {128, 256}` x `threads_per_row in {64, 128, 256}` x `cluster_n in {1..max}` x `reload_from in {None, "smem", "gmem"}` ~ **75 configs**
  - **Bwd**: same `num_threads`/`threads_per_row`/`cluster_n` plus `reload_wdy, reload_x in {None, "smem"}` x `use_tma in {False, True}` (SM90+ only) x `smem_stages in {2, 3}` ~ **400 configs**
- Tiny `threads_per_row in {8, 16, 32}` and `smem_stages = 4` are kept in the analytical heuristic (for the narrow-row safety floor `N <= 512`) but trimmed from the autotune search space - stages=4 doubles the data-buffer footprint vs stages=2 and crashes for fp32 N>=64K on Blackwell (227 KB opt-in smem); the tiny widths are only optimal for the narrow-row corner that's not interesting to autotune.
- Both spaces deduplicate at construction (drop `threads_per_row > num_threads` and non-divisible CTA layouts).
- `prune_invalid_rmsnorm_{fwd,bwd}_configs` run as the `@autotune` early-prune step per call:
  - `threads_per_row * cluster_n > N` (over-clusters the row)
  - `use_tma=True` when `per_head=True` (the runtime `USE_TMA` guard would silently fall back, producing identical-timing duplicates in the bench).

## Interface dispatch

New top-level `rmsnorm_fwd_tuned` and `rmsnorm_bwd_tuned` entry points, each decorated with `@autotune`:

- Cache `key=` is `["is_layernorm", "per_head"]` for fwd and `["per_head", "has_dw_partial", "has_db_partial"]` for bwd. The autotuner auto-appends each tensor's shape, dtype, and abstracted stride to the key - adjacent N values produce distinct cache entries; same-shape repeat calls hit the cache.
- `cache_results=True` (default) persists the chosen config to `$QUACK_CACHE_DIR`.
- Calling `.fn(config=...)` bypasses the autotune dispatch entirely.

## Autotuner bench fix (`quack/autotuner.py`)

The default `triton.testing.do_bench` measures kernels with a single input tensor on every iteration - after the first warmup pass that tensor sits in L2, so the bench rewards configs that exploit cache reuse (wider thread layouts, deeper smem stages, TMA descriptors) which lose under production cache-cold workloads. Replaced with `_l2_cold_cuda_graph_bench`:

- **Warmup**: plain Python loop running the kernel N times round-robin over the pre-cloned input sets -- drains P-state transitions, warms launch path / kernel compile / smem alloc.
- **Timed window**: single `graph.replay()` of a captured CUDA graph whose body records N round-robin kernel launches -- no Python loop, no per-launch CPU overhead. `ms/call = elapsed / total_recorded_launches = aggregate bytes / aggregate replay time / device peak`.
- Cloned tensor sets allocated once per shape in `__call__.benchmark()` and shared across all ~400 configs (avoids 400x re-cloning per shape).
- Falls back to legacy `triton.do_bench` path when a custom `do_bench=` is supplied or pre/post hooks are configured (those hooks' clone/restore doesn't survive CUDA graph capture).

Without this fix the autotuner regularly mis-ranks at heuristic boundaries (e.g. `row_bytes = 16K`): an earlier run showed 16 cells regressing 5-10% across 256 shapes. With the fix, that drops to 2.

## Benchmarks on GB200

Measured on a single GB200 (NVIDIA HBM3e, 1020W) across **256 shapes** - `T x D in {1K, 2K, 4K, 8K, 12K, 16K, 24K, 32K}` x 4 dtype combos `{bf16/bf16, fp32/fp32, bf16/fp32, fp32/bf16}`. Baseline = current `quack/main` (analytical heuristic, post-#132). Comparison = `rmsnorm_bwd_tuned` with the autotune cache warmed once per shape.

### Speedup heatmap (4 dtype combos x TxD)

Fwd:

<img width="1748" height="1513" alt="image" src="https://github.com/user-attachments/assets/67ef6bad-5e96-4f05-9605-0ad018672b73" />

- **Geomean: +6.7%** 

Bwd:

<img width="1748" height="1513" alt="image" src="https://github.com/user-attachments/assets/3d3ef959-7415-40f7-85b8-a28b5911f0e5" />

- **Geomean: +4.9%**
- **Median: +2.3%**
- **Max: +31.9%**
- **Min: -5.8%**
- **Overall: 148 / 256 shapes faster** (>=0.5%), **0 shapes regressing > 10%**, **2 shapes regressing 5-10%** (`bf16/fp32 T=24K D=8K` and `bf16/bf16 T=32K D=12K`)

Per-dtype geomean: bf16/bf16 **+7.4%**, fp32/fp32 **+5.0%**, bf16/fp32 **+3.9%**, fp32/bf16 **+3.4%**.

Top wins concentrate in the `D in {2K, 4K}` band (+23 to +32% across bf16/bf16 and fp32/fp32) - exactly the corners #132's TODO list called out as conservative. The autotuner finds non-obvious config combinations the analytical ladder misses; biggest single win is +31.9% at `T=4K, D=4K, bf16/bf16`.

### %SOL utilization - main vs this MR

Same 256-shape grid expressed as **% of GB200 HBM3e peak (8 TB/s per GPU)**, on a fixed 0-100 RdYlGn scale so the two plots are directly cell-by-cell comparable.

main (analytical heuristic, post-#132):

<img width="1748" height="1513" alt="image" src="https://github.com/user-attachments/assets/d61f35ea-d882-49c8-ac40-efa9c375a31c" />

This MR (autotuner):

Bwd:

<img width="1748" height="1513" alt="image" src="https://github.com/user-attachments/assets/3cfa57cd-310a-4afc-ba22-b734f8b1995e" />

| dtype combo | main geomean %SOL | main peak %SOL | tuned geomean %SOL | tuned peak %SOL |
|-------------|-------------------|----------------|--------------------|-----------------|
| bf16/bf16   | 52                | 87             | 56                 | 86              |
| fp32/fp32   | 77                | 91             | 81                 | 91              |
| bf16/fp32   | 73                | 91             | 76                 | 90              |
| fp32/bf16   | 76                | 89             | 79                 | 89              |

Peak %SOL is essentially unchanged (the analytical heuristic already saturates bandwidth at the easy corners). Geomean lifts **+3-4 pp across all four dtype combos** - gains are concentrated in the mid-band where the autotuner finds non-obvious config combinations the analytical ladder misses.

## Tests

- 18 fwd + 16 bwd config-direct tests parametrize specific launch combinations (`reload_from`, `cluster_n`, `(num_threads, threads_per_row)` for fwd; same plus `reload_x`, `reload_wdy` for bwd) and verify numerical equivalence against `rmsnorm_ref` / `rmsnorm_bwd_ref` with bf16 tolerance x 2 (different configs pick different reduction trees).
- 2 end-to-end dispatch tests invoke `rmsnorm_{fwd,bwd}_tuned` without `.fn`, exercising the full `@autotune` flow (early-prune -> bench -> cache -> call) on M=N=256.
- 2 guard tests verify `.fn` raises `RuntimeError("...requires a config")` when called bare (without the decorator's config injection).
