### PR TITLE
[Lint] Enable Ruff B904 rule

### DIFF
--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -74,8 +74,10 @@ def _torch_dtype(name: str) -> torch.dtype:
 def parse_comma_separated_ints(s: str):
     try:
         return tuple([int(x.strip()) for x in s.split(",")])
-    except ValueError:
-        raise argparse.ArgumentTypeError("Invalid format. Expected comma-separated integers.")
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            "Invalid format. Expected comma-separated integers."
+        ) from e
 
 
 def parse_cluster_shape_mnk(s: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ line-length = 100
 exclude = [".#*"]
 
 [tool.ruff.lint]
+extend-select = ["B904"]
 ignore = [
     "E731",  # do not assign a lambda expression, use a def
     "E741",  # Do not use variables named 'I', 'O', or 'l'


### PR DESCRIPTION
Enable B904 so exception chaining stays enforced going forward, and fix the remaining benchmark violation surfaced by the rule.