### PR TITLE
[Gemm] HotFix: Fix epi_load_barrier participant count when num_ab_load_warps > 1 in SM100

### DIFF
--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -1034,7 +1034,8 @@ class GemmSm100(GemmTmaBase):
         epi_load_barrier = None
         if const_expr(has_epi_load):
             epi_load_barrier = pipeline.NamedBarrier(
-                barrier_id=int(NamedBarrierGemm.EpilogueLoad), num_threads=(self.num_ab_load_warps + 1) * cute.arch.WARP_SIZE
+                barrier_id=int(NamedBarrierGemm.EpilogueLoad),
+                num_threads=(self.num_ab_load_warps + 1) * cute.arch.WARP_SIZE,
             )
 
         # Cluster wait before tensor memory alloc

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -1034,7 +1034,7 @@ class GemmSm100(GemmTmaBase):
         epi_load_barrier = None
         if const_expr(has_epi_load):
             epi_load_barrier = pipeline.NamedBarrier(
-                barrier_id=int(NamedBarrierGemm.EpilogueLoad), num_threads=2 * cute.arch.WARP_SIZE
+                barrier_id=int(NamedBarrierGemm.EpilogueLoad), num_threads=(self.num_ab_load_warps + 1) * cute.arch.WARP_SIZE
             )
 
         # Cluster wait before tensor memory alloc


### PR DESCRIPTION
## Summary
Fixes a hang in the SM100 GEMM epilogue-load synchronization barrier when gather_A is enabled (num_ab_load_warps == 4).

The EpilogueLoad named barrier coordinates the epilogue load warp with the A/B TMA load warps: on the first tile, all AB load warps call arrive() after finishing their initial TMA loads, and the epilogue load warp calls arrive_and_wait() before loading C / epilogue tensors, so epilogue TMA traffic does not contend with the first A/B loads.

The barrier was hard-coded to 2 * WARP_SIZE participants (one AB load warp + one epilogue load warp). That is correct when num_ab_load_warps == 1 (the default non-gather_A path), but wrong when num_ab_load_warps > 1: every AB load warp participates in arrive(), so the barrier must account for all num_ab_load_warps plus the single epilogue load warp.

With the wrong num_threads, the barrier never reaches the expected arrival count from the epilogue load warp’s perspective: once all AB load warps have arrived, arrive_and_wait() on the epilogue load warp can hang indefinitely.

## Root cause
```
# Before (incorrect for num_ab_load_warps > 1)
num_threads=2 * cute.arch.WARP_SIZE
# After
num_threads=(self.num_ab_load_warps + 1) * cute.arch.WARP_SIZE
```

num_ab_load_warps is 1 without gather_A and 4 with gather_A (see kernel warp layout setup). The barrier participant count must scale with the number of AB load warps that signal the barrier, not assume a single AB load warp.