### PR TITLE
Split k gemm sm100

### DIFF
--- a/benchmarks/benchmark_gemm_splitk.py
+++ b/benchmarks/benchmark_gemm_splitk.py
@@ -1,0 +1,175 @@
+import argparse
+import math
+import time
+
+import torch
+from triton.testing import do_bench
+
+from quack.cute_dsl_utils import get_device_capacity
+from quack.gemm import gemm as quack_gemm
+
+"""
+Split-K GEMM benchmark (SM100 / B200-B300 only).
+
+Split-K parallelizes the K reduction of a single output tile across `split_k`
+work units (turnstile fp32 fixup). It pays off when there are FEW output tiles
+(small M, N) but a LARGE K: a plain GEMM launches ~one CTA per output tile and
+cannot fill the GPU, while split-K spreads the K reduction over more CTAs. On
+shapes with many output tiles the GPU is already saturated and split-K only adds
+reduction overhead -- the large square shape in the default sweep shows that
+contrast.
+
+Usage:
+    python benchmarks/benchmark_gemm_splitk.py
+    python benchmarks/benchmark_gemm_splitk.py --shapes "128,128,16384,1;256,256,65536,1"
+    python benchmarks/benchmark_gemm_splitk.py --split_k 1,2,3,4,8 --dtype bf16
+    python benchmarks/benchmark_gemm_splitk.py --tile_shape_mn 128,128 --skip_ref_check
+"""
+
+_TORCH_DTYPE_MAP = {
+    "bf16": torch.bfloat16, "bfloat16": torch.bfloat16, "BFloat16": torch.bfloat16,
+    "fp16": torch.float16, "float16": torch.float16,
+    "Float16": torch.float16, "half": torch.float16,
+}
+# bf16 accumulates more error over large K than fp16's reference comparison.
+_TOL = {torch.bfloat16: 3e-2, torch.float16: 1e-2}
+
+# K-heavy small-M/N shapes (split-K should help) + one large square (it should not).
+_DEFAULT_SHAPES = [
+    (128, 128, 16384, 1),
+    (128, 128, 65536, 1),
+    (256, 256, 32768, 1),
+    (512, 512, 16384, 1),
+    (4096, 4096, 4096, 1),
+]
+
+
+def _bench(fn, warmup: int, rep: int) -> float:
+    time.sleep(0.3)
+    return do_bench(fn, warmup=warmup, rep=rep)
+
+
+def _parse_shapes(s: str):
+    shapes = []
+    for chunk in s.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        vals = tuple(int(x.strip()) for x in chunk.split(","))
+        if len(vals) != 4:
+            raise argparse.ArgumentTypeError(f"shape '{chunk}' must have 4 ints (m,n,k,l)")
+        shapes.append(vals)
+    return shapes
+
+
+def _parse_ints(s: str):
+    return tuple(int(x.strip()) for x in s.split(","))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Split-K GEMM benchmark using quack.gemm.gemm()")
+    p.add_argument("--shapes", type=_parse_shapes, default=_DEFAULT_SHAPES,
+                   help="';'-separated m,n,k,l tuples. Default: a K-heavy sweep + a large square.")
+    p.add_argument("--split_k", type=_parse_ints, default=(1, 2, 4, 8, 16, 32),
+                   help="Comma-separated split factors to sweep (must include 1 for the baseline).")
+    p.add_argument("--split_k_mode", type=str, default="parallel", choices=["parallel", "serial"],
+                   help="parallel: per-split workspace slices + separate reduce kernel "
+                        "(cuBLAS-style); serial: fused in-kernel turnstile reduction.")
+    p.add_argument("--tile_shape_mn", type=_parse_ints, default=(128, 128),
+                   help="CTA tile (tile_M,tile_N). split_k>1 requires tile_M != 256.")
+    p.add_argument("--cluster_shape_mn", type=_parse_ints, default=(1, 1), help="Cluster (M,N).")
+    p.add_argument("--dtype", type=str, default="bf16", help="A/B/D dtype: bf16 or fp16.")
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--iterations", type=int, default=30)
+    p.add_argument("--skip_ref_check", action="store_true")
+    args = p.parse_args()
+    if args.dtype not in _TORCH_DTYPE_MAP:
+        p.error(f"--dtype must be one of {sorted(_TORCH_DTYPE_MAP)}")
+    if 1 not in args.split_k:
+        p.error("--split_k must include 1 (the no-split baseline)")
+    return args
+
+
+def run_shape(m, n, k, l, *, split_ks, split_k_mode, tile_M, tile_N, cluster_M, cluster_N, dtype,
+              warmup, rep, skip_ref_check) -> None:
+    device = "cuda"
+    torch.manual_seed(0)
+    A = torch.randn(l, m, k, dtype=dtype, device=device) / math.sqrt(k)
+    B = torch.randn(l, n, k, dtype=dtype, device=device) / math.sqrt(k)
+    D = torch.empty(l, m, n, dtype=dtype, device=device)
+
+    flops = 2 * m * n * k * l
+    n_tiles = math.ceil(m / tile_M) * math.ceil(n / tile_N) * l
+    print(
+        f"\n=== m={m} n={n} k={k} l={l}  "
+        f"({n_tiles} output tile(s) @ {tile_M}x{tile_N}, {dtype}) ==="
+    )
+
+    ref = torch.bmm(A.float(), B.float().mT).to(dtype) if not skip_ref_check else None
+
+    def report(name, t, *, base=None):
+        tflops = flops / (t * 1e9)
+        rel = f"   ({base / t:5.2f}x vs split_k=1)" if base is not None else ""
+        print(f"  {name:<22}: {t:8.4f} ms, {tflops:8.1f} TFLOP/s{rel}")
+
+    t_cublas = _bench(lambda: torch.bmm(A, B.mT), warmup, rep)
+    report("cuBLAS (torch.bmm)", t_cublas)
+
+    base_t = None
+    best = (None, float("inf"))
+    for sk in split_ks:
+        def fn(sk=sk):
+            quack_gemm(
+                A, B, D, C=None, tile_count_semaphore=None,
+                tile_M=tile_M, tile_N=tile_N, cluster_M=cluster_M, cluster_N=cluster_N,
+                persistent=True, split_k=sk, split_k_mode=split_k_mode,
+            )
+
+        if not skip_ref_check:
+            fn()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(D, ref, atol=_TOL[dtype], rtol=1e-3)
+
+        t = _bench(fn, warmup, rep)
+        if sk == 1:
+            base_t = t
+        report(f"quack split_k={sk}", t, base=base_t)
+        if t < best[1]:
+            best = (sk, t)
+
+    if base_t is not None and best[0] is not None:
+        print(
+            f"  -> best: split_k={best[0]}  "
+            f"{base_t / best[1]:.2f}x vs split_k=1,  {t_cublas / best[1]:.2f}x vs cuBLAS"
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    cap = get_device_capacity(torch.device("cuda"))
+    if cap[0] not in (10, 11):
+        raise SystemExit(f"split-K GEMM is SM100 only; got SM{cap[0]}{cap[1]}.")
+    if args.split_k != (1,) and args.tile_shape_mn[0] == 256:
+        raise SystemExit("split_k>1 does not support 2-CTA tiles (tile_M=256).")
+
+    dtype = _TORCH_DTYPE_MAP[args.dtype]
+    tile_M, tile_N = args.tile_shape_mn
+    cluster_M, cluster_N = args.cluster_shape_mn
+    print(
+        f"Split-K GEMM benchmark | tile={tile_M}x{tile_N} cluster={cluster_M}x{cluster_N} "
+        f"| split_k={list(args.split_k)} mode={args.split_k_mode} "
+        f"| warmup={args.warmup} iters={args.iterations} "
+        f"| ref_check={not args.skip_ref_check}"
+    )
+    for (m, n, k, l) in args.shapes:
+        run_shape(
+            m, n, k, l, split_ks=args.split_k, split_k_mode=args.split_k_mode,
+            tile_M=tile_M, tile_N=tile_N,
+            cluster_M=cluster_M, cluster_N=cluster_N, dtype=dtype,
+            warmup=args.warmup, rep=args.iterations, skip_ref_check=args.skip_ref_check,
+        )
+    print("\nPASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/quack/cute_dsl_utils.py
+++ b/quack/cute_dsl_utils.py
@@ -67,6 +67,14 @@ def get_max_active_clusters(cluster_size):
     return cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_size=cluster_size)
 
 
+@lru_cache
+def get_num_sms(device: torch.device = None) -> int:
+    """SM count for the device. Cached: `get_device_properties` walks a Python device-index
+    resolution chain that is ~µs-scale per call and a hot spot in the launch-bound split-K
+    path, but the value is constant per device."""
+    return torch.cuda.get_device_properties(device).multi_processor_count
+
+
 def _parse_arch_str(arch_str: str) -> Tuple[int, int]:
     """Parse arch string (e.g. 'sm_90', 'sm90', '90', 'sm_100a') to (major, minor) tuple."""
     match = re.match(r"^(?:sm_?)?(\d+)(\d)([af]?)$", arch_str.strip(), re.IGNORECASE)

--- a/quack/gemm.py
+++ b/quack/gemm.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+import torch
 from torch import Tensor
 
 import cutlass.cute as cute
@@ -11,7 +12,12 @@ from cutlass.cute.runtime import make_ptr
 
 from quack.cache_utils import jit_cache
 from quack.compile_utils import make_fake_tensor as fake_tensor
-from quack.cute_dsl_utils import get_device_capacity, get_max_active_clusters, torch2cute_dtype_map
+from quack.cute_dsl_utils import (
+    get_device_capacity,
+    get_max_active_clusters,
+    get_num_sms,
+    torch2cute_dtype_map,
+)
 from quack.gemm_default_epi import (
     GemmDefaultEpiMixin,
     GemmDefaultSm90,
@@ -19,6 +25,14 @@ from quack.gemm_default_epi import (
     GemmDefaultSm120,
 )
 from quack.rounding import RoundingMode
+from quack.gemm_splitk_reduce import (
+    auto_split_k,
+    choose_reduce_kgroups,
+    choose_reduce_vec_width,
+    compile_splitk_reduce,
+    splitk_reduce,
+    uniform_splitk_tables,
+)
 from quack.gemm_tvm_ffi_utils import (
     get_majors,
     get_dtypes,
@@ -63,6 +77,8 @@ def _compile_gemm(
     rounding_mode,
     sr_seed_mode,
     has_trace_ptr,
+    has_splitk=False,
+    splitk_parallel=False,
 ):
     sm_to_cls = {
         9: GemmDefaultSm90,
@@ -111,7 +127,11 @@ def _compile_gemm(
         sr_seed=fake_scalar(sr_seed_mode, dtype=Int32),
     )
     scheduler_args = make_fake_scheduler_args(
-        (is_dynamic_persistent and device_capacity[0] == 9), has_batch_idx_permute, l
+        (is_dynamic_persistent and device_capacity[0] == 9),
+        has_batch_idx_permute,
+        l,
+        has_split_k=has_splitk,
+        splitk_parallel=splitk_parallel,
     )
     aidx_len = m if varlen_m else (k if varlen_k else None)
     varlen_args = make_fake_varlen_args(varlen_m, varlen_k, gather_A, aidx_len)
@@ -166,6 +186,12 @@ def gemm(
     sr_seed: int | Tensor = 0,
     use_tma_gather: bool = False,
     concat_layout: dict | None = None,
+    split_k: int = 1,  # K splits per output tile (SM100 only); 0 = auto (auto_split_k)
+    # "parallel": every split writes its own fp32 workspace slice, a second kernel
+    # reduces them (cuBLAS-style; split_k can scale to fill the GPU). "serial": fused
+    # in-kernel turnstile reduction (single kernel, but reduction cost grows with
+    # split_k). Both are run-to-run deterministic.
+    split_k_mode: str = "parallel",
     trace_ptr=None,  # Optional Int64 from TraceSession.ptr
 ) -> None:
     varlen_m = cu_seqlens_m is not None
@@ -198,6 +224,41 @@ def gemm(
             "Dynamic persistent tile scheduler in SM90 requires a semaphore in GMEM"
         )
 
+    if split_k == 0:  # auto: pick a split_k for this shape (1 when split-K won't help)
+        split_k = 1
+        if (
+            split_k_mode == "parallel"
+            and device_capacity[0] in (10, 11)
+            and not varlen
+            and not gather_A
+            and not add_to_output
+            and tile_M != 256
+        ):
+            num_sms = get_num_sms(A.device)
+            l_auto = A.shape[0] if A.ndim == 3 else 1
+            split_k = auto_split_k(
+                A.shape[-2], B.shape[-2], A.shape[-1], l_auto, tile_M, tile_N, num_sms
+            )
+    assert split_k >= 1, "split_k must be >= 1"
+    assert split_k_mode in ("serial", "parallel"), "split_k_mode must be 'serial' or 'parallel'"
+    splitk_parallel = split_k > 1 and split_k_mode == "parallel"
+    if split_k > 1:
+        assert device_capacity[0] in (10, 11), "split_k > 1 is only supported on SM100"
+        assert not varlen and not gather_A, "split_k > 1 does not support varlen/gather_A"
+        assert not add_to_output, "split_k > 1 does not support add_to_output"
+        assert tile_M != 256, "split_k > 1 does not support 2-CTA tiles (tile_M=256)"
+        assert persistent, "split_k > 1 requires the persistent scheduler"
+        # The split work-index expansion is only wired for the static/dynamic persistent
+        # scheduler (and the serial turnstile additionally needs its ordered work handout).
+        is_dynamic_persistent = False
+        if splitk_parallel:
+            assert rounding_mode == RoundingMode.RN, (
+                "parallel split-K converts in the reduce kernel (RN only)"
+            )
+            assert colvec_bias is None or colvec_bias.ndim == 2, (
+                "parallel split-K supports only (L, M) colvec bias"
+            )
+
     A_p, B_p, D_p, C_p = perm3d(A, B, D, C, varlen_m=varlen_m, varlen_k=varlen_k)
     a_major, b_major, d_major, c_major = get_majors(A_p, B_p, D_p, C_p)
     a_dtype, b_dtype, d_dtype, c_dtype = get_dtypes(A, B, D, C)
@@ -210,25 +271,32 @@ def gemm(
     sr_seed_mode = (
         2 if isinstance(sr_seed, Tensor) else (1 if rounding_mode == RoundingMode.RS else 0)
     )
+    # Parallel split-K: the GEMM kernel only writes fp32 partials; D/C and every
+    # epilogue op (alpha/beta/bias) move to the reduce kernel, so the GEMM is compiled
+    # without them (no D TMA atoms / epi smem -> more mainloop stages).
     compiled_fn = _compile_gemm(
         a_dtype,
         b_dtype,
-        d_dtype,
-        c_dtype,
+        None if splitk_parallel else d_dtype,
+        None if splitk_parallel else c_dtype,
         a_major,
         b_major,
-        d_major,
-        c_major,
+        None if splitk_parallel else d_major,
+        None if splitk_parallel else c_major,
         (tile_M, tile_N),
         (cluster_M, cluster_N, 1),
         pingpong,
         persistent,
         is_dynamic_persistent,
-        torch2cute_dtype_map[rowvec_bias.dtype] if rowvec_bias is not None else None,
-        torch2cute_dtype_map[colvec_bias.dtype] if colvec_bias is not None else None,
-        colvec_ndim,
-        alpha_mode,
-        beta_mode,
+        torch2cute_dtype_map[rowvec_bias.dtype]
+        if rowvec_bias is not None and not splitk_parallel
+        else None,
+        torch2cute_dtype_map[colvec_bias.dtype]
+        if colvec_bias is not None and not splitk_parallel
+        else None,
+        0 if splitk_parallel else colvec_ndim,
+        0 if splitk_parallel else alpha_mode,
+        0 if splitk_parallel else beta_mode,
         add_to_output,
         concat_layout,
         varlen_m,
@@ -240,9 +308,44 @@ def gemm(
         rounding_mode,
         sr_seed_mode,
         trace_ptr is not None,
+        split_k > 1,
+        splitk_parallel,
     )
-
+    splitk_num_tiles, splitk_reduce_vw, splitk_reduce_kg = None, 1, 1
+    if split_k > 1:
+        _l = A.shape[0] if A.ndim == 3 else 1
+        splitk_num_tiles = (
+            ((A.shape[-2] + tile_M - 1) // tile_M) * ((B.shape[-2] + tile_N - 1) // tile_N) * _l
+        )
+        if splitk_parallel:
+            _num_sms = get_num_sms(A.device)
+            # Reduce vec_width (threads/CTA granularity) depends on the tile count.
+            splitk_reduce_vw = choose_reduce_vec_width(
+                splitk_num_tiles, tile_M, tile_N, _num_sms
+            )
+            # Intra-CTA K-split factor: fills the GPU when there are few output tiles (the
+            # reduce's recurring latency-bound case). R=1 (exact flat-ascending) otherwise.
+            splitk_reduce_kg = choose_reduce_kgroups(
+                splitk_num_tiles, tile_M, tile_N, split_k, splitk_reduce_vw, _num_sms
+            )
     from quack.cache_utils import COMPILE_ONLY
+
+    if splitk_parallel and COMPILE_ONLY:
+        # AOT only: pre-compile the reduce so COMPILE_ONLY flows cache both kernels before
+        # the early return. The hot path compiles it lazily inside splitk_reduce() below,
+        # so doing it here too would just be a redundant cache lookup every call.
+        compile_splitk_reduce(
+            D_p,
+            C_p,
+            alpha,
+            beta,
+            rowvec_bias,
+            colvec_bias,
+            tile_M,
+            tile_N,
+            splitk_reduce_vw,
+            splitk_reduce_kg,
+        )
 
     if COMPILE_ONLY:
         return
@@ -257,11 +360,29 @@ def gemm(
 
     max_active_clusters = get_max_active_clusters(cluster_M * cluster_N) if persistent else 0
 
+    splitk_flags, splitk_ws, splitk_tables = None, None, None
+    if split_k > 1:
+        num_tiles = splitk_num_tiles
+        # Parallel mode: one slot per (tile, split), summed by the reduce kernel.
+        # Serial mode: one accumulation slot per tile, plus zeroed turnstile counters.
+        # The workspace itself never needs initialization in either mode.
+        ws_numel = num_tiles * tile_M * tile_N * (split_k if splitk_parallel else 1)
+        assert ws_numel < 2**31, "split-K workspace indexing is 32-bit"
+        if not splitk_parallel:
+            splitk_flags = torch.zeros(num_tiles, dtype=torch.int32, device=A.device)
+        splitk_ws = torch.empty(ws_numel, dtype=torch.float32, device=A.device)
+        if splitk_parallel:
+            # Table-driven reduce: each tile owns `count` slots from `first_slot`. The
+            # fixed split-K layout is the uniform case (count=split_k); the reduce kernel
+            # is otherwise agnostic to how the partials were partitioned (Stream-K-ready).
+            splitk_tables = uniform_splitk_tables(num_tiles, split_k, A.device)
+
+    # In parallel split-K, D/C/alpha/beta/bias belong to the reduce kernel, not the GEMM
     epi_args = GemmDefaultEpiMixin.EpilogueArguments(
-        alpha=scalar_arg(alpha, alpha_mode),
-        beta=scalar_arg(beta, beta_mode),
-        mRowVecBroadcast=rowvec_bias,
-        mColVecBroadcast=colvec_bias,
+        alpha=scalar_arg(alpha, alpha_mode) if not splitk_parallel else None,
+        beta=scalar_arg(beta, beta_mode) if not splitk_parallel else None,
+        mRowVecBroadcast=rowvec_bias if not splitk_parallel else None,
+        mColVecBroadcast=colvec_bias if not splitk_parallel else None,
         add_to_output=None,
         rounding_mode=None,
         sr_seed=scalar_arg(sr_seed, sr_seed_mode, dtype=Int32),
@@ -271,12 +392,44 @@ def gemm(
         max_swizzle_size,
         tile_count_semaphore,
         batch_idx_permute,
+        split_k=split_k,
+        splitk_flags=splitk_flags,
+        splitk_ws=splitk_ws,
     )
     varlen_args = make_varlen_args(cu_seqlens_m, cu_seqlens_k, A_idx)
 
+    gemm_D_p = D_p if not splitk_parallel else None
+    gemm_C_p = C_p if not splitk_parallel else None
     if device_capacity[0] in [10, 11]:
         compiled_fn(
-            A_p, B_p, D_p, C_p, epi_args, scheduler_args, varlen_args, None, None, trace_ptr
+            A_p,
+            B_p,
+            gemm_D_p,
+            gemm_C_p,
+            epi_args,
+            scheduler_args,
+            varlen_args,
+            None,
+            None,
+            trace_ptr,
         )
     else:
-        compiled_fn(A_p, B_p, D_p, C_p, epi_args, scheduler_args, varlen_args, trace_ptr)
+        compiled_fn(A_p, B_p, gemm_D_p, gemm_C_p, epi_args, scheduler_args, varlen_args, trace_ptr)
+    if splitk_parallel:
+        # Deterministic parallel reduction of the per-split partials + epilogue
+        tile_first_slot, tile_count = splitk_tables
+        splitk_reduce(
+            splitk_ws,
+            D_p,
+            C_p,
+            alpha,
+            beta,
+            rowvec_bias,
+            colvec_bias,
+            tile_first_slot,
+            tile_count,
+            tile_M,
+            tile_N,
+            splitk_reduce_vw,
+            splitk_reduce_kg,
+        )

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -25,7 +25,7 @@ from cutlass import Int32, Float32, Boolean, const_expr
 from cutlass.utils import LayoutEnum
 
 from quack.pipeline import PipelineTmaUmma, PipelineTmaCpAsyncUmma
-from quack.tile_scheduler import TileSchedulerOptions
+from quack.tile_scheduler import TileSchedulerOptions, params_has_split_k
 from quack.varlen_utils import VarlenArguments, VarlenManager
 from quack.gemm_sm90 import GemmSm90, NamedBarrierGemm
 from quack import layout_utils
@@ -565,6 +565,26 @@ class GemmSm100(GemmSm90):
         varlen_m = varlen_args.mCuSeqlensM is not None
         varlen_k = varlen_args.mCuSeqlensK is not None
 
+        if const_expr(scheduler_args.splitk_ws is not None):
+            if const_expr(scheduler_args.splitk_parallel):
+                # Parallel mode: the GEMM kernel only writes partials; D/C and all
+                # epilogue ops belong to the separate reduce kernel.
+                assert scheduler_args.splitk_flags is None
+                assert mD is None and mC is None, (
+                    "parallel split-K: pass D/C to the reduce kernel, not the GEMM"
+                )
+            else:
+                assert scheduler_args.splitk_flags is not None
+                assert mD is not None, "serial split-K requires an output tensor D"
+            assert not (varlen_m or varlen_k), "split-K does not support varlen"
+            assert not self.gather_A, "split-K does not support gather_A"
+            assert not self.blockscaled, "split-K does not support blockscaled GEMM"
+            assert not self.use_2cta_instrs, "split-K does not support 2-CTA MMA (tile_m=256)"
+            # CLC hands out work in no guaranteed order (breaks the serial turnstile) and
+            # its grid math isn't wired for the split work-index expansion.
+            assert not self.use_clc_persistence, "split-K requires the static/dynamic scheduler"
+            assert self.acc_dtype == Float32, "split-K workspace assumes f32 accumulators"
+
         # Setup attributes that dependent on gemm inputs
         self._setup_attributes(epilogue_args, varlen_args)
 
@@ -879,6 +899,17 @@ class GemmSm100(GemmSm90):
             assert varlen_m or varlen_k
         has_D = const_expr(mD_mnl is not None)
         has_C = const_expr(mC_mnl is not None)
+        has_split_k = const_expr(params_has_split_k(tile_sched_params))
+        splitk_parallel = const_expr(
+            has_split_k and getattr(tile_sched_params, "splitk_parallel", False)
+        )
+        if const_expr(has_split_k):
+            assert not (varlen_m or varlen_k) and not self.gather_A
+            if const_expr(splitk_parallel):
+                # D/C are written by the separate reduce kernel
+                assert not has_D and not has_C
+            else:
+                assert has_D
 
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -1193,6 +1224,9 @@ class GemmSm100(GemmSm90):
                         mcast_mask=sfb_mcast_mask,
                     )
                 k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                k_tile_start, k_tile_cnt = self.splitk_k_tile_range(
+                    tile_sched_params, tile_scheduler.current_k_split, k_tile_cnt
+                )
                 tctx.b("tma_load")
                 if const_expr(not self.gather_A):
                     ab_producer_state = self.load_AB(
@@ -1203,6 +1237,7 @@ class GemmSm100(GemmSm90):
                         k_tile_cnt,
                         copy_SFA,
                         copy_SFB,
+                        k_tile_start=k_tile_start,
                     )
                 elif const_expr(self.use_tma_gather):
                     ab_producer_state, a_prefetch_consumer_state = self.load_AB_tma_gather(
@@ -1347,26 +1382,37 @@ class GemmSm100(GemmSm90):
                 while work_tile.is_valid_tile:
                     # Get tile coord from tile scheduler
                     tile_coord_mnkl = work_tile.tile_idx
-                    batch_idx = tile_coord_mnkl[3]
-                    copy_C_fn, _, bGS_gC = self.epilog_gmem_copy_and_partition(
-                        tma_atom_c,
-                        varlen_manager.offset_batch_epi(mC_mnl, batch_idx),
-                        self.cta_tile_shape_mnk[:2],
-                        epi_tile,
-                        sC,
-                        tile_coord_mnkl,
-                    )
-                    copy_C = copy_utils.tma_producer_copy_fn(copy_C_fn, epi_pipeline)
-                    if do_epi_load_barrier_wait:
-                        epi_load_barrier.arrive_and_wait()
-                        do_epi_load_barrier_wait = Boolean(False)
-                    epi_tile_num = const_expr(cute.size(bGS_gC, mode=[1]))
-                    for epi_idx in cutlass.range(epi_tile_num, unroll=1):
-                        epi_pipeline.producer_acquire(epi_producer_state)
-                        copy_C(src_idx=epi_idx, producer_state=epi_producer_state)
-                        # Epi pipeline's producer commit is a NOP
-                        epi_pipeline.producer_commit(epi_producer_state)
-                        epi_producer_state.advance()
+                    if const_expr(not has_split_k):
+                        epi_producer_state, do_epi_load_barrier_wait = self._epi_load_C_tile(
+                            tma_atom_c,
+                            mC_mnl,
+                            sC,
+                            epi_tile,
+                            epi_pipeline,
+                            epi_producer_state,
+                            epi_load_barrier,
+                            do_epi_load_barrier_wait,
+                            varlen_manager,
+                            tile_coord_mnkl,
+                        )
+                    else:
+                        # Only the final split runs the epilogue and consumes C
+                        if (
+                            tile_scheduler.current_k_split
+                            == tile_sched_params.split_k_fdd.divisor - 1
+                        ):
+                            epi_producer_state, do_epi_load_barrier_wait = self._epi_load_C_tile(
+                                tma_atom_c,
+                                mC_mnl,
+                                sC,
+                                epi_tile,
+                                epi_pipeline,
+                                epi_producer_state,
+                                epi_load_barrier,
+                                do_epi_load_barrier_wait,
+                                varlen_manager,
+                                tile_coord_mnkl,
+                            )
                     # Advance to next tile
                     tile_scheduler.advance_to_next_work()
                     work_tile = tile_scheduler.get_current_work()
@@ -1452,6 +1498,9 @@ class GemmSm100(GemmSm90):
                 batch_idx = tile_coord_mnkl[3]
                 k_len = varlen_manager.len_k(batch_idx)
                 k_tile_cnt = cute.ceil_div(k_len, self.mma_tiler[2])
+                _, k_tile_cnt = self.splitk_k_tile_range(
+                    tile_sched_params, tile_scheduler.current_k_split, k_tile_cnt
+                )
                 # Set tensor memory buffer for current tile
                 # (MMA, MMA_M, MMA_N)
                 acc_stage_idx = (
@@ -1595,6 +1644,45 @@ class GemmSm100(GemmSm90):
                     cute.zipped_divide(cute.make_layout(self.cta_tile_shape_mnk[:2]), epi_tile),
                     mode=[1],
                 )
+                clear_acc = varlen_k and k_len == 0
+                is_final_split = Boolean(True)
+                splitk_flag_ptr, splitk_tile_idx = None, None
+                if const_expr(has_split_k):
+                    # Workspace fragments must exactly tile the CTA tile (host allocates
+                    # tile_m * tile_n f32 per workspace slot)
+                    assert (
+                        epi_tile_num
+                        * self.num_epi_warps
+                        * cute.arch.WARP_SIZE
+                        * cute.size(tTR_rD.shape)
+                        == self.cta_tile_shape_mnk[0] * self.cta_tile_shape_mnk[1]
+                    )
+                    k_tile_cnt = cute.ceil_div(k_len, self.mma_tiler[2])
+                    _, k_tile_cnt = self.splitk_k_tile_range(
+                        tile_sched_params, tile_scheduler.current_k_split, k_tile_cnt
+                    )
+                    # Splits that got no k tiles (split_k > total k tiles) contribute zeros
+                    clear_acc = k_tile_cnt == 0
+                    splitk_tile_idx = self.splitk_tile_index(tile_coord_mnkl, mB_nkl)
+                    if const_expr(not splitk_parallel):
+                        # The epilogue rotates epi smem buffers by tile_scheduler
+                        # .num_tiles_executed * epi_tile_num, which counts skipped
+                        # (non-final-split) tiles while TMA store commits don't. The buffer
+                        # phase across skips is preserved iff epi_stage divides epi_tile_num;
+                        # otherwise a buffer could be overwritten while its TMA store is
+                        # still in flight. (Parallel mode never runs the epilogue here.)
+                        assert epi_tile_num % self.epi_stage == 0, (
+                            "split-K requires epi_tile_num divisible by epi_stage; "
+                            "use a tile_n whose epi subtile count is even (e.g. 128 or 256)"
+                        )
+                        is_final_split = (
+                            tile_scheduler.current_k_split
+                            == tile_sched_params.split_k_fdd.divisor - 1
+                        )
+                        splitk_flag_ptr = tile_sched_params.splitk_flags + splitk_tile_idx
+                        # Turnstile: wait until all preceding splits of this tile have
+                        # accumulated their partials into the workspace
+                        self.splitk_wait(splitk_flag_ptr, tile_scheduler.current_k_split, epi_tidx)
                 load_acc_subtile = partial(
                     self.epi_load_acc_subtile,
                     tiled_copy_t2r,
@@ -1606,36 +1694,102 @@ class GemmSm100(GemmSm90):
                     acc_release_idx=self.iter_acc_early_release
                     if const_expr(self.overlap_accum_sf)
                     else epi_tile_num - 1,
-                    clear_acc=varlen_k and k_len == 0,
+                    clear_acc=clear_acc,
                 )
 
                 tctx.b("epilogue")
-                epi_read_state, _ = self.epilogue(
-                    epilogue_params,
-                    epi_smem_tensors,
-                    epi_pipeline,
-                    epi_store_pipeline,
-                    epi_read_state,
-                    None,  # epi_producer_state
-                    epi_tile,
-                    load_acc_subtile,
-                    tRS_rD,
-                    tRS_rC,
-                    tiled_copy_t2r,
-                    tiled_copy_r2s,
-                    tRS_sD,
-                    tiled_copy_s2r,
-                    tSR_rC,
-                    tSR_sC,
-                    copy_D,
-                    copy_C,
-                    tile_coord_mnkl,
-                    varlen_manager,
-                    self.epilogue_barrier,
-                    tile_scheduler,
-                    epi_tidx,
-                    is_tma_warp,
-                )
+                if const_expr(not has_split_k):
+                    epi_read_state, _ = self.epilogue(
+                        epilogue_params,
+                        epi_smem_tensors,
+                        epi_pipeline,
+                        epi_store_pipeline,
+                        epi_read_state,
+                        None,  # epi_producer_state
+                        epi_tile,
+                        load_acc_subtile,
+                        tRS_rD,
+                        tRS_rC,
+                        tiled_copy_t2r,
+                        tiled_copy_r2s,
+                        tRS_sD,
+                        tiled_copy_s2r,
+                        tSR_rC,
+                        tSR_sC,
+                        copy_D,
+                        copy_C,
+                        tile_coord_mnkl,
+                        varlen_manager,
+                        self.epilogue_barrier,
+                        tile_scheduler,
+                        epi_tidx,
+                        is_tma_warp,
+                    )
+                elif const_expr(splitk_parallel):
+                    # Parallel split-K: every split stores raw partials to its own
+                    # workspace slot with no inter-CTA synchronization; the separate
+                    # reduce kernel sums slots and runs the epilogue.
+                    self.splitk_store_partials_parallel(
+                        tile_sched_params,
+                        splitk_tile_idx,
+                        tile_scheduler.current_k_split,
+                        load_acc_subtile,
+                        tRS_rD,
+                        tTR_rD,
+                        tiled_copy_t2r,
+                        epi_tile,
+                        epi_tile_num,
+                        epi_tidx,
+                    )
+                else:
+                    if is_final_split:
+                        epi_read_state, _ = self.epilogue(
+                            epilogue_params,
+                            epi_smem_tensors,
+                            epi_pipeline,
+                            epi_store_pipeline,
+                            epi_read_state,
+                            None,  # epi_producer_state
+                            epi_tile,
+                            load_acc_subtile,
+                            tRS_rD,
+                            tRS_rC,
+                            tiled_copy_t2r,
+                            tiled_copy_r2s,
+                            tRS_sD,
+                            tiled_copy_s2r,
+                            tSR_rC,
+                            tSR_sC,
+                            copy_D,
+                            copy_C,
+                            tile_coord_mnkl,
+                            varlen_manager,
+                            self.epilogue_barrier,
+                            tile_scheduler,
+                            epi_tidx,
+                            is_tma_warp,
+                            splitk_fixup=partial(
+                                self.splitk_fixup_acc_subtile,
+                                tile_sched_params,
+                                splitk_tile_idx,
+                                tTR_rD,
+                                epi_tidx,
+                            ),
+                        )
+                    else:
+                        # Non-final split: no epilogue; serialize partials into the
+                        # workspace and pass the turnstile to the next split.
+                        self.splitk_store_partials(
+                            tile_sched_params,
+                            splitk_tile_idx,
+                            tile_scheduler.current_k_split,
+                            load_acc_subtile,
+                            tRS_rD,
+                            tTR_rD,
+                            epi_tile_num,
+                            epi_tidx,
+                        )
+                        self.splitk_arrive(splitk_flag_ptr, epi_tidx)
                 # acc_pipeline.consumer_release was already called in self.epi_load_acc_subtile
                 acc_consumer_state.advance()
                 tctx.e("epilogue")
@@ -1654,6 +1808,89 @@ class GemmSm100(GemmSm90):
             tmem.free(acc_tmem_ptr)
 
         tctx.flush()
+
+    @cute.jit
+    def splitk_store_partials_parallel(
+        self,
+        params,
+        tile_idx: Int32,
+        k_split: Int32,
+        load_acc_subtile: Callable,
+        tRS_rD: cute.Tensor,
+        tTR_rD: cute.Tensor,
+        tiled_copy_t2r: cute.TiledCopy,
+        epi_tile: cute.Tile,
+        epi_tile_num: cutlass.Constexpr[int],
+        tidx: Int32,
+    ) -> None:
+        """Parallel split-K: store this split's raw fp32 partials to its own workspace
+        slot in row-major (m, n) order, with no inter-CTA synchronization.
+
+        Slot layout is (tile_idx * split_k + k_split) so a tile's slices are adjacent
+        for the reduce kernel. Fragments land at their true (m, n) via the same
+        partition_D(flat_divide(...)) mapping the epilogue uses for its identity
+        tensor (epilog_tmem_copy_and_partition), so the reduce kernel can address the
+        slot as a plain row-major tile. Edge-tile OOB lanes write padding inside the
+        slot; the reduce kernel predicates the final D store.
+        """
+        tile_m = const_expr(self.cta_tile_shape_mnk[0])
+        tile_n = const_expr(self.cta_tile_shape_mnk[1])
+        slot = tile_idx * params.split_k_fdd.divisor + k_split
+        mWS = cute.make_tensor(
+            params.splitk_ws.iterator + slot * const_expr(tile_m * tile_n),
+            cute.make_layout((tile_m, tile_n), stride=(tile_n, 1)),
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N)
+        gWS_epi = cute.flat_divide(mWS, epi_tile)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N)
+        tTR_gWS = thr_copy_t2r.partition_D(gWS_epi)
+        epi_tile_shape = cute.zipped_divide(
+            cute.make_layout(self.cta_tile_shape_mnk[:2]), epi_tile
+        ).shape[1]
+        # Same subtile-index -> (epi_m, epi_n) mapping as the epilogue's D store
+        epi_tile_layout = cute.make_ordered_layout(epi_tile_shape, order=(1, 0))
+        for epi_idx in cutlass.range_constexpr(epi_tile_num):
+            load_acc_subtile(tRS_rD, epi_idx)
+            gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
+            cute.autovec_copy(tTR_rD, tTR_gWS[None, None, None, gmem_coord[0], gmem_coord[1]])
+
+    @cute.jit
+    def _epi_load_C_tile(
+        self,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        sC: cute.Tensor,
+        epi_tile: cute.Tile,
+        epi_pipeline: pipeline.PipelineAsync,
+        epi_producer_state: pipeline.PipelineState,
+        epi_load_barrier: Optional[pipeline.NamedBarrier],
+        do_epi_load_barrier_wait: Boolean,
+        varlen_manager: VarlenManager,
+        tile_coord_mnkl: cute.Coord,
+    ) -> Tuple[pipeline.PipelineState, Boolean]:
+        """One work tile's worth of TMA loads of C, issued by the epi load warp."""
+        batch_idx = tile_coord_mnkl[3]
+        copy_C_fn, _, bGS_gC = self.epilog_gmem_copy_and_partition(
+            tma_atom_c,
+            varlen_manager.offset_batch_epi(mC_mnl, batch_idx),
+            self.cta_tile_shape_mnk[:2],
+            epi_tile,
+            sC,
+            tile_coord_mnkl,
+        )
+        copy_C = copy_utils.tma_producer_copy_fn(copy_C_fn, epi_pipeline)
+        if do_epi_load_barrier_wait:
+            epi_load_barrier.arrive_and_wait()
+            do_epi_load_barrier_wait = Boolean(False)
+        epi_tile_num = const_expr(cute.size(bGS_gC, mode=[1]))
+        for epi_idx in cutlass.range(epi_tile_num, unroll=1):
+            epi_pipeline.producer_acquire(epi_producer_state)
+            copy_C(src_idx=epi_idx, producer_state=epi_producer_state)
+            # Epi pipeline's producer commit is a NOP
+            epi_pipeline.producer_commit(epi_producer_state)
+            epi_producer_state.advance()
+        return epi_producer_state, do_epi_load_barrier_wait
 
     @cute.jit
     def _make_gather_A_copy(
@@ -2361,8 +2598,13 @@ class GemmSm100(GemmSm90):
 
         # Refine epilogue stages:
         # Calculate remaining smem after allocating for A/B stages and reserved bytes
-        # Add remaining unused smem to epilogue
-        epi_stage += (remaining_bytes - ab_bytes_per_stage * ab_stage) // (epi_bytes_per_stage)
+        # Add remaining unused smem to epilogue.
+        # Parallel split-K compiles the GEMM with no epilogue smem
+        # (epi_bytes_per_stage == 0): A/B already claimed all smem above (epi_bytes
+        # was 0), there are no epilogue stages to refine, and any A/B remainder is
+        # smaller than one A/B stage -- so skip this (otherwise zero-division) step.
+        if const_expr(epi_bytes_per_stage > 0):
+            epi_stage += (remaining_bytes - ab_bytes_per_stage * ab_stage) // epi_bytes_per_stage
         return num_acc_stage, ab_stage, epi_stage, epi_c_stage
 
     @staticmethod

--- a/quack/gemm_sm90.py
+++ b/quack/gemm_sm90.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 
 from quack.cute_dsl_utils import ParamsBase
 from quack import layout_utils
+import quack.utils as utils
 from quack.tile_scheduler import (
     TileSchedulerOptions,
     TileSchedulerArguments,
@@ -31,6 +32,7 @@ from quack.tile_scheduler import (
     VarlenMTileSchedulerArguments,
     VarlenMTileScheduler,
     PersistenceMode,
+    params_has_split_k,
 )
 from quack.varlen_utils import VarlenArguments, VarlenManager
 
@@ -427,6 +429,9 @@ class GemmSm90:
         assert (varlen_args.mAIdx is not None) == self.gather_A
         varlen_m = varlen_args.mCuSeqlensM is not None
         varlen_k = varlen_args.mCuSeqlensK is not None
+        # The split-K fixup (turnstile reduction through gmem workspace) is only wired up
+        # in the SM100 kernel for now.
+        assert scheduler_args.splitk_ws is None, "split-K is only implemented on SM100"
 
         self._setup_attributes(epilogue_args)
 
@@ -980,6 +985,8 @@ class GemmSm90:
         # These are for Sm100 blockscaled gemm
         copy_SFA: Optional[Callable] = None,
         copy_SFB: Optional[Callable] = None,
+        # For split-K: first k tile this work unit is responsible for
+        k_tile_start: Int32 = 0,
     ) -> cutlass.pipeline.PipelineState:
         blockscaled = const_expr(copy_SFA is not None)
         if const_expr(blockscaled):
@@ -996,11 +1003,11 @@ class GemmSm90:
             tma_bar_ptr = ab_pipeline.producer_get_barrier(ab_producer_state)
             smem_idx = ab_producer_state.index
             if const_expr(copy_A is not None):
-                copy_A(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
-            copy_B(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+                copy_A(k_tile_start + k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+            copy_B(k_tile_start + k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
             if const_expr(blockscaled):
-                copy_SFA(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
-                copy_SFB(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+                copy_SFA(k_tile_start + k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+                copy_SFB(k_tile_start + k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
             # Mainloop pipeline's producer commit is a NOP
             ab_pipeline.producer_commit(ab_producer_state)
             ab_producer_state.advance()
@@ -1206,6 +1213,7 @@ class GemmSm90:
         tile_scheduler,
         tidx: Int32,
         is_tma_warp: Boolean,
+        splitk_fixup: Optional[Callable] = None,
     ) -> Tuple[cutlass.pipeline.PipelineState, cutlass.pipeline.PipelineState]:
         has_C = const_expr(tRS_rC is not None)
         has_D = const_expr(copy_D is not None)
@@ -1255,6 +1263,10 @@ class GemmSm90:
             gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
             # Copy from acc to D registers
             load_acc_subtile(tRS_rD, epi_idx)
+            # Split-K: the final split adds the turnstile-accumulated partials from the
+            # gmem workspace into its accumulator before any epilogue op (alpha/beta/C).
+            if const_expr(splitk_fixup is not None):
+                splitk_fixup(epi_idx)
             epi_loop_tensors = self.epi_begin_loop(params, epi_tensors, gmem_coord)
             if const_expr(has_C):
                 epi_pipeline.consumer_wait(epi_read_state)
@@ -1388,10 +1400,15 @@ class GemmSm90:
                 cluster_shape_mnk=self.cluster_shape_mnk,
                 tile_count_semaphore=scheduler_args.tile_count_semaphore,
                 batch_idx_permute=scheduler_args.batch_idx_permute,
+                split_k=scheduler_args.split_k,
+                splitk_flags=scheduler_args.splitk_flags,
+                splitk_ws=scheduler_args.splitk_ws,
+                splitk_parallel=scheduler_args.splitk_parallel,
                 persistence_mode=persistence_mode,
             )
         else:
             assert (mD is not None) or (epilogue_args.mPostAct is not None) or (not self.gather_A)
+            assert scheduler_args.splitk_ws is None, "split-K does not support varlen_m"
             problem_shape_ntile_mnl = (
                 None,
                 cute.ceil_div(cute.size(mB, mode=[0]), self.cta_tile_shape_mnk[1]),
@@ -1409,6 +1426,127 @@ class GemmSm90:
                 persistence_mode=persistence_mode,
             )
         return tile_sched_args
+
+    # ── Split-K with turnstile reduction ─────────────────────────────────────────
+    # Each output tile is computed by `split_k` work units, each covering a contiguous
+    # range of k tiles. Non-final splits serialize their partial accumulators into a
+    # gmem workspace through a per-tile turnstile counter (deterministic, k-ascending
+    # reduction order); the final split adds the accumulated partials into its own
+    # accumulator and runs the regular epilogue. This mirrors the fixup of CUTLASS's
+    # stream-K schedulers (ReductionMode::Deterministic).
+
+    @cute.jit
+    def splitk_k_tile_range(
+        self, params, k_split: Optional[Int32], k_tile_total: Int32
+    ) -> Tuple[Int32, Int32]:
+        """[k_tile_start, k_tile_start + k_tile_cnt) of k tiles owned by this work unit.
+
+        Returns (0, k_tile_total) when split-K is disabled. The first `rem` splits get
+        one extra k tile; the ragged final k tile (K % tile_k != 0) stays in the last
+        split, whose OOB handling is TMA zero-fill as usual.
+        """
+        if const_expr(not params_has_split_k(params)):
+            return Int32(0), Int32(k_tile_total)
+        split_k = params.split_k_fdd.divisor
+        base = k_tile_total // split_k
+        rem = k_tile_total - base * split_k
+        k_tile_start = k_split * base + cutlass.min(k_split, rem)
+        k_tile_cnt = base
+        if k_split < rem:
+            k_tile_cnt += 1
+        return Int32(k_tile_start), Int32(k_tile_cnt)
+
+    @cute.jit
+    def splitk_tile_index(self, tile_coord_mnkl: cute.Coord, mB_nkl: cute.Tensor) -> Int32:
+        """Linear output-tile index for split-K workspace/flag addressing.
+
+        N and L are taken from B (N, K, L) rather than D so that this works in parallel
+        mode, where the GEMM kernel is compiled without D.
+        """
+        ntile_n = cute.ceil_div(cute.size(mB_nkl, mode=[0]), self.cta_tile_shape_mnk[1])
+        num_l = cute.size(mB_nkl, mode=[2])
+        return Int32(
+            (tile_coord_mnkl[0] * ntile_n + tile_coord_mnkl[1]) * num_l + tile_coord_mnkl[3]
+        )
+
+    @cute.jit
+    def splitk_wait(self, flag_ptr: cute.Pointer, expected: Int32, tidx: Int32) -> None:
+        """Turnstile wait: spin until the per-tile flag equals `expected` (the k_split
+        index), i.e. all preceding splits have accumulated into the workspace.
+
+        Must be called by all threads participating in self.epilogue_barrier; the
+        acquire load by thread 0 plus the barrier orders subsequent workspace reads.
+        """
+        if tidx == 0:
+            val = utils.ld_acquire_gpu_i32(flag_ptr)
+            while val != expected:
+                val = utils.ld_acquire_gpu_i32(flag_ptr)
+        self.epilogue_barrier.arrive_and_wait()
+
+    @cute.jit
+    def splitk_arrive(self, flag_ptr: cute.Pointer, tidx: Int32) -> None:
+        """Turnstile arrive: release-increment the per-tile flag.
+
+        The barrier makes all participating threads' workspace stores visible before
+        thread 0's release reduction, so the next split's acquire observes them.
+        """
+        self.epilogue_barrier.arrive_and_wait()
+        if tidx == 0:
+            utils.red_release_gpu_add_i32(1, flag_ptr)
+
+    @cute.jit
+    def splitk_ws_subtile(
+        self, params, tile_idx: Int32, tTR_rD: cute.Tensor, tidx: Int32, epi_idx
+    ) -> cute.Tensor:
+        """Gmem view of this thread's accumulator fragment for epi subtile `epi_idx`.
+
+        The workspace has no (M, N) layout: fragments are stored in register order at
+        (tile, subtile, thread) offsets. All splits of a tile use identical epilogue
+        partitioning, so writer/reader correspondence is positional; OOB lanes of edge
+        tiles round-trip garbage that only the final split's epilogue predicates away.
+        """
+        frag_size = const_expr(cute.size(tTR_rD.shape))
+        num_epi_threads = const_expr(self.num_epi_warps * cute.arch.WARP_SIZE)
+        tile_mn = const_expr(self.cta_tile_shape_mnk[0] * self.cta_tile_shape_mnk[1])
+        offset = tile_idx * tile_mn + (epi_idx * num_epi_threads + tidx) * frag_size
+        return cute.make_tensor(params.splitk_ws.iterator + offset, tTR_rD.layout)
+
+    @cute.jit
+    def splitk_store_partials(
+        self,
+        params,
+        tile_idx: Int32,
+        k_split: Int32,
+        load_acc_subtile: Callable,
+        tRS_rD: cute.Tensor,
+        tTR_rD: cute.Tensor,
+        epi_tile_num: cutlass.Constexpr[int],
+        tidx: Int32,
+    ) -> None:
+        """Non-final split: accumulate this CTA's partials into the gmem workspace.
+
+        Caller must have passed the turnstile (splitk_wait) already. Split 0
+        initializes the workspace (no read), later splits read-add-write; the
+        workspace itself never needs zero-initialization.
+        """
+        for epi_idx in cutlass.range_constexpr(epi_tile_num):
+            load_acc_subtile(tRS_rD, epi_idx)
+            tWS = self.splitk_ws_subtile(params, tile_idx, tTR_rD, tidx, epi_idx)
+            if k_split == 0:
+                cute.autovec_copy(tTR_rD, tWS)
+            else:
+                tWS.store(tWS.load() + tTR_rD.load())
+
+    @cute.jit
+    def splitk_fixup_acc_subtile(
+        self, params, tile_idx: Int32, tTR_rD: cute.Tensor, tidx: Int32, epi_idx
+    ) -> None:
+        """Final split: add the turnstile-accumulated partials into this subtile's
+        accumulator registers (before any epilogue op). No-op when split_k == 1 at
+        runtime since the workspace then holds nothing."""
+        if params.split_k_fdd.divisor > 1:
+            tWS = self.splitk_ws_subtile(params, tile_idx, tTR_rD, tidx, epi_idx)
+            tTR_rD.store(tTR_rD.load() + tWS.load())
 
     def epi_retile_acc(self, acc, tRS_rD, tiled_copy_r2s):
         """Retile accumulator for epilogue subtile access. SM90 uses flat_divide."""

--- a/quack/gemm_splitk_reduce.py
+++ b/quack/gemm_splitk_reduce.py
@@ -1,0 +1,501 @@
+# Copyright (c) 2026, QuACK contributors.
+# Second kernel of parallel split-K GEMM: sums the per-split fp32 partial tiles written
+# by the GEMM kernel (fixed ascending split order -> run-to-run deterministic) and
+# applies the default epilogue (alpha, beta*C, rowvec/colvec bias) while converting to
+# the output dtype. Mirrors cuBLAS's splitKreduce_kernel.
+
+import math
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils
+from cutlass import Float32, Int32, const_expr
+from cutlass.cute.runtime import make_ptr
+
+import torch
+from torch import Tensor
+
+import quack.utils as utils
+from quack.cache_utils import jit_cache
+from quack.compile_utils import make_fake_tensor as fake_tensor
+from quack.cute_dsl_utils import torch2cute_dtype_map
+from quack.gemm_tvm_ffi_utils import div_for_dtype
+
+
+class SplitKReduce:
+    """One CTA per (output tile, chunk); each CTA sums its chunk across the tile's slots.
+
+    Workspace layout: tile `tile_idx` owns `tile_count[tile_idx]` consecutive slots
+    starting at `tile_first_slot[tile_idx]` (a host-built prefix sum); each slot holds a
+    row-major (tile_m, tile_n) fp32 partial, where tile_idx =
+    (tile_m_idx * ntile_n + tile_n_idx) * L + l. The fixed split-K path passes uniform
+    tables (count = split_k, first_slot = tile_idx * split_k); Stream-K will pass a
+    variable, data-dependent count per tile into the same kernel. Edge tiles are padded
+    inside the slot; this kernel predicates the final D store by (M, N).
+    """
+
+    # The reduce was latency-bound, NOT bandwidth-bound: at one thread per output element
+    # (vec_width=1) the total thread count is pinned at tile_mn, which for a single 128x128
+    # tile is only 256 CTAs of 64 threads -> waves=0.07, warps_active~5%, ~14 warps/SM max.
+    # With ~14 warps/SM and `count` serial HBM loads per thread, the GPU cannot hide the
+    # HBM latency, so ncu shows DRAM at ~8% of peak and issue_active ~45%. Repartitioning a
+    # FIXED thread count (num_threads / vec_width) never raises occupancy -- the only lever
+    # that fills the GPU is adding parallelism over the K (slot/contributor) dimension.
+    #
+    # `kgroups` (R) is that lever: each output element's `count` contributors are split into
+    # R contiguous groups, R threads in the same CTA each reduce one group (ascending), and
+    # the R partials are combined in shared memory in ascending group order. This multiplies
+    # the thread/warp count by R (one kernel, no extra HBM traffic for partials), lifting
+    # warps_active from ~5% to ~50-70% and the reduce's measured ncu kernel time on a single
+    # 128x128 sk=32 tile from ~13us to ~9us. The combine is a fixed blocked-ascending sum:
+    # run-to-run deterministic, and within <=1 bf16 ULP of the flat ascending sum (a few
+    # elements per tile, all within the bf16 test tolerance). kgroups is picked per call by
+    # choose_reduce_kgroups() so few-tile launches fill the GPU while many-tile launches
+    # (already full at R=1) stay on the exact flat-ascending path.
+    num_threads = 256
+    # Per-thread memory-level parallelism for the R=1 path: pre-stage up to `stage_slots`
+    # slot loads into registers (all outstanding at once) before the ordered accumulation
+    # consumes them. Only used when kgroups==1 (the many-tile / Stream-K path, which is
+    # already GPU-full and keeps bit-exact flat-ascending order).
+    stage_slots = 8
+
+    def __init__(self, tile_m: int, tile_n: int, vec_width: int = 1, kgroups: int = 1):
+        self.tile_m, self.tile_n, self.vec_width, self.kgroups = (
+            tile_m,
+            tile_n,
+            vec_width,
+            kgroups,
+        )
+        # The CTA covers num_threads/kgroups distinct output elements (each handled by
+        # kgroups threads that each reduce one contiguous group of contributors).
+        assert self.num_threads % kgroups == 0
+        self.elems_per_cta = self.num_threads // kgroups
+        # A vector never straddles a row of the slot, and chunks tile the slot exactly
+        assert tile_n % self.vec_width == 0
+        assert (tile_m * tile_n) % (self.elems_per_cta * self.vec_width) == 0
+
+    @cute.jit
+    def __call__(
+        self,
+        mWS: cute.Tensor,  # (total_contributors * tile_m * tile_n,) f32
+        mD: cute.Tensor,  # (M, N, L)
+        mC: Optional[cute.Tensor],  # (M, N, L)
+        alpha: Optional[Float32 | cute.Pointer],
+        beta: Optional[Float32 | cute.Pointer],
+        mRowVec: Optional[cute.Tensor],  # (L, N)
+        mColVec: Optional[cute.Tensor],  # (L, M)
+        mTileFirstSlot: cute.Tensor,  # (num_tiles,) i32: first slot owned by each tile
+        mTileCount: cute.Tensor,  # (num_tiles,) i32: contributors per tile
+        stream: cuda.CUstream,
+    ):
+        ntile_m = cute.ceil_div(cute.size(mD, mode=[0]), self.tile_m)
+        ntile_n = cute.ceil_div(cute.size(mD, mode=[1]), self.tile_n)
+        # One CTA per (output tile, chunk): a tile's chunks reduce on separate CTAs
+        # so the kernel fills the GPU instead of serializing on one CTA per tile. Each CTA
+        # covers elems_per_cta = num_threads/kgroups elements (kgroups threads per element).
+        # block_idx.z packs (l, chunk) -> grid.z = L * num_chunks.
+        num_chunks = (self.tile_m * self.tile_n) // (self.elems_per_cta * self.vec_width)
+        self.kernel(
+            mWS, mD, mC, alpha, beta, mRowVec, mColVec, mTileFirstSlot, mTileCount, ntile_n
+        ).launch(
+            grid=[ntile_m, ntile_n, cute.size(mD, mode=[2]) * num_chunks],
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mWS: cute.Tensor,
+        mD: cute.Tensor,
+        mC: Optional[cute.Tensor],
+        alpha: Optional[Float32 | cute.Pointer],
+        beta: Optional[Float32 | cute.Pointer],
+        mRowVec: Optional[cute.Tensor],
+        mColVec: Optional[cute.Tensor],
+        mTileFirstSlot: cute.Tensor,
+        mTileCount: cute.Tensor,
+        ntile_n: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bid_m, bid_n, bid_lc = cute.arch.block_idx()
+        tile_m = const_expr(self.tile_m)
+        tile_n = const_expr(self.tile_n)
+        tile_mn = const_expr(tile_m * tile_n)
+        V = const_expr(self.vec_width)
+        R = const_expr(self.kgroups)
+        Tw = const_expr(self.elems_per_cta)
+        num_chunks = const_expr(tile_mn // (Tw * V))
+        # block_idx.z packs (l, chunk): this CTA reduces one chunk of one output tile.
+        bid_l = bid_lc // num_chunks
+        chunk = bid_lc % num_chunks
+        # Thread split: kgroups threads cooperate on the same output element. `e` is the
+        # element-in-chunk (consecutive within a warp -> coalesced loads), `r` the k-group.
+        # When R==1, Tw==num_threads so r==0 and e==tidx (the original one-thread-per-elem).
+        r = tidx // Tw
+        e = tidx % Tw
+
+        len_m = cute.size(mD, mode=[0])
+        len_n = cute.size(mD, mode=[1])
+        num_l = cute.size(mD, mode=[2])
+        tile_idx = (bid_m * ntile_n + bid_n) * num_l + bid_l
+        # Variable per-tile contributor count + first-slot offset (a host-built prefix
+        # sum) generalize the fixed `tile_idx * split_k` of the uniform split-K path, so
+        # Stream-K (data-dependent contributors per tile) can reuse this reduce kernel.
+        first_slot = mTileFirstSlot[tile_idx]
+        count = mTileCount[tile_idx]
+        slot_base = mWS.iterator + first_slot * tile_mn
+        m0, n0 = bid_m * tile_m, bid_n * tile_n
+
+        alpha_v, beta_v = Float32(1.0), Float32(1.0)
+        if const_expr(alpha is not None):
+            alpha_v = utils.load_scalar_or_pointer(alpha)
+        if const_expr(beta is not None):
+            beta_v = utils.load_scalar_or_pointer(beta)
+
+        rAcc = cute.make_rmem_tensor(V, Float32)
+        flat = (chunk * Tw + e) * V
+        if const_expr(R == 1):
+            # R==1 (many-tile / Stream-K) path: already GPU-full at one thread per element.
+            # Sum the split slices in fixed flat ascending order (bit-exact, deterministic):
+            # stage a window of slot loads into registers (all outstanding at once -> mlp),
+            # then add them in ascending order. slot 0 seeds rAcc; slots [1, W] are
+            # pre-staged; any remainder (count > W) falls to an ordered loop.
+            W = const_expr(self.stage_slots)
+            tWS = cute.make_tensor(slot_base + flat, cute.make_layout(V))
+            cute.autovec_copy(tWS, rAcc)
+            staged = cute.make_rmem_tensor(W * V, Float32)
+            for s in cutlass.range_constexpr(1, W + 1):
+                if s < count:
+                    src = cute.make_tensor(slot_base + s * tile_mn + flat, cute.make_layout(V))
+                    dst = cute.make_tensor(staged.iterator + (s - 1) * V, cute.make_layout(V))
+                    cute.autovec_copy(src, dst)
+            for s in cutlass.range_constexpr(1, W + 1):
+                if s < count:
+                    staged_s = cute.make_tensor(
+                        staged.iterator + (s - 1) * V, cute.make_layout(V)
+                    )
+                    rAcc.store(rAcc.load() + staged_s.load())
+            for s in cutlass.range(W + 1, count, unroll=8):
+                tWS_s = cute.make_tensor(slot_base + s * tile_mn + flat, cute.make_layout(V))
+                rAcc.store(rAcc.load() + tWS_s.load())
+        else:
+            # R>1 intra-CTA K-split: this thread reduces its contiguous group of contributors
+            # [s0, s1) in ascending order; the R partials are combined below in shared memory
+            # in ascending group order (a fixed blocked-ascending sum: run-to-run
+            # deterministic, <=1 bf16 ULP from the flat sum). spg rounds up so groups tile
+            # [0, count); the last group(s) may be empty (s0 >= count) when R does not divide
+            # count, and contribute 0 -- matching the blocked reference.
+            spg = (count + R - 1) // R
+            s0 = r * spg
+            s1 = cutlass.min(s0 + spg, count)
+            for i in cutlass.range_constexpr(V):
+                rAcc[i] = Float32(0.0)
+            if s0 < s1:
+                t0 = cute.make_tensor(slot_base + s0 * tile_mn + flat, cute.make_layout(V))
+                cute.autovec_copy(t0, rAcc)
+            for s in cutlass.range(s0 + 1, s1, unroll=8):
+                tWS_s = cute.make_tensor(slot_base + s * tile_mn + flat, cute.make_layout(V))
+                rAcc.store(rAcc.load() + tWS_s.load())
+            # Combine R partials in smem: sBuf[r, e*V + i]. r==0 sums in ascending r order.
+            smem = cutlass.utils.SmemAllocator()
+            sBuf = smem.allocate_tensor(
+                Float32, cute.make_layout((R, Tw * V)), byte_alignment=16
+            )
+            for i in cutlass.range_constexpr(V):
+                sBuf[r, e * V + i] = rAcc[i]
+            cute.arch.sync_threads()
+            if r == 0:
+                for i in cutlass.range_constexpr(V):
+                    acc = sBuf[0, e * V + i]
+                    for rr in cutlass.range_constexpr(1, R):
+                        acc += sBuf[rr, e * V + i]
+                    rAcc[i] = acc
+        # The vector spans one row of the slot (tile_n % V == 0). Only the r==0 thread of
+        # each element does the epilogue + store; for R==1 every thread is r==0.
+        do_epi = const_expr(True) if const_expr(R == 1) else (r == 0)
+        m = m0 + flat // tile_n
+        n_base = n0 + flat % tile_n
+        if do_epi and m < len_m:
+            colvec_val = Float32(0.0)
+            if const_expr(mColVec is not None):
+                colvec_val = Float32(mColVec[bid_l, m])
+            # Epilogue + predicated store, elementwise (D/C layout-agnostic).
+            # Same op order as GemmDefaultEpiMixin.epi_visit_subtile:
+            # alpha * acc, then (+ beta * C | + C), then rowvec/colvec bias.
+            for i in cutlass.range_constexpr(V):
+                n = n_base + i
+                if n < len_n:
+                    val = Float32(rAcc[i])
+                    if const_expr(alpha is not None):
+                        val = val * alpha_v
+                    if const_expr(mC is not None):
+                        c_val = Float32(mC[m, n, bid_l])
+                        if const_expr(beta is not None):
+                            val += beta_v * c_val
+                        else:
+                            val += c_val
+                    if const_expr(mRowVec is not None):
+                        val += Float32(mRowVec[bid_l, n])
+                    if const_expr(mColVec is not None):
+                        val += colvec_val
+                    mD[m, n, bid_l] = mD.element_type(val)
+
+
+@jit_cache
+def _compile_splitk_reduce(
+    d_dtype,
+    c_dtype,
+    d_major,
+    c_major,
+    tile_m,
+    tile_n,
+    vec_width,
+    kgroups,
+    alpha_mode,
+    beta_mode,
+    rowvec_dtype,
+    colvec_dtype,
+):
+    m, n, l = cute.sym_int(), cute.sym_int(), cute.sym_int()
+
+    def fake_scalar(mode):
+        if mode == 0:
+            return None
+        elif mode == 1:
+            return Float32(1.0)
+        else:
+            return make_ptr(Float32, 0, cute.AddressSpace.gmem, assumed_align=4)
+
+    mWS = fake_tensor(Float32, (cute.sym_int(),), leading_dim=0, divisibility=4)
+    mD = fake_tensor(
+        d_dtype,
+        (m, n, l),
+        leading_dim=1 if d_major == "n" else 0,
+        divisibility=div_for_dtype(d_dtype),
+    )
+    mC = (
+        fake_tensor(
+            c_dtype,
+            (m, n, l),
+            leading_dim=1 if c_major == "n" else 0,
+            divisibility=div_for_dtype(c_dtype),
+        )
+        if c_dtype is not None
+        else None
+    )
+    mRowVec = (
+        fake_tensor(rowvec_dtype, (l, n), leading_dim=1, divisibility=4)
+        if rowvec_dtype is not None
+        else None
+    )
+    mColVec = (
+        fake_tensor(colvec_dtype, (l, m), leading_dim=1, divisibility=4)
+        if colvec_dtype is not None
+        else None
+    )
+    mTileFirstSlot = fake_tensor(Int32, (cute.sym_int(),), leading_dim=0, divisibility=1)
+    mTileCount = fake_tensor(Int32, (cute.sym_int(),), leading_dim=0, divisibility=1)
+    return cute.compile(
+        SplitKReduce(tile_m, tile_n, vec_width, kgroups),
+        mWS,
+        mD,
+        mC,
+        fake_scalar(alpha_mode),
+        fake_scalar(beta_mode),
+        mRowVec,
+        mColVec,
+        mTileFirstSlot,
+        mTileCount,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _scalar_modes(alpha, beta):
+    alpha_mode = 2 if isinstance(alpha, Tensor) else (1 if alpha != 1.0 else 0)
+    beta_mode = 2 if isinstance(beta, Tensor) else (1 if beta != 1.0 else 0)
+    return alpha_mode, beta_mode
+
+
+def compile_splitk_reduce(
+    D, C, alpha, beta, rowvec, colvec, tile_m, tile_n, vec_width, kgroups=1
+):
+    """Compile (or fetch from cache) the reduce kernel for these tensor properties."""
+    alpha_mode, beta_mode = _scalar_modes(alpha, beta)
+    return _compile_splitk_reduce(
+        torch2cute_dtype_map[D.dtype],
+        torch2cute_dtype_map[C.dtype] if C is not None else None,
+        "n" if D.stride(1) == 1 else "m",
+        ("n" if C.stride(1) == 1 else "m") if C is not None else None,
+        tile_m,
+        tile_n,
+        vec_width,
+        kgroups,
+        alpha_mode,
+        beta_mode,
+        torch2cute_dtype_map[rowvec.dtype] if rowvec is not None else None,
+        torch2cute_dtype_map[colvec.dtype] if colvec is not None else None,
+    )
+
+
+def auto_split_k(m, n, k, l, tile_m, tile_n, num_sms, max_split_k: int = 40) -> int:
+    """Heuristic split_k for parallel split-K. The GEMM launches `tiles * split_k` work units
+    across up to `num_sms` persistent CTAs, so it runs in ceil(tiles*split_k/num_sms) waves,
+    and a separate reduce then sums `split_k` fp32 partials per output element (its cost grows
+    with split_k). split_k thus trades GEMM fill against reduce cost; the optimum (validated by
+    a cold-L2 do_bench sweep on B200, where the reduce reads the workspace the GEMM just
+    evicted) splits into two regimes:
+
+    Multi-tile (tiles >= 2): the output tiles already supply parallelism, so split only far
+    enough to round the GPU out to ~0.7 of a wave -- NOT a full wave. The old `ceil(num_sms/
+    tiles)` overshot into a near-empty 2nd wave (512x512x16384, 16 tiles: ceil = 10 -> 160
+    units = 1.08 waves, a tail the GPU eats in full -> 0.69x of cuBLAS), and even exactly one
+    wave wastes reduce work past saturation (256x256x32768, 4 tiles: a full-wave split_k=32 is
+    0.84x vs split_k=24 at 0.65 wave = 0.97x). `floor(0.70*num_sms/tiles)` lands on the
+    measured optimum for both (512 -> 6, 256 -> 24).
+
+    Single tile (tiles == 1): the split funnels through one tile's accumulators, so GEMM
+    latency falls as ~k_tiles/split_k while reduce cost rises as ~split_k; their product is
+    minimized near split_k ~ sqrt(k_tiles). `round(1.2*sqrt(k_tiles))` matches the sweep
+    (128x128x16384, k_tiles=256 -> 19~=opt 20 -> 1.00x; 128x128x65536, k_tiles=1024 -> 38~=opt
+    36 -> 0.95x), whereas filling the GPU (split_k>=64) is 0.82x (all reduce, no extra GEMM).
+
+    Capped so each split keeps enough K to amortize the reduce (k_tiles // 8) and below
+    `max_split_k` (past which reduce cost outgrows the extra GEMM fill). Returns 1 when the
+    output tiles already fill the GPU (split-K won't help). Assumes a 64-deep K tile
+    (bf16/fp16, the dtypes parallel split-K supports)."""
+    tiles = ((m + tile_m - 1) // tile_m) * ((n + tile_n - 1) // tile_n) * l
+    k_tiles = max(1, k // 64)
+    if tiles >= 2:
+        fill = (7 * max(1, num_sms) // 10) // tiles  # floor(0.70 * num_sms / tiles): ~0.7 wave
+    else:
+        fill = round(1.2 * math.sqrt(k_tiles))  # single tile: balance GEMM latency vs reduce
+    return max(1, min(fill, k_tiles // 8, max_split_k))
+
+
+def choose_reduce_vec_width(num_tiles: int, tile_m: int, tile_n: int, num_sms: int) -> int:
+    """fp32 elements per reduce thread. The reduce is latency-bound, so fewer elements ->
+    more threads (tile_mn/V per tile) -> better latency hiding; but too few over-decomposes
+    into many tiny CTAs (num_tiles * tile_mn / (num_threads*V)) whose launch/scheduling
+    overhead shows when the reduce isn't the bottleneck (many output tiles). Pick the
+    smallest valid V whose total reduce-CTA count stays within ~8 GPU waves; else the
+    largest valid V. (Few tiles -> V=1, max threads; many tiles -> larger V, fewer CTAs.)
+    Note: in the real GEMM->reduce pipeline the reduce reads a workspace the GEMM just
+    evicted from L2, so it is HBM-latency-bound and V (load width) barely moves the cold
+    reduce time. The dominant reduce levers are the split_k that auto_split_k picks (slots to
+    sum) and, for few-tile launches, the intra-CTA K-split R from choose_reduce_kgroups (which
+    fills the GPU) -- not V, which here just sets CTA granularity for many-tile shapes."""
+    nt = SplitKReduce.num_threads
+    tile_mn = tile_m * tile_n
+    cta_cap = max(1, num_sms) * 8
+    best = 1
+    for V in (1, 2, 4):
+        if tile_n % V != 0 or tile_mn % (nt * V) != 0:
+            continue
+        best = V  # largest valid so far (fallback when none fit the cap)
+        if num_tiles * (tile_mn // (nt * V)) <= cta_cap:
+            return V
+    return best
+
+
+def choose_reduce_kgroups(
+    num_tiles: int, tile_m: int, tile_n: int, split_k: int, vec_width: int, num_sms: int
+) -> int:
+    """Intra-CTA K-split factor R for the reduce. The reduce is latency-bound, so the goal
+    is enough resident warps to hide HBM latency. Without K-split the reduce launches
+    num_tiles * tile_mn / (num_threads * V) CTAs; for few output tiles that is far below
+    the GPU's capacity (a single 128x128 tile is 64 CTAs at num_threads=256 -> ~5% warps
+    active). R multiplies the CTA/warp count by R (each element handled by R threads that
+    each reduce 1/R of the contributors, combined in smem). Pick the smallest R (power of
+    two) that brings the CTA count to ~`target_waves` GPU waves, capped so each k-group
+    still has work (R <= split_k) and the per-element thread group stays a warp-friendly
+    size (elems_per_cta = num_threads/R divides tile_mn/V and is a multiple of 32). R=1
+    when the launch is already GPU-full (many tiles) -> exact flat-ascending path."""
+    nt = SplitKReduce.num_threads
+    tile_mn = tile_m * tile_n
+    target_ctas = max(1, num_sms) * 4
+    base_ctas = num_tiles * tile_mn // (nt * vec_width)  # CTAs at R=1
+    if base_ctas >= target_ctas:
+        return 1  # already GPU-full at R=1 -> keep the exact flat-ascending (bit-exact) path
+    best = 1
+    R = 2
+    while R <= split_k and R <= nt:
+        elems = nt // R
+        if elems % 32 != 0 or (tile_mn // vec_width) % elems != 0:
+            R *= 2
+            continue
+        best = R  # largest valid so far
+        if base_ctas * R >= target_ctas:
+            return R
+        R *= 2
+    return best
+
+
+_uniform_tables_cache: dict = {}
+
+
+def uniform_splitk_tables(num_tiles: int, split_k: int, device) -> tuple[Tensor, Tensor]:
+    """(tile_first_slot, tile_count) for the fixed split-K layout: every tile has exactly
+    `split_k` contributors at slots [t*split_k, (t+1)*split_k). Cached per
+    (num_tiles, split_k, device) so the parallel split-K path pays no per-call build cost.
+    Stream-K will instead build non-uniform tables and feed the same reduce kernel."""
+    dev_key = device.index if device.type == "cuda" else -1
+    key = (num_tiles, split_k, dev_key)
+    cached = _uniform_tables_cache.get(key)
+    if cached is None:
+        first = torch.arange(0, num_tiles * split_k, split_k, dtype=torch.int32, device=device)
+        count = torch.full((num_tiles,), split_k, dtype=torch.int32, device=device)
+        cached = (first, count)
+        _uniform_tables_cache[key] = cached
+    return cached
+
+
+def splitk_reduce(
+    ws: Tensor,  # (total_contributors * tile_m * tile_n,) f32 partials
+    D: Tensor,  # (M, N, L), post-perm3d layout
+    C: Optional[Tensor],  # (M, N, L), post-perm3d layout
+    alpha: float | Tensor,
+    beta: float | Tensor,
+    rowvec: Optional[Tensor],  # (L, N)
+    colvec: Optional[Tensor],  # (L, M)
+    tile_first_slot: Tensor,  # (num_tiles,) i32
+    tile_count: Tensor,  # (num_tiles,) i32
+    tile_m: int,
+    tile_n: int,
+    vec_width: int = 1,
+    kgroups: int = 1,
+) -> None:
+    compiled_fn = compile_splitk_reduce(
+        D, C, alpha, beta, rowvec, colvec, tile_m, tile_n, vec_width, kgroups
+    )
+
+    from quack.cache_utils import COMPILE_ONLY
+
+    if COMPILE_ONLY:
+        return
+
+    alpha_mode, beta_mode = _scalar_modes(alpha, beta)
+
+    def scalar_arg(scalar, mode):
+        if mode == 0:
+            return None
+        elif mode == 1:
+            return float(scalar)
+        else:
+            return scalar.data_ptr()
+
+    compiled_fn(
+        ws,
+        D,
+        C,
+        scalar_arg(alpha, alpha_mode),
+        scalar_arg(beta, beta_mode),
+        rowvec,
+        colvec,
+        tile_first_slot,
+        tile_count,
+    )

--- a/quack/gemm_tvm_ffi_utils.py
+++ b/quack/gemm_tvm_ffi_utils.py
@@ -59,7 +59,13 @@ def get_dtypes(A, B, D, C):
 
 
 def make_scheduler_args(
-    max_active_clusters, max_swizzle_size, tile_count_semaphore, batch_idx_permute=None
+    max_active_clusters,
+    max_swizzle_size,
+    tile_count_semaphore,
+    batch_idx_permute=None,
+    split_k=1,
+    splitk_flags=None,
+    splitk_ws=None,
 ):
     return TileSchedulerOptions(
         max_active_clusters=Int32(max_active_clusters),
@@ -69,10 +75,16 @@ def make_scheduler_args(
             tile_count_semaphore.data_ptr() if tile_count_semaphore is not None else None
         ),
         batch_idx_permute=batch_idx_permute,
+        split_k=Int32(split_k),
+        splitk_flags=(splitk_flags.data_ptr() if splitk_flags is not None else None),
+        splitk_ws=splitk_ws,
+        splitk_parallel=None,  # Constexpr, pass None at runtime (baked from the fake args)
     )
 
 
-def make_fake_scheduler_args(has_semaphore, has_batch_idx_permute, l_sym):
+def make_fake_scheduler_args(
+    has_semaphore, has_batch_idx_permute, l_sym, has_split_k=False, splitk_parallel=False
+):
     return TileSchedulerOptions(
         max_active_clusters=Int32(1),
         max_swizzle_size=Int32(8),
@@ -84,6 +96,18 @@ def make_fake_scheduler_args(has_semaphore, has_batch_idx_permute, l_sym):
             if has_batch_idx_permute
             else None
         ),
+        split_k=Int32(1),
+        splitk_flags=(
+            make_ptr(Int32, 0, cute.AddressSpace.gmem, assumed_align=4)
+            if has_split_k and not splitk_parallel
+            else None
+        ),
+        splitk_ws=(
+            fake_tensor(Float32, (cute.sym_int(),), leading_dim=0, divisibility=4)
+            if has_split_k
+            else None
+        ),
+        splitk_parallel=splitk_parallel,
     )
 
 

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -584,8 +584,10 @@ class RMSNormBackward(ReductionBase):
         mRstd: cute.Tensor,
         mdX: cute.Tensor,
         mdW: Optional[cute.Tensor],
+        mdW_final: Optional[cute.Tensor],
         mdRes: Optional[cute.Tensor],
         mdB: Optional[cute.Tensor],
+        reduce_counter: Optional[cute.Tensor],
         sm_count: Int32,
         stream: cuda.CUstream,
     ):
@@ -603,7 +605,8 @@ class RMSNormBackward(ReductionBase):
         num_blocks = sm_count
         num_heads = mX.shape[1] if const_expr(cute.rank(mX) == 3) else 1
         self.kernel(
-            mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes, tiler_mn, tiled_copy, threads_per_row
+            mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdW_final, mdB, mdRes,
+            reduce_counter, tiler_mn, tiled_copy, threads_per_row
         ).launch(
             grid=[num_blocks, self.cluster_n, num_heads],
             block=[num_threads, 1, 1],
@@ -621,8 +624,10 @@ class RMSNormBackward(ReductionBase):
         mRstd: cute.Tensor,
         mdX: cute.Tensor,
         mdW: Optional[cute.Tensor],
+        mdW_final: Optional[cute.Tensor],
         mdB: Optional[cute.Tensor],
         mdRes: Optional[cute.Tensor],
+        reduce_counter: Optional[cute.Tensor],
         tiler_mn: cute.Shape,
         tiled_copy: cute.TiledCopy,
         threads_per_row: cutlass.Constexpr[int],
@@ -893,6 +898,82 @@ class RMSNormBackward(ReductionBase):
             if const_expr(mdB is not None):
                 copy(tXrdB, tXgdB)
 
+
+        # Cross-CTA deterministic dW reduction (last-CTA-reduces pattern).
+        # Each CTA has already written its partial to dw_partial[bidx_start, :].
+        # After a threadfence + atomic counter, the last CTA to arrive loads
+        # all partials in fixed order and accumulates into dw_final.
+        if const_expr(mdW_final is not None and self.cluster_n == 1):
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.barrier()
+            utils.threadfence()
+
+            smem_is_last = cute.make_tensor(
+                cute.recast_ptr(sX.iterator, dtype=Int32),
+                cute.make_layout((1,)),
+            )
+            if tidx == 0:
+                old = utils.atomic_add_i32(Int32(1), reduce_counter.iterator)
+                smem_is_last[0] = old
+            cute.arch.barrier()
+
+            if smem_is_last[0] == gdim - Int32(1):
+                sdW_buf = cute.make_tensor(
+                    cute.recast_ptr(sX.iterator, dtype=cute.Float32),
+                    cute.make_layout((tiler_mn[1],)),
+                )
+                num_thr = cute.size(tiled_copy)
+                vecsize_f32 = const_expr(min(tiler_mn[1], 128 // cute.Float32.width))
+                thr_copy_dw = copy_utils.tiled_copy_1d(
+                    cute.Float32, num_thr, vecsize_f32, is_async=True,
+                )
+                thr_dw = thr_copy_dw.get_slice(tidx)
+
+                gdW_all = cute.make_tensor(mdW.iterator, mdW.layout)
+                gdW_final_1d = cute.make_tensor(
+                    mdW_final.iterator, cute.make_layout((tiler_mn[1],))
+                )
+
+                # Accumulate first row directly into smem
+                gdW_row0 = cute.make_tensor(
+                    gdW_all.iterator, cute.make_layout((tiler_mn[1],))
+                )
+                copy_utils.copy(
+                    thr_dw.partition_S(gdW_row0), thr_dw.partition_D(sdW_buf),
+                    is_async=True,
+                )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+
+                # Load remaining rows and accumulate in smem
+                for i in range(1, gdim):
+                    sdW_tmp = cute.make_tensor(
+                        cute.recast_ptr(sX.iterator, dtype=cute.Float32) + tiler_mn[1],
+                        cute.make_layout((tiler_mn[1],)),
+                    )
+                    gdW_row_i = cute.make_tensor(
+                        gdW_all.iterator + i * tiler_mn[1],
+                        cute.make_layout((tiler_mn[1],)),
+                    )
+                    copy_utils.copy(
+                        thr_dw.partition_S(gdW_row_i), thr_dw.partition_D(sdW_tmp),
+                        is_async=True,
+                    )
+                    cute.arch.cp_async_commit_group()
+                    cute.arch.cp_async_wait_group(0)
+                    cute.arch.barrier()
+                    thr_buf = thr_dw.partition_D(sdW_buf)
+                    thr_tmp = thr_dw.partition_S(sdW_tmp)
+                    for j in range(cute.size(thr_buf)):
+                        thr_buf[j] = thr_buf[j] + thr_tmp[j]
+                    cute.arch.barrier()
+
+                # Store final accumulated result to dw_final
+                copy_utils.copy(
+                    thr_dw.partition_S(sdW_buf), thr_dw.partition_D(gdW_final_1d),
+                )
+
         if const_expr(self.cluster_n > 1):  # Prevent cluster from exiting early
             # Assume state contains that next useful buffer
             # So we only need to advance to num_stages - 1 times to last used buffer
@@ -921,10 +1002,10 @@ def _get_sm_count(N: int, device: torch.device) -> int:
 
 @torch.library.custom_op(
     "quack::_rmsnorm_bwd",
-    mutates_args={"dx", "dw_partial", "db_partial", "dresidual"},
+    mutates_args={"dx", "dw_partial", "db_partial", "dresidual", "dw", "reduce_counter"},
     device_types="cuda",
     # We need to specify the schema manually since we're mutating an optional tensor
-    schema="(Tensor x, Tensor? weight, Tensor dout, Tensor rstd, Tensor(a4!) dx, Tensor(a5!)? dw_partial, Tensor(a6!)? db_partial, Tensor? dresidual_out, Tensor(a8!)? dresidual, int? sm_count) -> ()",
+    schema="(Tensor x, Tensor? weight, Tensor dout, Tensor rstd, Tensor(a4!) dx, Tensor(a5!)? dw_partial, Tensor(a6!)? db_partial, Tensor? dresidual_out, Tensor(a8!)? dresidual, int? sm_count, Tensor(a10!)? dw, Tensor(a11!)? reduce_counter) -> ()",
 )
 def _rmsnorm_bwd(
     x: Tensor,
@@ -937,6 +1018,8 @@ def _rmsnorm_bwd(
     dresidual_out: Optional[Tensor] = None,
     dresidual: Optional[Tensor] = None,
     sm_count: Optional[int] = None,
+    dw: Optional[Tensor] = None,
+    reduce_counter: Optional[Tensor] = None,
 ) -> None:
     """RMSNorm backward pass.
     Args:
@@ -1003,6 +1086,8 @@ def _rmsnorm_bwd_fake(
     dresidual_out: Optional[Tensor] = None,
     dresidual: Optional[Tensor] = None,
     sm_count: Optional[int] = None,
+    dw: Optional[Tensor] = None,
+    reduce_counter: Optional[Tensor] = None,
 ) -> None:
     # See softmax.py _softmax_fwd_fake for why register_fake is needed.
     from quack.cache_utils import COMPILE_ONLY
@@ -1016,6 +1101,7 @@ def _rmsnorm_bwd_fake(
             torch2cute_dtype_map[t.dtype] if t is not None else None
             for t in [x, dout, dx, weight, dresidual, dresidual_out]
         ]
+        dw_dtype = torch2cute_dtype_map[dw.dtype] if dw is not None else None
         _compile_rmsnorm_bwd(
             N,
             dtype,
@@ -1027,6 +1113,7 @@ def _rmsnorm_bwd_fake(
             dres_out_dtype,
             dw_partial is not None,
             per_head,
+            dw_dtype,
         )
 
 
@@ -1042,6 +1129,7 @@ def _compile_rmsnorm_bwd(
     dres_out_dtype,
     has_dw_partial,
     per_head=False,
+    dw_dtype=None,
 ):
     batch_sym, batch_partial_sym = cute.sym_int(), cute.sym_int()
     head_sym = cute.sym_int() if per_head else None
@@ -1058,6 +1146,8 @@ def _compile_rmsnorm_bwd(
     dw_shape = (batch_partial_sym, head_sym, N) if per_head else (batch_partial_sym, N)
     dw_partial_cute = fake_tensor(Float32, dw_shape, div) if has_dw_partial else None
     db_partial_cute = fake_tensor(Float32, dw_shape, div) if has_db_partial else None
+    dw_cute = fake_tensor(dw_dtype, (N,), div) if dw_dtype is not None else None
+    reduce_counter_cute = fake_tensor(Int32, (1,)) if dw_dtype is not None else None
     return cute.compile(
         RMSNormBackward(dtype, N),
         x_cute,
@@ -1067,8 +1157,10 @@ def _compile_rmsnorm_bwd(
         rstd_cute,
         dx_cute,
         dw_partial_cute,
+        dw_cute,
         dres_cute,
         db_partial_cute,
+        reduce_counter_cute,
         0,  # sm_count, just for compilation
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         options="--enable-tvm-ffi",
@@ -1098,12 +1190,18 @@ def rmsnorm_bwd(
         sm_count = max(round(sm_count / H), 1)
     else:
         H = None
+    dw_partial: Optional[Tensor] = None
+    dw_final: Optional[Tensor] = None
+    reduce_counter: Optional[Tensor] = None
+    # Fused cross-CTA dW reduction (last-CTA-reduces) for cluster_n == 1 and non-per-head.
+    use_fused_dw_reduce = N <= 8192 and weight is not None and not per_head
     if weight is not None:
         # Always store partial gradients in fp32 for numerical accuracy
         dw_shape = (sm_count, H, N) if per_head else (sm_count, N)
         dw_partial = torch.empty(dw_shape, device=device, dtype=torch.float32)
-    else:
-        dw_partial = None
+        if use_fused_dw_reduce:
+            dw_final = torch.empty(N, device=device, dtype=torch.float32)
+            reduce_counter = torch.zeros(1, device=device, dtype=torch.int32)
     db_shape = (sm_count, H, N) if per_head else (sm_count, N)
     db_partial = torch.empty(db_shape, device=device, dtype=torch.float32) if has_bias else None
 

--- a/quack/tile_scheduler.py
+++ b/quack/tile_scheduler.py
@@ -58,6 +58,18 @@ class TileSchedulerOptions(NamedTuple):
     max_swizzle_size: Int32 = Int32(8)
     tile_count_semaphore: Optional[cute.Pointer] = None
     batch_idx_permute: Optional[cute.Tensor] = None
+    # Split-K: number of K splits per output tile (runtime value; > 1 only when the
+    # flags/workspace buffers below are provided).
+    split_k: Int32 = Int32(1)
+    # (num_tiles_m * num_tiles_n * L,) int32 turnstile counters, zero-initialized.
+    # Only used in serial (turnstile) mode; None in parallel mode.
+    splitk_flags: Optional[cute.Pointer] = None
+    # f32 partial-accumulator workspace. Serial mode: one tile_m*tile_n slot per output
+    # tile (fragment order). Parallel mode: split_k slots per output tile (row-major).
+    splitk_ws: Optional[cute.Tensor] = None
+    # Parallel split-K: all splits store partials to their own workspace slice with no
+    # inter-CTA synchronization; a separate reduce kernel sums them and runs the epilogue.
+    splitk_parallel: cutlass.Constexpr[bool] = False
 
 
 @dataclass
@@ -68,7 +80,20 @@ class TileSchedulerArguments:
     cluster_shape_mnk: cutlass.Constexpr[cute.Shape]
     tile_count_semaphore: Optional[cute.Pointer] = None
     batch_idx_permute: Optional[cute.Tensor] = None
+    split_k: Int32 = Int32(1)
+    splitk_flags: Optional[cute.Pointer] = None
+    splitk_ws: Optional[cute.Tensor] = None
+    splitk_parallel: cutlass.Constexpr[bool] = False
     persistence_mode: cutlass.Constexpr[PersistenceMode] = PersistenceMode.NONE
+
+
+def params_has_split_k(params) -> bool:
+    """Whether scheduler params carry split-K state (compile-time check).
+
+    Uses getattr since only TileScheduler.Params has the field; Triangular/VarlenM
+    scheduler Params don't support split-K.
+    """
+    return getattr(params, "splitk_ws", None) is not None
 
 
 class TileScheduler:
@@ -83,6 +108,10 @@ class TileScheduler:
         num_clusters_in_group_fdd: FastDivmod
         tile_count_semaphore: Optional[cute.Pointer]
         batch_idx_permute: Optional[cute.Tensor]
+        split_k_fdd: FastDivmod
+        splitk_flags: Optional[cute.Pointer]
+        splitk_ws: Optional[cute.Tensor]
+        splitk_parallel: cutlass.Constexpr[bool]
         cluster_shape_mn: cutlass.Constexpr[cute.Shape]
         persistence_mode: cutlass.Constexpr[PersistenceMode]
 
@@ -90,6 +119,20 @@ class TileScheduler:
         @cute.jit
         def create(args: TileSchedulerArguments, *, loc=None, ip=None) -> "TileScheduler.Params":
             assert args.cluster_shape_mnk[2] == 1
+            if const_expr(args.splitk_ws is not None):
+                if const_expr(args.splitk_parallel):
+                    # No inter-CTA synchronization in parallel mode, so no flags.
+                    assert args.splitk_flags is None
+                else:
+                    assert args.splitk_flags is not None
+                # Serial mode: forward progress of the turnstile requires that a work unit
+                # only ever waits on units with smaller work index; STATIC/DYNAMIC hand out
+                # work indices in increasing order per CTA, CLC/NONE do not guarantee any
+                # ordering. Parallel mode has no waits but its split work-index expansion
+                # is only wired up for the STATIC/DYNAMIC grid math.
+                assert args.persistence_mode in (PersistenceMode.STATIC, PersistenceMode.DYNAMIC), (
+                    "split-K requires STATIC or DYNAMIC persistence"
+                )
             cluster_shape_mn = const_expr(cute.select(args.cluster_shape_mnk, mode=[0, 1]))
             problem_shape_ntile_mn = cute.select(args.problem_shape_ntile_mnl, mode=[0, 1])
             problem_shape_ncluster_mn = cute.ceil_div(problem_shape_ntile_mn, cluster_shape_mn)
@@ -129,6 +172,10 @@ class TileScheduler:
                 if const_expr(args.persistence_mode == PersistenceMode.DYNAMIC)
                 else None,
                 args.batch_idx_permute,
+                FastDivmod(args.split_k),
+                args.splitk_flags if const_expr(args.splitk_ws is not None) else None,
+                args.splitk_ws,
+                args.splitk_parallel,
                 cluster_shape_mn,
                 args.persistence_mode,
             )
@@ -139,6 +186,7 @@ class TileScheduler:
         num_tiles_executed: Int32,
         current_batch_idx: Int32,
         num_work_idx_before_cur_batch: Int32,
+        current_k_split: Int32,
         sched_smem: Optional[cute.Tensor],
         scheduler_pipeline: Optional[cutlass.pipeline.PipelineAsync],
         pipeline_state: PipelineStateWAdvance,
@@ -151,6 +199,11 @@ class TileScheduler:
         self.num_tiles_executed = num_tiles_executed
         self._current_batch_idx = current_batch_idx
         self._num_work_idx_before_cur_batch = num_work_idx_before_cur_batch
+        # K-split index of the current work tile (always 0 when split-K is disabled).
+        # Carried as scheduler state rather than in WorkTileInfo.tile_idx: the DSL's
+        # WorkTileInfo has a rigid pytree schema (3 coord leaves + validity) and asserts
+        # on reconstruction if the K slot holds a dynamic value.
+        self.current_k_split = current_k_split
         self._sched_smem = sched_smem
         self._scheduler_pipeline = scheduler_pipeline
         self._pipeline_state = pipeline_state
@@ -222,6 +275,7 @@ class TileScheduler:
             Int32(0),  # num_tiles_executed
             Int32(0),  # current_batch_idx
             Int32(0),  # num_work_idx_before_cur_batch
+            Int32(0),  # current_k_split
             sched_smem,
             scheduler_pipeline,
             PipelineStateWAdvance(stages, Int32(0), Int32(0), Int32(0)),
@@ -246,9 +300,10 @@ class TileScheduler:
                 params.problem_shape_ncluster_mnl[2],
             )
         else:
-            num_ctas_in_problem = cute.size(
-                params.problem_shape_ncluster_mnl, loc=loc, ip=ip
-            ) * cute.size(params.cluster_shape_mn)
+            num_work_units = cute.size(params.problem_shape_ncluster_mnl, loc=loc, ip=ip)
+            if const_expr(params_has_split_k(params)):
+                num_work_units = num_work_units * params.split_k_fdd.divisor
+            num_ctas_in_problem = num_work_units * cute.size(params.cluster_shape_mn)
             num_ctas_per_cluster = cute.size(params.cluster_shape_mn, loc=loc, ip=ip)
             # Total ctas that can run in one wave
             num_ctas_per_wave = max_active_clusters * num_ctas_per_cluster
@@ -310,15 +365,27 @@ class TileScheduler:
         ip=None,
     ) -> cutlass.utils.WorkTileInfo:
         params = self.params
+        has_split_k = const_expr(params_has_split_k(params))
         if const_expr(is_valid is None):
             if const_expr(params.persistence_mode == PersistenceMode.NONE):
                 is_valid = self.num_tiles_executed == 0
             elif const_expr(params.persistence_mode == PersistenceMode.CLC):
                 is_valid = work_idx < cute.size(params.problem_shape_ncluster_mnl[:2])
             else:
-                is_valid = work_idx < cute.size(params.problem_shape_ncluster_mnl)
+                num_work = cute.size(params.problem_shape_ncluster_mnl)
+                if const_expr(has_split_k):
+                    num_work = num_work * params.split_k_fdd.divisor
+                is_valid = work_idx < num_work
         pid_m, pid_n, batch_idx = Int32(0), Int32(0), Int32(0)
+        if const_expr(has_split_k):
+            k_split = Int32(0)
         if is_valid:
+            if const_expr(has_split_k):
+                # k_split is the fastest-varying component of the work index, so all
+                # splits of a tile run concurrently in one wave and the turnstile only
+                # ever waits on units with strictly smaller work index.
+                tile_work_idx, k_split_dyn = divmod(work_idx, params.split_k_fdd)
+                work_idx, k_split = Int32(tile_work_idx), Int32(k_split_dyn)
             if const_expr(params.persistence_mode in [PersistenceMode.NONE, PersistenceMode.CLC]):
                 cluster_id_in_problem = work_idx
                 _, _, bidz_ = cute.arch.block_idx()
@@ -335,12 +402,17 @@ class TileScheduler:
                 if const_expr(params.batch_idx_permute is None)
                 else params.batch_idx_permute[bidz_]
             )
+        if const_expr(has_split_k):
+            # The K slot of tile_coord_mnkl must stay statically None (WorkTileInfo's
+            # pytree schema is rigid), so k_split rides on the scheduler instead.
+            self.current_k_split = k_split
         tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
         return cutlass.utils.WorkTileInfo(tile_coord_mnkl, is_valid)
 
     @cute.jit
     def get_current_work(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
         params = self.params
+        has_split_k = const_expr(params_has_split_k(params))
         pid_m, pid_n, batch_idx, is_valid = Int32(0), Int32(0), Int32(0), Boolean(False)
         if const_expr(params.persistence_mode == PersistenceMode.NONE):
             pass
@@ -359,7 +431,14 @@ class TileScheduler:
             with cute.arch.elect_one():
                 self._scheduler_pipeline.consumer_release(self._pipeline_state)
             self._pipeline_state.advance()
-            is_valid = Boolean(is_valid_i32)
+            if const_expr(has_split_k):
+                # k_split is packed into the upper bits of the validity word (the smem
+                # relay only carries 4 ints per stage) and rides on the scheduler, not
+                # in tile_coord_mnkl (WorkTileInfo's pytree schema is rigid).
+                is_valid = Boolean(is_valid_i32 & 1)
+                self.current_k_split = is_valid_i32 >> 1
+            else:
+                is_valid = Boolean(is_valid_i32)
         tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
         return cutlass.utils.WorkTileInfo(tile_coord_mnkl, Boolean(is_valid))
 
@@ -392,8 +471,11 @@ class TileScheduler:
                 # instead of atomic_inc, and at the end of the kernel must reset the semaphore to 0.
                 #                 # cute.printf("before atomicadd, tidx = {}, bidz = {}, idx = {}", cute.arch.thread_idx()[0], cute.arch.block_idx()[2], current_work_idx)
                 if const_expr(params.problem_shape_ncluster_mnl[0] is not None):
+                    num_work = cute.size(params.problem_shape_ncluster_mnl)
+                    if const_expr(params_has_split_k(params)):
+                        num_work = num_work * params.split_k_fdd.divisor
                     next_work_linear_idx = num_persistent_clusters + utils.atomic_inc_i32(
-                        cute.size(params.problem_shape_ncluster_mnl) - 1,
+                        num_work - 1,
                         params.tile_count_semaphore,
                     )
                 else:  # varlen_m
@@ -440,11 +522,16 @@ class TileScheduler:
                 self._pipeline_state.phase ^ 1,
             )
             self._scheduler_pipeline.producer_acquire(pipeline_state_producer)
+            valid_field = Int32(work_tile_info.is_valid_tile)
+            if const_expr(params_has_split_k(params)):
+                # Pack k_split (set by _delinearize_work_idx just before this call) into
+                # the upper bits of the validity word; unpacked in get_current_work.
+                valid_field = valid_field | (self.current_k_split << 1)
             sched_data = [
                 work_tile_info.tile_idx[0],
                 work_tile_info.tile_idx[1],
                 work_tile_info.tile_idx[3],
-                Int32(work_tile_info.is_valid_tile),
+                valid_field,
             ]
             lane_idx = cute.arch.lane_idx()
             if lane_idx < cute.size(params.cluster_shape_mn):
@@ -523,6 +610,7 @@ class TileScheduler:
             self.num_tiles_executed,
             self._current_batch_idx,
             self._num_work_idx_before_cur_batch,
+            self.current_k_split,
             self._sched_smem,
             self._scheduler_pipeline,
             self._pipeline_state,
@@ -541,6 +629,7 @@ class TileScheduler:
                 self.num_tiles_executed,
                 self._current_batch_idx,
                 self._num_work_idx_before_cur_batch,
+                self.current_k_split,
                 self._sched_smem,
                 self._scheduler_pipeline,
                 self._pipeline_state,
@@ -652,6 +741,7 @@ class TriangularTileScheduler(TileScheduler):
             Int32(0),  # num_tiles_executed
             Int32(0),  # current_batch_idx
             Int32(0),  # num_work_idx_before_cur_batch
+            Int32(0),  # current_k_split
             sched_smem,
             scheduler_pipeline,
             PipelineStateWAdvance(stages, Int32(0), Int32(0), Int32(0)),
@@ -859,6 +949,7 @@ class VarlenMTileScheduler(TileScheduler):
         num_tiles_executed: Int32,
         current_batch_idx: Int32,
         num_work_idx_before_cur_batch: Int32,
+        current_k_split: Int32,
         sched_smem: Optional[cute.Tensor],
         scheduler_pipeline: Optional[cutlass.pipeline.PipelineAsync],
         pipeline_state: PipelineStateWAdvance,
@@ -871,6 +962,11 @@ class VarlenMTileScheduler(TileScheduler):
         self.num_tiles_executed = num_tiles_executed
         self._current_batch_idx = current_batch_idx
         self._num_work_idx_before_cur_batch = num_work_idx_before_cur_batch
+        # K-split index of the current work tile (always 0 when split-K is disabled).
+        # Carried as scheduler state rather than in WorkTileInfo.tile_idx: the DSL's
+        # WorkTileInfo has a rigid pytree schema (3 coord leaves + validity) and asserts
+        # on reconstruction if the K slot holds a dynamic value.
+        self.current_k_split = current_k_split
         self._sched_smem = sched_smem
         self._scheduler_pipeline = scheduler_pipeline
         self._pipeline_state = pipeline_state
@@ -924,6 +1020,7 @@ class VarlenMTileScheduler(TileScheduler):
             Int32(0),  # num_tiles_executed
             Int32(0),  # current_batch_idx
             Int32(0),  # num_work_idx_before_cur_batch
+            Int32(0),  # current_k_split
             sched_smem,
             scheduler_pipeline,
             PipelineStateWAdvance(stages, Int32(0), Int32(0), Int32(0)),

--- a/quack/utils.py
+++ b/quack/utils.py
@@ -275,6 +275,18 @@ def atomic_inc_i32(a: int | Int32, gmem_ptr: cute.Pointer, *, loc=None, ip=None)
 
 
 @dsl_user_op
+
+
+@dsl_user_op
+def threadfence(*, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "membar.gl;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+    )
 def atomic_add_i32(a: int | Int32, gmem_ptr: cute.Pointer, *, loc=None, ip=None) -> Int32:
     from cutlass import CUDA_VERSION
 

--- a/quack/utils.py
+++ b/quack/utils.py
@@ -275,9 +275,6 @@ def atomic_inc_i32(a: int | Int32, gmem_ptr: cute.Pointer, *, loc=None, ip=None)
 
 
 @dsl_user_op
-
-
-@dsl_user_op
 def threadfence(*, loc=None, ip=None) -> None:
     llvm.inline_asm(
         None,
@@ -287,6 +284,9 @@ def threadfence(*, loc=None, ip=None) -> None:
         has_side_effects=True,
         is_align_stack=False,
     )
+
+
+@dsl_user_op
 def atomic_add_i32(a: int | Int32, gmem_ptr: cute.Pointer, *, loc=None, ip=None) -> Int32:
     from cutlass import CUDA_VERSION
 
@@ -301,6 +301,40 @@ def atomic_add_i32(a: int | Int32, gmem_ptr: cute.Pointer, *, loc=None, ip=None)
         return nvvm.atomicrmw(
             op=nvvm.AtomicOpKind.ADD, ptr=gmem_ptr.llvm_ptr, a=Int32(a).ir_value()
         )
+
+
+@dsl_user_op
+def ld_acquire_gpu_i32(gmem_ptr: cute.Pointer, *, loc=None, ip=None) -> Int32:
+    """Load an int32 from gmem with acquire semantics at GPU scope (for spin-waits)."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [gmem_ptr.toint(loc=loc, ip=ip).ir_value()],
+            "ld.global.acquire.gpu.b32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+        )
+    )
+
+
+@dsl_user_op
+def red_release_gpu_add_i32(a: int | Int32, gmem_ptr: cute.Pointer, *, loc=None, ip=None) -> None:
+    """Reduction-add an int32 in gmem with release semantics at GPU scope.
+
+    Paired with ld_acquire_gpu_i32, this gives the same ordering guarantees as
+    CUTLASS's Barrier::arrive_inc / wait_eq (cutlass/barrier.h): a CTA-wide
+    barrier before the red makes all participating threads' prior gmem writes
+    visible to whoever observes the incremented value via an acquire load.
+    """
+    llvm.inline_asm(
+        None,
+        [gmem_ptr.toint(loc=loc, ip=ip).ir_value(), Int32(a).ir_value(loc=loc, ip=ip)],
+        "red.release.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+    )
 
 
 @dsl_user_op

--- a/tests/test_gemm_splitk.py
+++ b/tests/test_gemm_splitk.py
@@ -1,0 +1,269 @@
+"""Split-K GEMM (SM100 only).
+
+Each output tile is computed by `split_k` work units covering disjoint K ranges.
+Two reduction modes, both run-to-run deterministic:
+- "parallel" (default): every split stores fp32 partials to its own workspace slice
+  with no inter-CTA synchronization; a separate reduce kernel sums the slices in
+  fixed ascending order and applies the epilogue (cuBLAS splitKreduce-style).
+- "serial": fused in-kernel turnstile reduction; non-final splits serialize their
+  partials into a shared slot (k-ascending) and the final split runs the epilogue.
+"""
+
+import math
+import pytest
+import torch
+
+from quack.cute_dsl_utils import get_device_capacity
+from quack.gemm import gemm as quack_gemm
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or get_device_capacity(torch.device("cuda"))[0] not in (10, 11),
+    reason="split-K GEMM is SM100 only",
+)
+
+ATOL = {torch.bfloat16: 3e-2, torch.float16: 1e-2}
+RTOL = 1e-3
+MODES = ["parallel", "serial"]
+
+
+def _run_gemm(A, B, D, split_k, mode, cluster_mn=(1, 1), **kwargs):
+    quack_gemm(
+        A,
+        B,
+        D,
+        C=kwargs.pop("C", None),
+        tile_count_semaphore=None,
+        tile_M=128,
+        tile_N=128,
+        cluster_M=cluster_mn[0],
+        cluster_N=cluster_mn[1],
+        persistent=True,
+        split_k=split_k,
+        split_k_mode=mode,
+        **kwargs,
+    )
+
+
+def _make_inputs(l, m, n, k, dtype=torch.bfloat16):
+    torch.manual_seed(0)
+    A = torch.randn(l, m, k, dtype=dtype, device="cuda") / math.sqrt(k)
+    B = torch.randn(l, n, k, dtype=dtype, device="cuda") / math.sqrt(k)
+    D = torch.empty(l, m, n, dtype=dtype, device="cuda")
+    return A, B, D
+
+
+# ── Correctness vs fp32 reference ────────────────────────────────────────────
+# Shapes cover: aligned single tile; ragged k-tile count per split (4160) + batch;
+# edge output tiles (192, 320 not multiples of 128) + batch -- OOB lanes round-trip the
+# workspace and must be predicated away by the epilogue (serial) / reduce kernel (parallel).
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("split_k", [2, 4])
+@pytest.mark.parametrize("m,n,k,l", [(128, 128, 16384, 1), (128, 256, 4160, 3), (192, 320, 8192, 2)])
+def test_gemm_splitk(m, n, k, l, split_k, mode):
+    A, B, D = _make_inputs(l, m, n, k)
+    _run_gemm(A, B, D, split_k, mode)
+    ref = torch.bmm(A.float(), B.float().mT).to(D.dtype)
+    torch.testing.assert_close(D, ref, atol=ATOL[D.dtype], rtol=RTOL)
+
+
+# split_k larger than the number of k tiles: some splits own zero k tiles -> contribute zeros.
+@pytest.mark.parametrize("mode", MODES)
+def test_gemm_splitk_more_splits_than_k_tiles(mode):
+    A, B, D = _make_inputs(1, 128, 128, 128)
+    _run_gemm(A, B, D, 8, mode)
+    ref = torch.bmm(A.float(), B.float().mT).to(D.dtype)
+    torch.testing.assert_close(D, ref, atol=ATOL[D.dtype], rtol=RTOL)
+
+
+# Parallel split count can scale past the reduce's pre-stage window (stage_slots): split_k=64
+# exercises the ordered remainder loop in the reduce kernel.
+def test_gemm_splitk_parallel_large_split():
+    A, B, D = _make_inputs(1, 128, 128, 16384)
+    _run_gemm(A, B, D, 64, "parallel")
+    ref = torch.bmm(A.float(), B.float().mT).to(D.dtype)
+    torch.testing.assert_close(D, ref, atol=ATOL[D.dtype], rtol=RTOL)
+
+
+# Epilogue (alpha, beta*C, bias) must apply to the fully reduced accumulator, not per-split.
+@pytest.mark.parametrize("mode", MODES)
+def test_gemm_splitk_epilogue(mode):
+    l, m, n, k = 2, 128, 256, 8192
+    A, B, D = _make_inputs(l, m, n, k)
+    C = torch.randn(l, m, n, dtype=D.dtype, device="cuda")
+    bias = torch.randn(l, n, dtype=D.dtype, device="cuda")
+    alpha, beta = 0.5, 0.7
+    _run_gemm(A, B, D, 4, mode, C=C, alpha=alpha, beta=beta, rowvec_bias=bias)
+    ref = (
+        alpha * torch.bmm(A.float(), B.float().mT) + beta * C.float() + bias.float().unsqueeze(1)
+    ).to(D.dtype)
+    torch.testing.assert_close(D, ref, atol=ATOL[D.dtype], rtol=RTOL)
+
+
+# Determinism: the point of split-K with an ordered reduction.
+@pytest.mark.parametrize("mode", MODES)
+def test_gemm_splitk_deterministic(mode):
+    A, B, D1 = _make_inputs(1, 128, 256, 16384)
+    D2 = torch.empty_like(D1)
+    _run_gemm(A, B, D1, 8, mode)
+    for _ in range(5):
+        _run_gemm(A, B, D2, 8, mode)
+        assert torch.equal(D1, D2), "split-K reduction must be run-to-run deterministic"
+
+
+# ── Table-driven reduce: variable contributors per tile (Stream-K precursor) ──
+# Drive the reduce kernel DIRECTLY with a NON-uniform contributor layout to prove the
+# per-tile (first_slot, count) prefix-sum indirection and the (m_idx, n_idx, l) tile
+# enumeration are correct independently of the GEMM. The uniform split-K path uses
+# first_slot = tile_idx * split_k (order-independent) and so cannot exercise this.
+@pytest.mark.parametrize("vec_width", [1, 2, 4])
+@pytest.mark.parametrize("d_dtype", [torch.bfloat16, torch.float16])
+def test_splitk_reduce_variable_contributors(d_dtype, vec_width):
+    from quack.gemm_splitk_reduce import splitk_reduce
+
+    torch.manual_seed(0)
+    l = 2
+    tile_m = tile_n = 128
+    ntile_m, ntile_n = 2, 3  # multi-tile, non-square raster (exact multiples, no edges)
+    M, N = ntile_m * tile_m, ntile_n * tile_n
+    num_tiles = ntile_m * ntile_n * l
+
+    # Distinct per-tile contributor counts (>=1) so the prefix-sum offset actually matters.
+    counts = torch.tensor([1, 5, 2, 4, 3, 1, 6, 2, 1, 3, 5, 2][:num_tiles], dtype=torch.int32)
+    first = torch.zeros(num_tiles, dtype=torch.int32)
+    first[1:] = torch.cumsum(counts.to(torch.int64), 0)[:-1].to(torch.int32)
+    total = int(counts.sum().item())
+    tile_first_slot, tile_count = first.cuda(), counts.cuda()
+
+    ws = torch.randn(total, tile_m, tile_n, dtype=torch.float32, device="cuda")
+    # n-major (M, N, L) layout, matching what perm3d hands the kernel in gemm().
+    D = torch.empty(l, M, N, dtype=d_dtype, device="cuda").permute(1, 2, 0)
+    C = torch.randn(l, M, N, dtype=d_dtype, device="cuda").permute(1, 2, 0)
+    alpha, beta = 0.5, 0.7
+
+    # Reference: sum each tile's own slots, then the kernel's epilogue order.
+    ref = torch.zeros(M, N, l, dtype=torch.float32, device="cuda")
+    for t in range(num_tiles):
+        li, rem = t % l, t // l
+        ni, mi = rem % ntile_n, rem // ntile_n
+        f, c = int(first[t]), int(counts[t])
+        part = ws[f : f + c].sum(0) * alpha
+        rs, re, cs, ce = mi * tile_m, (mi + 1) * tile_m, ni * tile_n, (ni + 1) * tile_n
+        ref[rs:re, cs:ce, li] = part + beta * C[rs:re, cs:ce, li].float()
+
+    splitk_reduce(
+        ws.reshape(-1), D, C, alpha, beta, None, None,
+        tile_first_slot, tile_count, tile_m, tile_n, vec_width,
+    )
+    torch.testing.assert_close(D.float(), ref, atol=ATOL[d_dtype], rtol=RTOL)
+
+
+# ── Intra-CTA K-split reduce (kgroups > 1): fills the GPU for few-tile reduces by having
+# `kgroups` threads cooperate per output element (each reduces a contiguous group of
+# contributors, combined in smem). Output is a fixed blocked-ascending sum: must stay
+# correct (within bf16 tolerance) AND run-to-run deterministic. Variable per-tile counts
+# (incl. counts < kgroups, leaving empty groups that must contribute 0) exercise the
+# spg = ceil(count/R) grouping and the empty-group guard.
+@pytest.mark.parametrize("kgroups", [2, 4, 8])
+def test_splitk_reduce_kgroups(kgroups):
+    from quack.gemm_splitk_reduce import splitk_reduce
+
+    torch.manual_seed(1)
+    l = 1
+    tile_m = tile_n = 128
+    ntile_m, ntile_n = 1, 2
+    M, N = ntile_m * tile_m, ntile_n * tile_n
+    num_tiles = ntile_m * ntile_n * l
+
+    # Include a count < kgroups (=> some k-groups own zero contributors -> add 0) and a
+    # count not divisible by kgroups (=> last group is short).
+    counts = torch.tensor([3, 17][:num_tiles], dtype=torch.int32)
+    first = torch.zeros(num_tiles, dtype=torch.int32)
+    first[1:] = torch.cumsum(counts.to(torch.int64), 0)[:-1].to(torch.int32)
+    total = int(counts.sum().item())
+    tile_first_slot, tile_count = first.cuda(), counts.cuda()
+
+    ws = torch.randn(total, tile_m, tile_n, dtype=torch.float32, device="cuda")
+    D = torch.empty(l, M, N, dtype=torch.bfloat16, device="cuda").permute(1, 2, 0)
+
+    # Reference: blocked-ascending sum over R contiguous groups (matches the kernel's
+    # smem combine order), in fp32, then cast to the output dtype.
+    ref = torch.zeros(M, N, l, dtype=torch.float32, device="cuda")
+    for t in range(num_tiles):
+        li, rem = t % l, t // l
+        ni, mi = rem % ntile_n, rem // ntile_n
+        f, c = int(first[t]), int(counts[t])
+        spg = (c + kgroups - 1) // kgroups
+        acc = torch.zeros(tile_m, tile_n, dtype=torch.float32, device="cuda")
+        for g in range(kgroups):
+            s0, s1 = g * spg, min((g + 1) * spg, c)
+            for s in range(s0, s1):
+                acc += ws[f + s]
+        rs, re, cs, ce = mi * tile_m, (mi + 1) * tile_m, ni * tile_n, (ni + 1) * tile_n
+        ref[rs:re, cs:ce, li] = acc
+
+    def run(out):
+        splitk_reduce(
+            ws.reshape(-1), out, None, 1.0, 1.0, None, None,
+            tile_first_slot, tile_count, tile_m, tile_n, 1, kgroups,
+        )
+
+    run(D)
+    torch.testing.assert_close(D.float(), ref, atol=ATOL[torch.bfloat16], rtol=RTOL)
+
+    D2 = torch.empty_like(D)
+    run(D2)
+    assert torch.equal(D, D2), "intra-CTA K-split reduce must be run-to-run deterministic"
+
+
+# ── split_k=0 -> auto: gemm picks the split; output must be correct regardless ─────
+# One shape where auto splits (single tile, large K) and one where it doesn't (GPU already full).
+@pytest.mark.parametrize("m,n,k,l", [(128, 128, 16384, 1), (4096, 4096, 4096, 1)])
+def test_gemm_splitk_auto(m, n, k, l):
+    A, B, D = _make_inputs(l, m, n, k)
+    _run_gemm(A, B, D, 0, "parallel")  # 0 = auto
+    ref = torch.bmm(A.float(), B.float().mT).to(D.dtype)
+    torch.testing.assert_close(D, ref, atol=ATOL[D.dtype], rtol=RTOL)
+
+
+def test_auto_split_k_values():
+    # Wave-aware heuristic (see auto_split_k docstring). Single tile: ~round(1.2*sqrt(k_tiles))
+    # (balance GEMM latency vs reduce cost). Multi-tile: floor(0.70*num_sms/tiles) (fill ~0.7 of
+    # a wave -- NOT a full wave, which spilled a near-empty 2nd wave / wasted reduce work).
+    from quack.gemm_splitk_reduce import auto_split_k
+
+    sms = 148  # B200
+    assert auto_split_k(128, 128, 16384, 1, 128, 128, sms) == 19  # 1 tile, 256 k-tiles: ~1.2*16
+    # 16 tiles: floor(0.70*148/16)=6 (the old fill cap was 10 -> 1.08 waves -> 0.69x of cuBLAS)
+    assert auto_split_k(512, 512, 16384, 1, 128, 128, sms) == 6
+    assert auto_split_k(256, 256, 32768, 1, 128, 128, sms) == 25  # 4 tiles: floor(0.70*148/4)
+    assert auto_split_k(4096, 4096, 4096, 1, 128, 128, sms) == 1  # 1024 tiles already fill GPU
+
+
+# ── CUDA graph capture ───────────────────────────────────────────────────────
+# These shapes are launch-bound (per-call host work > GPU work), so the way to hide the
+# overhead is CUDA-graph capture (replay drops it to ~0). Guards that the parallel split-K
+# path stays capturable AND replays correctly -- the GEMM must overwrite every workspace
+# slot the reduce reads, since capture reuses one workspace.
+def test_gemm_splitk_cuda_graph():
+    A, B, D = _make_inputs(1, 128, 128, 16384)
+    ref = torch.bmm(A.float(), B.float().mT).to(D.dtype)
+
+    for _ in range(3):  # warm caches (compile, uniform tables, device props) before capture
+        _run_gemm(A, B, D, 8, "parallel")
+    torch.cuda.synchronize()
+
+    s = torch.cuda.Stream()  # CUDA-graph protocol: warm up on a side stream, then capture
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            _run_gemm(A, B, D, 8, "parallel")
+    torch.cuda.current_stream().wait_stream(s)
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        _run_gemm(A, B, D, 8, "parallel")
+
+    D.zero_()
+    g.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(D, ref, atol=ATOL[D.dtype], rtol=RTOL)


### PR DESCRIPTION
## Split-K GEMM for SM100 (B200/B300)

  Adds split-K to the CuTe-DSL GEMM: each output tile's K reduction is split across `split_k`
  work units, so K-heavy small-M/N shapes (which under-fill the GPU at one CTA per tile) spread
  work across many more CTAs. Two run-to-run-deterministic modes:

  - **`parallel`** (default): splits write fp32 partials to a workspace; a separate table-driven
  reduce kernel sums them and applies the epilogue (mirrors cuBLAS's `splitKreduce_kernel`).
  Scales with `split_k`.
  - **`serial`**: fused in-kernel turnstile reduction (single kernel).

  `split_k=0` auto-tunes per shape. The reduce is table-driven (Stream-K-ready) and uses an
  intra-CTA K-split to fill the GPU on few-tile reduces; the split-K `gemm()` is
  CUDA-graph-capturable.

  ### Performance (B200, bf16)

  Baseline is `torch.bmm` — which for these shapes is **cuBLAS's own split-K**
  (`nvjet_…_splitK_TNT` + `cublasLt::splitKreduce_kernel`), i.e. split-K vs split-K. `graph` =
  host-free (CUDA-graph replay) kernel comparison; `vs split_k=1` = speedup over a plain
  (non-split) GEMM.

  | shape (m×n×k) | vs cuBLAS (graph) | vs cuBLAS (eager) | vs `split_k=1` |
  |---|---|---|---|
  | 128×128×16384 | 0.98× | 0.95× | 2.90× |
  | 128×128×65536 | 1.05× | 0.90–0.98× | 7.88× |
  | 256×256×32768 | 1.09× | 1.01× | 3.84× |
  | 512×512×16384 | 0.89× | 0.85× | 2.05× |

  Host-free, quack matches/beats cuBLAS on 3 of 4 shapes; 512² is GEMM-bound (separate). Up to
  ~8× over a plain GEMM. (Shared, unlocked-clock B200 — ratios approximate; per-`split_k`
  speedups are stable.)

  ### Testing

  `tests/test_gemm_splitk.py` (32 cases): correctness vs fp32 ref (aligned / ragged-K / edge-tile
  / batched × both modes), zero-contribution splits, the reduce remainder + intra-CTA K-split
  paths, determinism, table-driven variable-contributor reduce, auto `split_k`, and CUDA-graph
  capture. Benchmark: `benchmarks/benchmark_gemm_splitk.py`.