### PR TITLE
[Autotuner] Fix BrokenPipeError root cause

### DIFF
--- a/quack/_compile_worker.py
+++ b/quack/_compile_worker.py
@@ -167,8 +167,14 @@ def main():
                     fake_args.append(_make_fake_tensor(meta))
                 else:
                     fake_args.append(meta)
+            fake_kwargs = {}
+            for k, v in kwargs.items():
+                if isinstance(v, dict) and "shape" in v:
+                    fake_kwargs[k] = _make_fake_tensor(v)
+                else:
+                    fake_kwargs[k] = v
             try:
-                fn(*fake_args, **kwargs, **config_kwargs)
+                fn(*fake_args, **fake_kwargs, **config_kwargs)
                 _send(stdout, "OK")
             except Exception as e:
                 _send(stdout, f"ERR:{e}")

--- a/quack/autotuner.py
+++ b/quack/autotuner.py
@@ -400,6 +400,17 @@ class Autotuner:
             else:
                 tensor_meta.append(arg)
 
+        tensor_meta_kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, Tensor):
+                tensor_meta_kwargs[k] = {
+                    "shape": list(v.shape),
+                    "stride": list(v.stride()),
+                    "dtype": str(v.dtype),
+                }
+            else:
+                tensor_meta_kwargs[k] = v
+
         fn_module = self.fn.__module__
         fn_qualname = self.fn.__qualname__
 
@@ -450,7 +461,7 @@ class Autotuner:
                         "fn_module": fn_module,
                         "fn_qualname": fn_qualname,
                         "tensor_meta": tensor_meta,
-                        "kwargs": kwargs,
+                        "kwargs": tensor_meta_kwargs,
                         "config_kwargs": config.all_kwargs(),
                     },
                 )


### PR DESCRIPTION
Hi, I noticed that some gemm configs weren't compiled due to caught `BrokenPipeError`s from https://github.com/Dao-AILab/quack/blob/99bd7973bf3dc6db40961e413d4bdfea6c6fee3e/quack/autotuner.py#L446-L459

This turned out to happen when we sent tensors in the `kwargs`, which would crash when other non 0 ranks would try to load them up. Switching to using `tensor_meta` like `args` ended up fixing this.