### PR TITLE
Epi Mixins: Add support for variadic aux outputs for epi visitors

### DIFF
--- a/quack/activation.py
+++ b/quack/activation.py
@@ -21,17 +21,24 @@ sub_packed_f32x2 = partial(
 
 
 @dsl_user_op
-def tanh(a: float | Float32, *, loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value(loc=loc, ip=ip)],
-            "tanh.approx.f32 $0, $1;",
-            "=f,f",
-            has_side_effects=False,
-            is_align_stack=False,
+def tanh(x: F32_or_F32x2, *, loc=None, ip=None) -> F32_or_F32x2:
+    @dsl_user_op
+    def impl(a: float | Float32, *, loc=None, ip=None) -> Float32:
+        return Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [Float32(a).ir_value(loc=loc, ip=ip)],
+                "tanh.approx.f32 $0, $1;",
+                "=f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+            )
         )
-    )
+
+    if const_expr(not isinstance(x, tuple)):
+        return impl(x, loc=loc, ip=ip)
+    else:
+        return (impl(x[0], loc=loc, ip=ip), impl(x[1], loc=loc, ip=ip))
 
 
 @dsl_user_op
@@ -727,6 +734,7 @@ act_fn_map = {
     "relu": relu,
     "relu_sq": relu_sq,
     "gelu_tanh_approx": gelu_tanh_approx,
+    "tanh": tanh,
 }
 
 dact_fn_map = {
@@ -736,6 +744,9 @@ dact_fn_map = {
     "relu": drelu,
     "relu_sq": drelu_sq,
     "gelu_tanh_approx": dgelu_tanh_approx,
+    # "tanh" is intentionally absent: only the forward epilogue exists. Adding a
+    # None entry would make gemm_dact silently skip the derivative (the identity
+    # path reserved for activation=None) instead of rejecting the activation.
 }
 
 gate_fn_map = {

--- a/quack/gemm_act.py
+++ b/quack/gemm_act.py
@@ -115,10 +115,11 @@ class GemmActMixin(ComposableEpiMixin):
     ):
         """Setup aux output TMA copies and partitions before the epilogue loop.
 
-        Returns None when mAuxOut wasn't supplied so the framework skips the aux-out path.
+        Returns an empty tuple when mAuxOut wasn't supplied so the framework
+        skips the aux-out path.
         """
         if getattr(params, "mAuxOut", None) is None:
-            return None
+            return ()
         sAuxOut = epi_smem_tensors["mAuxOut"]
         tiled_copy_aux_out_r2s = self.epi_make_aux_out_tiled_copy_r2s(
             params, tiled_copy_r2s, tiled_copy_t2r
@@ -133,11 +134,18 @@ class GemmActMixin(ComposableEpiMixin):
             sAuxOut,
             tile_coord_mnkl,
         )
-        return tiled_copy_aux_out_r2s, tRS_sAuxOut, copy_aux_out
+        return ((tiled_copy_aux_out_r2s, tRS_sAuxOut, copy_aux_out),)
 
     @cute.jit
     def epi_convert_aux_out(
-        self, tRS_rAuxOut, sr_seed, tidx, tile_coord_mnkl, num_prev_subtiles, epi_idx
+        self,
+        output_idx: cutlass.Constexpr[int],
+        tRS_rAuxOut,
+        sr_seed,
+        tidx,
+        tile_coord_mnkl,
+        num_prev_subtiles,
+        epi_idx,
     ):
         """Convert aux output from acc_dtype to aux_out_dtype. Override for custom postprocessing."""
         if const_expr(
@@ -164,7 +172,7 @@ class GemmActMixin(ComposableEpiMixin):
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
         GemmDefaultEpiMixin.epi_visit_subtile(self, params, epi_loop_tensors, tRS_rD, tRS_rC)
         # Apply activation function if provided
         # If we don't have .shape here, the compiler generates local stores and loads
@@ -180,7 +188,7 @@ class GemmActMixin(ComposableEpiMixin):
                     )
         else:
             tRS_rAuxOut = tRS_rD
-        return tRS_rAuxOut
+        return (tRS_rAuxOut,)
 
 
 class GemmActSm90(GemmActMixin, GemmSm90):
@@ -249,7 +257,7 @@ class GemmGatedMixin(GemmActMixin):
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
         GemmDefaultEpiMixin.epi_visit_subtile(self, params, epi_loop_tensors, tRS_rD, tRS_rC)
         tRS_rAuxOut_layout = cute.recast_layout(2, 1, tRS_rD.layout)
         # If we don't have .shape here, the compiler generates local stores and loads
@@ -262,14 +270,28 @@ class GemmGatedMixin(GemmActMixin):
                 tRS_rAuxOut[2 * i], tRS_rAuxOut[2 * i + 1] = params.act_fn(
                     (tRS_rD[4 * i], tRS_rD[4 * i + 2]), (tRS_rD[4 * i + 1], tRS_rD[4 * i + 3])
                 )
-        return tRS_rAuxOut
+        return (tRS_rAuxOut,)
 
     @cute.jit
     def epi_convert_aux_out(
-        self, tRS_rAuxOut, sr_seed, tidx, tile_coord_mnkl, num_prev_subtiles, epi_idx
+        self,
+        output_idx: cutlass.Constexpr[int],
+        tRS_rAuxOut,
+        sr_seed,
+        tidx,
+        tile_coord_mnkl,
+        num_prev_subtiles,
+        epi_idx,
     ):
         tRS_rAuxOut_out = GemmActMixin.epi_convert_aux_out(
-            self, tRS_rAuxOut, sr_seed, tidx, tile_coord_mnkl, num_prev_subtiles, epi_idx
+            self,
+            output_idx,
+            tRS_rAuxOut,
+            sr_seed,
+            tidx,
+            tile_coord_mnkl,
+            num_prev_subtiles,
+            epi_idx,
         )
         if const_expr(self.arch in (90, 120)):
             # Only need this if we're using STSM

--- a/quack/gemm_base.py
+++ b/quack/gemm_base.py
@@ -93,8 +93,12 @@ class GemmBase:
             and self.d_dtype == cutlass.BFloat16
         )
 
-        # Setup aux output (returns None for default epilogue, context tuple for Act)
-        aux_out_ctx = self.epi_setup_aux_out(
+        # Setup aux outputs. Returns a tuple of ``(tiled_copy_r2s,
+        # tRS_sAuxOut, copy_aux_out)`` triples — empty for the default
+        # epilogue, one entry for the standard ``GemmAct``/``GemmGated``
+        # single-output mixins, multiple entries for multi-output mixins
+        # (e.g. ``T*tanh`` + ``1-tanh^2`` from one GEMM).
+        aux_out_ctxs = self.epi_setup_aux_out(
             params,
             epi_smem_tensors,
             tiled_copy_r2s,
@@ -178,7 +182,10 @@ class GemmBase:
                         src_idx=epi_coord_C,
                         dst_idx=(epi_idx + self.epi_c_stage) % self.epi_c_stage,
                     )
-            tRS_rAuxOut = self.epi_visit_subtile(params, epi_loop_tensors, tRS_rD, tRS_rC)
+            # Returns a tuple of register tensors — one per aux output.
+            # Length matches ``aux_out_ctxs``. ``()`` for the default
+            # epilogue (no aux output).
+            tRS_rAuxOuts = self.epi_visit_subtile(params, epi_loop_tensors, tRS_rD, tRS_rC)
             self.epi_end_loop(
                 params,
                 epi_tensors,
@@ -190,15 +197,19 @@ class GemmBase:
                 varlen_manager,
                 tidx,
             )
-            if const_expr(aux_out_ctx is not None):
-                tRS_rAuxOut_out = self.epi_convert_aux_out(
-                    tRS_rAuxOut,
+            # Convert each output to its storage dtype.
+            tRS_rAuxOuts_out = tuple(
+                self.epi_convert_aux_out(
+                    i,
+                    tRS_rAuxOuts[i],
                     epi_loop_tensors.get("sr_seed"),
                     tidx,
                     tile_coord_mnkl,
                     num_prev_subtiles,
                     epi_idx,
                 )
+                for i in range(len(aux_out_ctxs))
+            )
             if const_expr(use_tma_epi):
                 if is_tma_warp:
                     epi_store_pipeline.producer_acquire()
@@ -218,12 +229,15 @@ class GemmBase:
                     copy_utils.sr_cvt_copy(tiled_copy_r2s, tRS_rD, tRS_sD_cur, seed, tidx)
                 else:
                     copy_utils.cvt_copy(tiled_copy_r2s, tRS_rD, tRS_sD_cur)
-            if const_expr(aux_out_ctx is not None):
-                tiled_copy_aux_out_r2s, tRS_sAuxOut, copy_aux_out = aux_out_ctx
+            # Copy each aux output from registers to shared memory. All share
+            # the same ``epi_buffer`` index so the s2g TMA stores below happen
+            # in lockstep after the fence.
+            for i in cutlass.range_constexpr(len(aux_out_ctxs)):
+                tiled_copy_aux_out_r2s, tRS_sAuxOut, _ = aux_out_ctxs[i]
                 cute.copy(
                     tiled_copy_aux_out_r2s,
                     # Need contiguous for Sm80 and Sm120 where acc layout is ((2, 2), MMA_M, MMA_N)
-                    copy_utils.contiguous(tiled_copy_aux_out_r2s.retile(tRS_rAuxOut_out)),
+                    copy_utils.contiguous(tiled_copy_aux_out_r2s.retile(tRS_rAuxOuts_out[i])),
                     tRS_sAuxOut[None, None, None, epi_buffer],
                 )
             if const_expr(use_tma_epi):
@@ -232,14 +246,16 @@ class GemmBase:
                 if is_tma_warp:
                     if const_expr(has_D):
                         copy_D(src_idx=epi_buffer, dst_idx=epi_coord)
-                    if const_expr(aux_out_ctx is not None):
+                    for i in cutlass.range_constexpr(len(aux_out_ctxs)):
+                        _, _, copy_aux_out = aux_out_ctxs[i]
                         copy_aux_out(src_idx=epi_buffer, dst_idx=epi_coord)
                     epi_store_pipeline.producer_commit()
             else:
                 epilogue_barrier.arrive_and_wait()
                 if const_expr(has_D):
                     copy_D(src_idx=epi_buffer, dst_idx=epi_coord)
-                if const_expr(aux_out_ctx is not None):
+                for i in cutlass.range_constexpr(len(aux_out_ctxs)):
+                    _, _, copy_aux_out = aux_out_ctxs[i]
                     copy_aux_out(src_idx=epi_buffer, dst_idx=epi_coord)
                 epilogue_barrier.arrive_and_wait()
 
@@ -370,8 +386,8 @@ class GemmBase:
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
-        return None
+    ) -> Tuple[cute.Tensor, ...]:
+        return ()
 
     def epi_visit_acc(
         self,
@@ -462,14 +478,27 @@ class GemmBase:
         varlen_manager,
         tidx,
     ):
-        """Default epilogue has no aux output."""
-        return None
+        """Return a tuple of ``(tiled_copy_r2s, tRS_sAuxOut, copy_aux_out)``
+        triples — one per aux output. The default epilogue has no aux output,
+        so the tuple is empty.
+        """
+        return ()
 
     @cute.jit
     def epi_convert_aux_out(
-        self, tRS_rAuxOut, sr_seed, tidx, tile_coord_mnkl, num_prev_subtiles, epi_idx
+        self,
+        output_idx: cutlass.Constexpr[int],
+        tRS_rAuxOut,
+        sr_seed,
+        tidx,
+        tile_coord_mnkl,
+        num_prev_subtiles,
+        epi_idx,
     ):
-        """Convert aux output from acc_dtype to output dtype. Override for custom postprocessing."""
+        """Convert one aux output register tensor from acc_dtype to its storage
+        dtype. ``output_idx`` selects which aux output this call is for
+        (single-output mixins can ignore it).
+        """
         return tRS_rAuxOut
 
 

--- a/quack/gemm_dact.py
+++ b/quack/gemm_dact.py
@@ -51,7 +51,7 @@ class GemmDActMixin(GemmActMixin):
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
         assert tRS_rC is not None
         # We don't add C to the accumulator
         GemmDefaultEpiMixin.epi_visit_subtile(self, params, epi_loop_tensors, tRS_rD, tRS_rC=None)
@@ -74,7 +74,7 @@ class GemmDActMixin(GemmActMixin):
                     )
         else:
             tRS_rAuxOut = tRS_rC_acc
-        return tRS_rAuxOut
+        return (tRS_rAuxOut,)
 
 
 class GemmDActSm90(GemmDActMixin, GemmSm90):
@@ -138,7 +138,7 @@ class GemmDGatedMixin(GemmActMixin):
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
         tDrColVec = epi_loop_tensors.get("mColVecBroadcast")
         tDrColVecReduce = epi_loop_tensors.get("mColVecReduce")
         assert tRS_rC is not None
@@ -216,7 +216,7 @@ class GemmDGatedMixin(GemmActMixin):
         tRS_rdXY_f16x2 = cute.make_rmem_tensor(tRS_rdXY_f32x2.layout, implicit_dtype)
         tRS_rdXY_f16x2.store(tRS_rdXY_f32x2.load().to(implicit_dtype))
         tRS_rD.store(cute.recast_tensor(tRS_rdXY_f16x2, Float32).load())
-        return tRS_rOut
+        return (tRS_rOut,)
 
     # epi_end is inherited from ComposableEpiMixin → delegates to ColVecReduce.end()
 

--- a/quack/gemm_default_epi.py
+++ b/quack/gemm_default_epi.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2025, Wentao Guo, Tri Dao.
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
@@ -53,7 +53,13 @@ class GemmDefaultEpiMixin(ComposableEpiMixin):
         epi_loop_tensors,
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
+        """Return a tuple of register tensors (one per aux output).
+
+        The returned tuple must be the same length as the tuple returned
+        from :meth:`epi_setup_aux_out`. The default impl returns ``()`` —
+        no aux outputs.
+        """
         # Use .get(): inactive ops are filtered out of epi_loop_tensors.
         alpha = epi_loop_tensors.get("alpha")
         beta = epi_loop_tensors.get("beta")
@@ -79,7 +85,7 @@ class GemmDefaultEpiMixin(ComposableEpiMixin):
         if const_expr(tDrColVec is not None):
             for i in cutlass.range(cute.size(tDrColVec), unroll_full=True):
                 tRS_rD[i] += tDrColVec[i]
-        return None
+        return ()
 
 
 class GemmDefaultSm80(GemmDefaultEpiMixin, GemmSm80):

--- a/quack/gemm_norm_act.py
+++ b/quack/gemm_norm_act.py
@@ -55,7 +55,7 @@ class GemmNormActMixin(GemmActMixin):
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
         tDrRowVec = epi_loop_tensors.get("mRowVecBroadcast")
         tDrColVec = epi_loop_tensors.get("mColVecBroadcast")
         # Load accumulator and apply alpha/beta/C
@@ -85,7 +85,7 @@ class GemmNormActMixin(GemmActMixin):
                     )
         else:
             tRS_rAuxOut = tRS_rD
-        return tRS_rAuxOut
+        return (tRS_rAuxOut,)
 
 
 class GemmNormActSm90(GemmNormActMixin, GemmSm90):
@@ -114,7 +114,7 @@ class GemmNormGatedMixin(GemmGatedMixin):
         epi_loop_tensors: Tuple[cute.Tensor, ...],
         tRS_rD: cute.Tensor,
         tRS_rC: Optional[cute.Tensor] = None,
-    ) -> Optional[cute.Tensor]:
+    ) -> Tuple[cute.Tensor, ...]:
         tDrRowVec = epi_loop_tensors.get("mRowVecBroadcast")
         tDrColVec = epi_loop_tensors.get("mColVecBroadcast")
         # Load accumulator and apply alpha/beta/C
@@ -143,7 +143,7 @@ class GemmNormGatedMixin(GemmGatedMixin):
                     (tRS_rD[4 * i], tRS_rD[4 * i + 2]),
                     (tRS_rD[4 * i + 1], tRS_rD[4 * i + 3]),
                 )
-        return tRS_rAuxOut
+        return (tRS_rAuxOut,)
 
 
 class GemmNormGatedSm90(GemmNormGatedMixin, GemmSm90):

--- a/quack/gemm_sq_reduce.py
+++ b/quack/gemm_sq_reduce.py
@@ -111,11 +111,12 @@ class GemmSqReduceMixin(GemmActMixin):
         if const_expr(getattr(params, "mAuxOut", None) is not None):
             tRS_rAuxOut = cute.make_rmem_tensor_like(tRS_rD)
             tRS_rAuxOut.store(tRS_rD.load())
+            tRS_rAuxOuts = (tRS_rAuxOut,)
         else:
-            tRS_rAuxOut = None
+            tRS_rAuxOuts = ()
         # Multiply by rowvec (norm_weight) AFTER sq_sum
         vec_multiply(self, tRS_rD, None, tDrRowVec)
-        return tRS_rAuxOut
+        return tRS_rAuxOuts
 
 
 class GemmSqReduceSm90(GemmSqReduceMixin, GemmSm90):

--- a/quack/gemm_symmetric.py
+++ b/quack/gemm_symmetric.py
@@ -75,8 +75,10 @@ class GemmSymmetricMixin(GemmActMixin):
             and self.d_dtype == cutlass.BFloat16
         )
 
-        # Setup aux output (returns None for default epilogue, context tuple for Act)
-        aux_out_ctx = self.epi_setup_aux_out(
+        # Setup aux outputs. Returns a tuple of ``(tiled_copy_r2s,
+        # tRS_sAuxOut, copy_aux_out)`` triples — empty when no aux output
+        # was requested, one entry per aux output otherwise.
+        aux_out_ctxs = self.epi_setup_aux_out(
             params,
             epi_smem_tensors,
             tiled_copy_r2s,
@@ -165,7 +167,9 @@ class GemmSymmetricMixin(GemmActMixin):
                         src_idx=epi_coord_C,
                         dst_idx=(epi_idx + self.epi_c_stage) % self.epi_c_stage,
                     )
-            tRS_rAuxOut = self.epi_visit_subtile(params, epi_loop_tensors, tRS_rD, tRS_rC)
+            # Returns a tuple of register tensors — one per aux output.
+            # Length matches ``aux_out_ctxs``.
+            tRS_rAuxOuts = self.epi_visit_subtile(params, epi_loop_tensors, tRS_rD, tRS_rC)
             self.epi_end_loop(
                 params,
                 epi_tensors,
@@ -177,15 +181,19 @@ class GemmSymmetricMixin(GemmActMixin):
                 varlen_manager,
                 tidx,
             )
-            if const_expr(aux_out_ctx is not None):
-                tRS_rAuxOut_out = self.epi_convert_aux_out(
-                    tRS_rAuxOut,
+            # Convert each output to its storage dtype.
+            tRS_rAuxOuts_out = tuple(
+                self.epi_convert_aux_out(
+                    i,
+                    tRS_rAuxOuts[i],
                     epi_loop_tensors.get("sr_seed"),
                     tidx,
                     tile_coord_mnkl,
                     num_prev_subtiles,
                     epi_idx,
                 )
+                for i in range(len(aux_out_ctxs))
+            )
             if const_expr(use_tma_epi):
                 if is_tma_warp:
                     epi_store_pipeline.producer_acquire()
@@ -205,12 +213,12 @@ class GemmSymmetricMixin(GemmActMixin):
                     copy_utils.sr_cvt_copy(tiled_copy_r2s, tRS_rD, tRS_sD_cur, seed, tidx)
                 else:
                     copy_utils.cvt_copy(tiled_copy_r2s, tRS_rD, tRS_sD_cur)
-            if const_expr(aux_out_ctx is not None):
-                tiled_copy_aux_out_r2s, tRS_sAuxOut, copy_aux_out = aux_out_ctx
+            for i in cutlass.range_constexpr(len(aux_out_ctxs)):
+                tiled_copy_aux_out_r2s, tRS_sAuxOut, _ = aux_out_ctxs[i]
                 cute.copy(
                     tiled_copy_aux_out_r2s,
                     # Need contiguous for Sm80 and Sm120 where acc layout is ((2, 2), MMA_M, MMA_N)
-                    copy_utils.contiguous(tiled_copy_aux_out_r2s.retile(tRS_rAuxOut_out)),
+                    copy_utils.contiguous(tiled_copy_aux_out_r2s.retile(tRS_rAuxOuts_out[i])),
                     tRS_sAuxOut[None, None, None, epi_buffer],
                 )
             if const_expr(use_tma_epi):
@@ -219,7 +227,8 @@ class GemmSymmetricMixin(GemmActMixin):
                 if is_tma_warp:
                     if const_expr(has_D):
                         copy_D(src_idx=epi_buffer, dst_idx=epi_coord)
-                    if const_expr(aux_out_ctx is not None):
+                    for i in cutlass.range_constexpr(len(aux_out_ctxs)):
+                        _, _, copy_aux_out = aux_out_ctxs[i]
                         if square_tile_m != square_tile_n:  # don't write twice on the diagonal
                             copy_aux_out(src_idx=epi_buffer, dst_idx=epi_coord)
                     epi_store_pipeline.producer_commit()
@@ -227,7 +236,8 @@ class GemmSymmetricMixin(GemmActMixin):
                 epilogue_barrier.arrive_and_wait()
                 if const_expr(has_D):
                     copy_D(src_idx=epi_buffer, dst_idx=epi_coord)
-                if const_expr(aux_out_ctx is not None):
+                for i in cutlass.range_constexpr(len(aux_out_ctxs)):
+                    _, _, copy_aux_out = aux_out_ctxs[i]
                     if square_tile_m != square_tile_n:  # don't write twice on the diagonal
                         copy_aux_out(src_idx=epi_buffer, dst_idx=epi_coord)
                 epilogue_barrier.arrive_and_wait()


### PR DESCRIPTION
Generalize the epilogue visitor API from a single optional aux output to a tuple of aux outputs so one GEMM can emit several epilogue tensors

- epi_setup_aux_out returns a tuple of (tiled_copy_r2s, tRS_sAuxOut, copy_aux_out) triples; () means no aux output.
- epi_visit_subtile returns a tuple of register tensors, one per aux output, matching the setup tuple ((), instead of None, by default).
- epi_convert_aux_out takes the constexpr output index as its first argument so multi-output mixins can pick per-output conversions.

The epilogue loops in GemmBase and GemmSymmetric convert and store each aux output in turn; all outputs share the epi_buffer index so the s2g TMA stores happen in lockstep after the smem fence. Existing single-output mixins (Act/Gated/DAct/DGated/NormAct/NormGated/SqReduce) now return one-element tuples; behavior is unchanged.