### PR TITLE
Remove deprecation warning in 4.5

### DIFF
--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -965,11 +965,11 @@ class GemmSm100(GemmTmaBase):
         )
         # Tensor memory dealloc barrier init
         tmem = cutlass.utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
             is_two_cta=use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
         )
 
         # Cluster arrive after barrier init


### PR DESCRIPTION
See title, removing

```Shell
/home/drisspg/.venvs/flex/lib/python3.13/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/cute/core.py:5789: DeprecationWarning: Use explicit `struct.scalar.ptr` for pointer instead.
  warnings.warn
  ```