### PR TITLE
add mxfp8 gemm gated and dgated in sm100

### DIFF
--- a/quack/blockscaled_gemm_utils.py
+++ b/quack/blockscaled_gemm_utils.py
@@ -739,6 +739,162 @@ def compile_blockscaled_gemm_tvm_ffi(
     return run
 
 
+def compile_blockscaled_gemm_gated_tvm_ffi(
+    ab_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    postact_dtype: Type[cutlass.Numeric],
+    activation: str,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    mA: torch.Tensor,
+    mB: torch.Tensor,
+    mSFA: torch.Tensor,
+    mSFB: torch.Tensor,
+    mAuxOut: torch.Tensor,
+    *,
+    use_clc_persistence: bool = True,
+) -> Callable:
+    device_capacity = get_device_capacity(mA.device)
+    if device_capacity[0] not in (10, 11):
+        raise RuntimeError("Blockscaled gated GEMM requires SM100/SM110")
+    # Local import avoids a module-load cycle (gemm_act imports gemm_tvm_ffi_utils,
+    # which this module also uses).
+    from quack.gemm_act import GemmGatedBlockscaledSm100
+    from quack.activation import gate_fn_map
+
+    gemm = partial(
+        GemmGatedBlockscaledSm100,
+        sf_vec_size=sf_vec_size,
+        use_clc_persistence=use_clc_persistence,
+    )(cutlass.Float32, ab_dtype, mma_tiler_mn, (*cluster_shape_mn, 1))
+    gate_fn = gate_fn_map[activation]
+
+    scheduler_args = make_scheduler_args(
+        get_max_active_clusters(cluster_shape_mn[0] * cluster_shape_mn[1]),
+        max_swizzle_size=8,
+        tile_count_semaphore=None,
+        batch_idx_permute=None,
+    )
+    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    fake_mA = _make_fake_compact_tensor(
+        mA.shape, ab_dtype, leading_dim=_leading_dim_from_stride(mA)
+    )
+    fake_mB = _make_fake_compact_tensor(
+        mB.shape, ab_dtype, leading_dim=_leading_dim_from_stride(mB)
+    )
+    fake_mAuxOut = _make_fake_compact_tensor(
+        mAuxOut.shape, postact_dtype, leading_dim=_leading_dim_from_stride(mAuxOut)
+    )
+
+    @cute.jit
+    def runner(a, b, sfa, sfb, aux, stream):
+        # act_fn (gate_fn) is a compile-time Constexpr captured from the closure.
+        epi = gemm.EpilogueArguments(aux, gate_fn)
+        # mD=None: only the post-activation aux output is stored.
+        gemm(a, b, None, None, epi, scheduler_args, VarlenArguments(), stream, sfa, sfb, None)
+
+    compiled = cute.compile(
+        runner,
+        fake_mA,
+        fake_mB,
+        _make_compile_tensor_like(mSFA, sf_dtype, dynamic_layout=True),
+        _make_compile_tensor_like(mSFB, sf_dtype, dynamic_layout=True),
+        fake_mAuxOut,
+        stream,
+        options="--enable-tvm-ffi",
+    )
+
+    def run(a, b, sfa, sfb, aux):
+        compiled(a, b, sfa, sfb, aux)
+
+    return run
+
+
+def compile_blockscaled_gemm_dgated_tvm_ffi(
+    ab_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    implicit_dtype: Type[cutlass.Numeric],
+    postact_dtype: Type[cutlass.Numeric],
+    activation: str,
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    mA: torch.Tensor,
+    mB: torch.Tensor,
+    mC: torch.Tensor,
+    mD: torch.Tensor,
+    mSFA: torch.Tensor,
+    mSFB: torch.Tensor,
+    mAuxOut: torch.Tensor,
+    *,
+    use_clc_persistence: bool = True,
+) -> Callable:
+    device_capacity = get_device_capacity(mA.device)
+    if device_capacity[0] not in (10, 11):
+        raise RuntimeError("Blockscaled dgated GEMM requires SM100/SM110")
+    from quack.gemm_dact import GemmDGatedBlockscaledSm100
+    from quack.activation import dgate_fn_map
+
+    gemm = partial(
+        GemmDGatedBlockscaledSm100,
+        sf_vec_size=sf_vec_size,
+        use_clc_persistence=use_clc_persistence,
+    )(cutlass.Float32, ab_dtype, mma_tiler_mn, (*cluster_shape_mn, 1))
+    gemm.implicit_dtype = implicit_dtype  # matches gemm_dact's post_init
+    act_bwd_fn = dgate_fn_map[activation]
+
+    scheduler_args = make_scheduler_args(
+        get_max_active_clusters(cluster_shape_mn[0] * cluster_shape_mn[1]),
+        max_swizzle_size=8,
+        tile_count_semaphore=None,
+        batch_idx_permute=None,
+    )
+    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    fake_mA = _make_fake_compact_tensor(
+        mA.shape, ab_dtype, leading_dim=_leading_dim_from_stride(mA)
+    )
+    fake_mB = _make_fake_compact_tensor(
+        mB.shape, ab_dtype, leading_dim=_leading_dim_from_stride(mB)
+    )
+    # C (PreAct) and D (dPreAct) are passed as 32-bit (packed bf16x2) tensors.
+    fake_mC = _make_fake_compact_tensor(
+        mC.shape, cutlass.Float32, leading_dim=_leading_dim_from_stride(mC)
+    )
+    fake_mD = _make_fake_compact_tensor(
+        mD.shape, cutlass.Float32, leading_dim=_leading_dim_from_stride(mD)
+    )
+    fake_mAuxOut = _make_fake_compact_tensor(
+        mAuxOut.shape, postact_dtype, leading_dim=_leading_dim_from_stride(mAuxOut)
+    )
+
+    @cute.jit
+    def runner(a, b, c, d, sfa, sfb, aux, stream):
+        epi = gemm.EpilogueArguments(aux, act_bwd_fn)
+        # __call__(mA, mB, mD, mC, ...): Out is D, PreAct is C.
+        gemm(a, b, d, c, epi, scheduler_args, VarlenArguments(), stream, sfa, sfb, None)
+
+    compiled = cute.compile(
+        runner,
+        fake_mA,
+        fake_mB,
+        fake_mC,
+        fake_mD,
+        _make_compile_tensor_like(mSFA, sf_dtype, dynamic_layout=True),
+        _make_compile_tensor_like(mSFB, sf_dtype, dynamic_layout=True),
+        fake_mAuxOut,
+        stream,
+        options="--enable-tvm-ffi",
+    )
+
+    def run(a, b, c, d, sfa, sfb, aux):
+        compiled(a, b, c, d, sfa, sfb, aux)
+
+    return run
+
+
 def blockscaled_gemm_reference(
     a_ref: torch.Tensor,
     b_ref: torch.Tensor,

--- a/quack/gemm_act.py
+++ b/quack/gemm_act.py
@@ -289,6 +289,10 @@ class GemmGatedSm100(GemmGatedMixin, GemmSm100):
     pass
 
 
+class GemmGatedBlockscaledSm100(GemmGatedSm100):
+    pass
+
+
 class GemmGatedSm120Mixin:
     @staticmethod
     def _compute_tile_shape_or_override(

--- a/quack/gemm_blockscaled_interface.py
+++ b/quack/gemm_blockscaled_interface.py
@@ -24,8 +24,11 @@ from torch import Tensor
 
 import cutlass
 
+from quack.activation import dgate_fn_map, gate_fn_map
 from quack.blockscaled_gemm_utils import (
     ceil_div,
+    compile_blockscaled_gemm_dgated_tvm_ffi,
+    compile_blockscaled_gemm_gated_tvm_ffi,
     compile_blockscaled_gemm_tvm_ffi,
     pack_scale_2d_to_blocked_contig,
     scale_blocked_for_cublas,
@@ -303,6 +306,165 @@ def mxfp8_gemm_cublas(
         out_dtype=out_dtype,
     )
     return out if was_2d else out.unsqueeze(0)
+
+
+# ---------------------------------------------------------------------------
+# Gated (SwiGLU/GeGLU) forward + backward — blockscaled MXFP8
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=64)
+def _compile_gated_cached(
+    m, n_full, k, l, mma_tiler_mn, cluster_shape_mn, activation, out_torch_dtype
+):
+    dev = torch.device("cuda")
+    n_out = n_full // 2
+    rm, rn = ceil_div(m, 128), ceil_div(n_full, 128)
+    rk = ceil_div(k // _SF_VEC_SIZE, 4)
+    fake_mA = torch.empty(l, m, k, dtype=torch.float8_e4m3fn, device=dev).permute(1, 2, 0)
+    fake_mB = torch.empty(l, n_full, k, dtype=torch.float8_e4m3fn, device=dev).permute(1, 2, 0)
+    fake_aux = torch.empty(l, m, n_out, dtype=out_torch_dtype, device=dev).permute(1, 2, 0)
+    fake_sc_A = torch.empty(l, rm, rk, 512, dtype=torch.float8_e8m0fnu, device=dev)
+    fake_sc_B = torch.empty(l, rn, rk, 512, dtype=torch.float8_e8m0fnu, device=dev)
+    fake_mSFA = scale_view_for_kernel(fake_sc_A, m, k // _SF_VEC_SIZE, l)
+    fake_mSFB = scale_view_for_kernel(fake_sc_B, n_full, k // _SF_VEC_SIZE, l)
+    return compile_blockscaled_gemm_gated_tvm_ffi(
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E8M0FNU,
+        _SF_VEC_SIZE,
+        _TORCH_TO_CUTLASS_D[out_torch_dtype],
+        activation,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        fake_mA,
+        fake_mB,
+        fake_mSFA,
+        fake_mSFB,
+        fake_aux,
+    )
+
+
+def mxfp8_gemm_gated(
+    A: Tensor,
+    B: Tensor,
+    A_scale: Tensor,
+    B_scale: Tensor,
+    activation: str,
+    out: Optional[Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    *,
+    mma_tiler_mn: Optional[Tuple[int, int]] = None,
+    cluster_shape_mn: Optional[Tuple[int, int]] = None,
+) -> Tensor:
+    assert activation in gate_fn_map, f"unknown gate activation {activation!r}"
+    m, n_full, k, l, mA, mB, _scA, _scB, sfa, sfb, was_2d = _to_kernel_layout(
+        A, B, A_scale, B_scale
+    )
+    assert n_full % 2 == 0, f"fused N ({n_full}) must be even"
+    n_out = n_full // 2
+    assert out_dtype in _TORCH_TO_CUTLASS_D, f"unsupported out dtype: {out_dtype}"
+    if out is None:
+        out = torch.empty((m, n_out) if was_2d else (l, m, n_out), dtype=out_dtype, device=A.device)
+    else:
+        assert out.dtype in _TORCH_TO_CUTLASS_D, f"unsupported out dtype: {out.dtype}"
+    assert out.is_contiguous(), "out must be contiguous"
+    out_3d = out.unsqueeze(0) if was_2d else out  # (l, m, n_out)
+    mAuxOut = out_3d.permute(1, 2, 0)  # (m, n_out, l), N-major
+
+    if mma_tiler_mn is None or cluster_shape_mn is None:
+        tlr, clu = _default_tiler_cluster(m, n_full)
+        mma_tiler_mn = mma_tiler_mn or tlr
+        cluster_shape_mn = cluster_shape_mn or clu
+    runner = _compile_gated_cached(
+        m, n_full, k, l, mma_tiler_mn, cluster_shape_mn, activation, out.dtype
+    )
+    runner(mA, mB, sfa, sfb, mAuxOut)
+    return out
+
+
+@lru_cache(maxsize=64)
+def _compile_dgated_cached(
+    m, n, k, l, mma_tiler_mn, cluster_shape_mn, activation, postact_torch_dtype
+):
+    dev = torch.device("cuda")
+    rm, rn = ceil_div(m, 128), ceil_div(n, 128)
+    rk = ceil_div(k // _SF_VEC_SIZE, 4)
+    fake_mA = torch.empty(l, m, k, dtype=torch.float8_e4m3fn, device=dev).permute(1, 2, 0)
+    fake_mB = torch.empty(l, n, k, dtype=torch.float8_e4m3fn, device=dev).permute(1, 2, 0)
+    # C (PreAct) / D (dPreAct) are (l, m, 2n) 16-bit, viewed as (l, m, n) f32, N-major.
+    fake_C = torch.empty(l, m, 2 * n, dtype=postact_torch_dtype, device=dev)
+    fake_D = torch.empty(l, m, 2 * n, dtype=postact_torch_dtype, device=dev)
+    fake_C = fake_C.view(torch.float32).permute(1, 2, 0)
+    fake_D = fake_D.view(torch.float32).permute(1, 2, 0)
+    fake_aux = torch.empty(l, m, n, dtype=postact_torch_dtype, device=dev).permute(1, 2, 0)
+    fake_sc_A = torch.empty(l, rm, rk, 512, dtype=torch.float8_e8m0fnu, device=dev)
+    fake_sc_B = torch.empty(l, rn, rk, 512, dtype=torch.float8_e8m0fnu, device=dev)
+    fake_mSFA = scale_view_for_kernel(fake_sc_A, m, k // _SF_VEC_SIZE, l)
+    fake_mSFB = scale_view_for_kernel(fake_sc_B, n, k // _SF_VEC_SIZE, l)
+    sf_dtype_d = _TORCH_TO_CUTLASS_D[postact_torch_dtype]
+    return compile_blockscaled_gemm_dgated_tvm_ffi(
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E8M0FNU,
+        _SF_VEC_SIZE,
+        sf_dtype_d,  # implicit_dtype (the 16-bit packed element)
+        sf_dtype_d,  # postact_dtype
+        activation,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        fake_mA,
+        fake_mB,
+        fake_C,
+        fake_D,
+        fake_mSFA,
+        fake_mSFB,
+        fake_aux,
+    )
+
+
+def mxfp8_gemm_dgated(
+    A: Tensor,
+    B: Tensor,
+    A_scale: Tensor,
+    B_scale: Tensor,
+    PreAct: Tensor,
+    activation: str,
+    dPreAct: Optional[Tensor] = None,
+    PostAct: Optional[Tensor] = None,
+    *,
+    mma_tiler_mn: Optional[Tuple[int, int]] = None,
+    cluster_shape_mn: Optional[Tuple[int, int]] = None,
+) -> Tuple[Tensor, Tensor]:
+    assert activation in dgate_fn_map, f"unknown dgate activation {activation!r}"
+    m, n, k, l, mA, mB, _scA, _scB, sfa, sfb, was_2d = _to_kernel_layout(A, B, A_scale, B_scale)
+    assert PreAct.dtype in _TORCH_TO_CUTLASS_D and PreAct.element_size() == 2, (
+        f"PreAct must be bf16/fp16, got {PreAct.dtype}"
+    )
+    PreAct3 = _as_3d(PreAct, PreAct.dim())  # (l, m, 2n)
+    assert tuple(PreAct3.shape) == (l, m, 2 * n), (
+        f"PreAct shape: expected (l={l}, m={m}, 2n={2 * n}), got {tuple(PreAct3.shape)}"
+    )
+    assert PreAct3.is_contiguous(), "PreAct must be contiguous (row-major)"
+
+    if dPreAct is None:
+        dPreAct = torch.empty_like(PreAct)
+    if PostAct is None:
+        PostAct = torch.empty((m, n) if was_2d else (l, m, n), dtype=PreAct.dtype, device=A.device)
+    dPreAct3 = _as_3d(dPreAct, dPreAct.dim())
+    PostAct3 = _as_3d(PostAct, PostAct.dim())
+    assert dPreAct3.is_contiguous() and PostAct3.is_contiguous()
+
+    # 16-bit (l, m, 2n) -> f32 (l, m, n) -> (m, n, l) N-major view (no copy).
+    mC = PreAct3.view(torch.float32).permute(1, 2, 0)
+    mD = dPreAct3.view(torch.float32).permute(1, 2, 0)
+    mAuxOut = PostAct3.permute(1, 2, 0)  # (m, n, l) N-major
+
+    if mma_tiler_mn is None or cluster_shape_mn is None:
+        tlr, clu = _default_tiler_cluster(m, n)
+        mma_tiler_mn = mma_tiler_mn or tlr
+        cluster_shape_mn = cluster_shape_mn or clu
+    runner = _compile_dgated_cached(
+        m, n, k, l, mma_tiler_mn, cluster_shape_mn, activation, PreAct.dtype
+    )
+    runner(mA, mB, mC, mD, sfa, sfb, mAuxOut)
+    return dPreAct, PostAct
 
 
 def mxfp8_gemm_ref(

--- a/quack/gemm_dact.py
+++ b/quack/gemm_dact.py
@@ -233,6 +233,10 @@ class GemmDGatedSm100(GemmDGatedMixin, GemmSm100):
     pass
 
 
+class GemmDGatedBlockscaledSm100(GemmDGatedSm100):
+    pass
+
+
 class GemmDGatedSm120(GemmDGatedMixin, GemmSm120):
     pass
 

--- a/tests/test_gemm_sm100_blockscaled_gated.py
+++ b/tests/test_gemm_sm100_blockscaled_gated.py
@@ -1,0 +1,174 @@
+import pytest
+import torch
+
+
+_SF_VEC = 32
+
+
+def _skip_if_not_sm100():
+    if torch.cuda.get_device_properties(0).major < 10:
+        pytest.skip("SM100+ required")
+
+
+def _dequant(q: torch.Tensor, sc: torch.Tensor) -> torch.Tensor:
+    return q.float() * sc.float().repeat_interleave(_SF_VEC, dim=-1)
+
+
+def _gated_ref(A_q, A_sc, W_q, W_sc, activation):
+    from quack.gemm_interface import gated_to_pytorch_fn_map
+
+    a_dq = _dequant(A_q, A_sc)  # (..., m, k)
+    b_dq = _dequant(W_q, W_sc)  # (..., n_full, k)
+    full = a_dq @ b_dq.transpose(-1, -2)  # (..., m, n_full)
+    gate, up = full[..., ::2], full[..., 1::2]
+    return gated_to_pytorch_fn_map[activation](gate, up)
+
+
+@pytest.mark.parametrize("activation", ["swiglu", "reglu", "geglu"])
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize(
+    "m,n_out,k",
+    [
+        (256, 64, 256),  # n_full=128, single N-tile
+        (256, 128, 256),  # n_full=256
+        (512, 256, 512),  # n_full=512, larger K
+    ],
+)
+def test_mxfp8_gemm_gated(m, n_out, k, batched, activation):
+    _skip_if_not_sm100()
+    from quack.gemm_blockscaled_interface import mxfp8_gemm_gated, mxfp8_quantize
+
+    n_full = 2 * n_out
+    L = 2 if batched else 1
+    torch.manual_seed(0)
+    shape_A = (L, m, k) if batched else (m, k)
+    # Fused gate/up weight stored nn.Linear-style (n_full, k) row-major.
+    shape_W = (L, n_full, k) if batched else (n_full, k)
+    A_hp = torch.randn(*shape_A, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    W_hp = torch.randn(*shape_W, device="cuda", dtype=torch.bfloat16) * k**-0.5
+
+    A_q, A_sc = mxfp8_quantize(A_hp)  # (..., m, k), (..., m, k/32)
+    W_q, W_sc = mxfp8_quantize(W_hp)  # (..., n_full, k), (..., n_full, k/32)
+
+    # Pass .mT to reach the (K, N) K-contig layout the interface expects.
+    out = mxfp8_gemm_gated(A_q, W_q.mT, A_sc, W_sc.mT, activation)
+    assert out.shape == ((L, m, n_out) if batched else (m, n_out))
+    assert out.dtype == torch.bfloat16
+
+    ref = _gated_ref(A_q, A_sc, W_q, W_sc, activation)
+    err = (out.float() - ref.float()).abs().max().item()
+    scale = ref.float().abs().max().item() + 1e-6
+    # fp8 inputs + gate activation + bf16 output rounding.
+    assert err < 2e-2 or err / scale < 5e-2, f"max_err={err}, rel={err / scale}"
+
+
+def test_mxfp8_gemm_gated_preallocated_out():
+    _skip_if_not_sm100()
+    from quack.gemm_blockscaled_interface import mxfp8_gemm_gated, mxfp8_quantize
+
+    m, n_out, k = 256, 128, 256
+    torch.manual_seed(0)
+    A_hp = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    W_hp = torch.randn(2 * n_out, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    A_q, A_sc = mxfp8_quantize(A_hp)
+    W_q, W_sc = mxfp8_quantize(W_hp)
+
+    out_alloc = mxfp8_gemm_gated(A_q, W_q.mT, A_sc, W_sc.mT, "swiglu")
+    out_pre = torch.empty(m, n_out, device="cuda", dtype=torch.bfloat16)
+    mxfp8_gemm_gated(A_q, W_q.mT, A_sc, W_sc.mT, "swiglu", out=out_pre)
+    assert torch.equal(out_alloc, out_pre)
+
+
+@pytest.mark.parametrize(
+    "mma_tiler_mn,cluster_shape_mn,m,n_out,k",
+    [
+        ((128, 128), (1, 1), 256, 128, 256),
+        ((256, 128), (2, 1), 512, 128, 256),  # 2-CTA path (M=256 tile)
+    ],
+)
+def test_mxfp8_gemm_gated_tiler_override(mma_tiler_mn, cluster_shape_mn, m, n_out, k):
+    _skip_if_not_sm100()
+    from quack.gemm_blockscaled_interface import mxfp8_gemm_gated, mxfp8_quantize
+
+    n_full = 2 * n_out
+    torch.manual_seed(0)
+    A_hp = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    W_hp = torch.randn(n_full, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    A_q, A_sc = mxfp8_quantize(A_hp)
+    W_q, W_sc = mxfp8_quantize(W_hp)
+
+    out = mxfp8_gemm_gated(
+        A_q,
+        W_q.mT,
+        A_sc,
+        W_sc.mT,
+        "swiglu",
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+    )
+    ref = _gated_ref(A_q, A_sc, W_q, W_sc, "swiglu")
+    err = (out.float() - ref.float()).abs().max().item()
+    scale = ref.float().abs().max().item() + 1e-6
+    assert err < 2e-2 or err / scale < 5e-2, f"max_err={err}, rel={err / scale}"
+
+
+# ---------------------------------------------------------------------------
+# Backward gated (dSwiGLU / dGeGLU / dReGLU)
+# ---------------------------------------------------------------------------
+import torch.nn.functional as F  # noqa: E402
+
+_FWD_ACT = {
+    "swiglu": lambda g: F.silu(g),
+    "reglu": lambda g: F.relu(g),
+    "geglu": lambda g: F.gelu(g, approximate="tanh"),
+}
+
+
+def _dgated_ref(A_q, A_sc, W_q, W_sc, PreAct, activation):
+    dy = (_dequant(A_q, A_sc) @ _dequant(W_q, W_sc).transpose(-1, -2)).float()
+    gate = PreAct[..., ::2].float().detach().clone().requires_grad_()
+    up = PreAct[..., 1::2].float().detach().clone().requires_grad_()
+    y = _FWD_ACT[activation](gate) * up
+    y.backward(dy)
+    return gate.grad, up.grad, y.detach()
+
+
+@pytest.mark.parametrize("activation", ["swiglu", "reglu", "geglu"])
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("m,n,k", [(256, 128, 256), (512, 256, 512)])
+def test_mxfp8_gemm_dgated(m, n, k, batched, activation):
+    _skip_if_not_sm100()
+    from quack.gemm_blockscaled_interface import mxfp8_gemm_dgated, mxfp8_quantize
+
+    L = 2 if batched else 1
+    torch.manual_seed(0)
+    # A @ W.T = dy  (m, n).  A=(m,k) is e.g. quantized dout; W=(n,k) is e.g. W2.
+    shape_A = (L, m, k) if batched else (m, k)
+    shape_W = (L, n, k) if batched else (n, k)
+    A_hp = torch.randn(*shape_A, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    W_hp = torch.randn(*shape_W, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    A_q, A_sc = mxfp8_quantize(A_hp)
+    W_q, W_sc = mxfp8_quantize(W_hp)
+
+    # Forward pre-activation [gate; up] interleaved, (..., m, 2n).
+    pre_shape = (L, m, 2 * n) if batched else (m, 2 * n)
+    PreAct = torch.randn(*pre_shape, device="cuda", dtype=torch.bfloat16)
+
+    dPreAct, PostAct = mxfp8_gemm_dgated(A_q, W_q.mT, A_sc, W_sc.mT, PreAct, activation)
+    assert dPreAct.shape == PreAct.shape
+    assert PostAct.shape == ((L, m, n) if batched else (m, n))
+    assert dPreAct.dtype == torch.bfloat16 and PostAct.dtype == torch.bfloat16
+
+    dgate_ref, dup_ref, y_ref = _dgated_ref(A_q, A_sc, W_q, W_sc, PreAct, activation)
+
+    def _close(got, ref):
+        err = (got.float() - ref.float()).abs().max().item()
+        scale = ref.float().abs().max().item() + 1e-6
+        return err < 2e-2 or err / scale < 5e-2, err, err / scale
+
+    ok_y, e_y, r_y = _close(PostAct, y_ref)
+    ok_g, e_g, r_g = _close(dPreAct[..., ::2], dgate_ref)
+    ok_u, e_u, r_u = _close(dPreAct[..., 1::2], dup_ref)
+    assert ok_y, f"PostAct max_err={e_y}, rel={r_y}"
+    assert ok_g, f"dgate max_err={e_g}, rel={r_g}"
+    assert ok_u, f"dup max_err={e_u}, rel={r_u}"


### PR DESCRIPTION
This PR adds `GemmGatedBlockscaledSm100` and `GemmDGatedBlockscaledSm100` for MXFP8 version of `gemm_gated` and `gemm_dgated`. Tested on B200 only.