### PR TITLE
[GEMM] Add SplitK Serial,Parallel,Separate modes to all GEMM classes and dtypes

### DIFF
--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -5,6 +5,7 @@ import torch
 from triton.testing import do_bench
 
 from quack.gemm import gemm as quack_gemm
+from quack.gemm_interface import SplitKMode
 
 """
 GEMM benchmark using quack.gemm.gemm() for both the dense path and the SM100
@@ -119,6 +120,17 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--persistent", action="store_true", help="Persistent kernel")
     parser.add_argument("--dynamic_persistent", action="store_true", help="Dynamic persistent")
     parser.add_argument("--pingpong", action="store_true", help="Pingpong kernel")
+    parser.add_argument(
+        "--split_k", type=int, default=1, help="Split the K dim over this many CTAs per tile"
+    )
+    parser.add_argument(
+        "--split_k_mode",
+        choices=["serial", "parallel", "staged"],
+        default="serial",
+        help="serial: turnstile-ordered f32 partial commits, last split finalizes "
+        "(deterministic); parallel: partial commits in arrival order (nondeterministic); "
+        "staged: f32 workspace + reduction kernel applying the epilogue",
+    )
     parser.add_argument("--varlen_m", action="store_true", help="Variable length M dimension")
     parser.add_argument("--varlen_k", action="store_true", help="Variable length K dimension")
     parser.add_argument("--gather_A", action="store_true", help="Gather A")
@@ -515,7 +527,9 @@ def run(args):
     #   D: (l, m, n) or (total_m, n) if varlen_m — n-major
     cu_seqlens_m, cu_seqlens_k, A_idx = None, None, None
     tile_count_semaphore = (
-        torch.zeros(1, dtype=torch.int32, device=device) if args.dynamic_persistent else None
+        torch.zeros(1, dtype=torch.int32, device=device)
+        if args.dynamic_persistent and torch.cuda.get_device_capability()[0] == 9
+        else None
     )
 
     def _make_a_non_varlen(l_, m_, k_, major):
@@ -589,6 +603,8 @@ def run(args):
             cu_seqlens_k=cu_seqlens_k,
             A_idx=A_idx,
             use_tma_gather=args.use_tma_gather,
+            split_k=args.split_k,
+            split_k_mode=SplitKMode[args.split_k_mode.upper()],
         )
         if tile_count_semaphore is not None:
             tile_count_semaphore.zero_()

--- a/quack/blockscaled/utils.py
+++ b/quack/blockscaled/utils.py
@@ -9,8 +9,11 @@ import torch
 import cutlass
 import cutlass.cute as cute
 
+from cutlass import Int32, Float32
+
 from quack.compile_utils import make_fake_tensor as fake_tensor
 from quack.cute_dsl_utils import get_device_capacity, get_max_active_clusters
+from quack.gemm_config import SplitKMode
 from quack.gemm_default_epi import GemmDefaultSm100
 from quack.gemm_tvm_ffi_utils import div_for_dtype, make_scheduler_args
 from quack.blockscaled.quantize import (
@@ -710,6 +713,8 @@ def compile_blockscaled_gemm_tvm_ffi(
     use_clc_persistence: bool = True,
     varlen_m: bool = False,
     varlen_k: bool = False,
+    split_k: int = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> Callable:
     """Compile the SM100 blockscaled GEMM.
 
@@ -717,18 +722,54 @@ def compile_blockscaled_gemm_tvm_ffi(
     mB is (n, k, l); run(...) takes an extra cu_seqlens_m tensor.
     When varlen_k: mA is (m, total_k), mB is (n, total_k), mD is (m, n, l);
     run(...) takes an extra cu_seqlens_k tensor.
+
+    split_k > 1 (dense only): block-scaled composes with the dense finalizer-only
+    split-K device path with no kernel changes (the SF loads ride the same
+    k_tile_start-offset copy list as A/B; the accumulator is already descaled f32
+    before the epilogue). run(...) allocates the per-tile completion flag and the f32
+    partials workspace per call (mirroring quack.gemm.gemm) and threads them through.
+    SERIAL/PARALLEL only — SEPARATE needs a block-scaled reduction-kernel path.
     """
     device_capacity = get_device_capacity(mA.device)
     if device_capacity[0] not in (10, 11):
         raise RuntimeError("Blockscaled SM100 GEMM requires SM100/SM110")
     assert not (varlen_m and varlen_k), "Only one of varlen_m / varlen_k"
+    split_k_mode = SplitKMode(split_k_mode)
+    if split_k > 1:
+        if varlen_m or varlen_k:
+            raise ValueError("block-scaled split_k requires a dense GEMM (no varlen)")
+        if split_k_mode == SplitKMode.SEPARATE:
+            raise NotImplementedError(
+                "block-scaled split_k does not support SEPARATE yet; use SERIAL or PARALLEL"
+            )
 
     gemm = partial(
         GemmDefaultSm100,
         sf_vec_size=sf_vec_size,
         use_clc_persistence=use_clc_persistence,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )(cutlass.Float32, ab_dtype, mma_tiler_mn, (*cluster_shape_mn, 1))
-    compile_epi_args = gemm.EpilogueArguments()
+    # Per-CTA tile shape (post 2-CTA halving): the workspace stripe is exactly
+    # cta_tile_m * cta_tile_n f32 elements per output tile. cta_tile_shape_mnk is only
+    # populated later in _setup_attributes, so derive from use_2cta_instrs + mma_tiler.
+    cta_tile_m = mma_tiler_mn[0] // (2 if gemm.use_2cta_instrs else 1)
+    cta_tile_n = mma_tiler_mn[1]
+    split_k_compile = split_k > 1  # SERIAL/PARALLEL reach the in-kernel finalize path
+    if split_k_compile:
+        compile_epi_args = gemm.EpilogueArguments(
+            split_k_semaphore=fake_tensor(
+                Int32, (cute.sym_int(), cute.sym_int(), cute.sym_int()), leading_dim=1
+            ),
+            split_k_workspace=fake_tensor(
+                Float32,
+                (cute.sym_int(), cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                leading_dim=0,
+                divisibility=4,
+            ),
+        )
+    else:
+        compile_epi_args = gemm.EpilogueArguments()
     scheduler_args = make_scheduler_args(
         get_max_active_clusters(cluster_shape_mn[0] * cluster_shape_mn[1]),
         max_swizzle_size=8,
@@ -804,6 +845,58 @@ def compile_blockscaled_gemm_tvm_ffi(
         fake_mD = _make_fake_compact_tensor(
             mD.shape, d_dtype, leading_dim=_leading_dim_from_stride(mD)
         )
+
+    if split_k_compile:
+
+        @cute.jit
+        def runner(
+            a: cute.Tensor,
+            b: cute.Tensor,
+            d: cute.Tensor,
+            sfa: cute.Tensor,
+            sfb: cute.Tensor,
+            sem: cute.Tensor,
+            ws: cute.Tensor,
+            varlen_args,
+            stream,
+        ):
+            epi = compile_epi_args._replace(split_k_semaphore=sem, split_k_workspace=ws)
+            gemm(a, b, d, None, epi, scheduler_args, varlen_args, stream, sfa, sfb, None)
+
+        compiled = cute.compile(
+            runner,
+            fake_mA,
+            fake_mB,
+            fake_mD,
+            _make_compile_tensor_like(mSFA, sf_dtype, dynamic_layout=True),
+            _make_compile_tensor_like(mSFB, sf_dtype, dynamic_layout=True),
+            compile_epi_args.split_k_semaphore,
+            compile_epi_args.split_k_workspace,
+            varlen_args_fake,
+            stream,
+            options="--enable-tvm-ffi",
+        )
+
+        def run(a, b, d, sfa, sfb):
+            # Allocate the per-tile completion flag + f32 partials workspace per call,
+            # mirroring quack.gemm.gemm. d is (m, n, l) here.
+            num_l = d.shape[2]
+            ntile_m = ceil_div(d.shape[0], cta_tile_m)
+            ntile_n = ceil_div(d.shape[1], cta_tile_n)
+            ntile_m = ceil_div(ntile_m, cluster_shape_mn[0]) * cluster_shape_mn[0]
+            ntile_n = ceil_div(ntile_n, cluster_shape_mn[1]) * cluster_shape_mn[1]
+            sem = torch.zeros((num_l, ntile_m, ntile_n), dtype=torch.int32, device=d.device)
+            alloc = torch.empty if split_k_mode == SplitKMode.SERIAL else torch.zeros
+            ws = alloc(
+                (num_l, ntile_m, ntile_n, cta_tile_m * cta_tile_n),
+                dtype=torch.float32,
+                device=d.device,
+            )
+            compiled(
+                a, b, d, sfa, sfb, sem.permute(1, 2, 0), ws.permute(3, 1, 2, 0), VarlenArguments()
+            )
+
+        return run
 
     @cute.jit
     def runner(

--- a/quack/cute_dsl_utils.py
+++ b/quack/cute_dsl_utils.py
@@ -16,7 +16,7 @@ except ImportError:
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Int32, Int64, Float16, BFloat16, Float32
+from cutlass import Int32, Int64, Float16, BFloat16, Float32, Float8E4M3FN, Float8E5M2
 from cutlass.base_dsl.tvm_ffi_builder import spec
 from cutlass.cutlass_dsl import NumericMeta
 
@@ -54,6 +54,8 @@ _converter_module._convert_single_arg = _patched_convert_single_arg
 
 
 torch2cute_dtype_map = {
+    torch.float8_e4m3fn: Float8E4M3FN,
+    torch.float8_e5m2: Float8E5M2,
     torch.float16: Float16,
     torch.bfloat16: BFloat16,
     torch.float32: Float32,

--- a/quack/gemm.py
+++ b/quack/gemm.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+import torch
 from torch import Tensor
 
 import cutlass.cute as cute
@@ -10,6 +11,8 @@ from cutlass import Int32, Float32
 from cutlass.cute.runtime import make_ptr
 
 from quack.cache import jit_cache
+from quack.split_k_reduce import split_k_reduce
+from quack.gemm_config import SplitKMode
 from quack.compile_utils import make_fake_tensor as fake_tensor
 from quack.cute_dsl_utils import get_device_capacity, get_max_active_clusters, torch2cute_dtype_map
 from quack.gemm_default_epi import (
@@ -68,6 +71,8 @@ def _compile_gemm(
     num_warps,
     sf_dtype=None,
     sf_vec_size=None,
+    split_k=1,
+    split_k_mode=SplitKMode.SERIAL,
 ):
     sm_to_cls = {
         8: GemmDefaultSm80,
@@ -90,6 +95,15 @@ def _compile_gemm(
         varlen_k=varlen_k,
         gather_A=gather_A,
     )
+    if split_k > 1 and split_k_mode == SplitKMode.SEPARATE:
+        # D is the f32 partials workspace; its batch extent is l * split_k, not l,
+        # so it needs its own symbolic batch dim.
+        mD = fake_tensor(
+            d_dtype,
+            (m, n, cute.sym_int()),
+            leading_dim=1 if d_major == "n" else 0,
+            divisibility=128 // d_dtype.width,
+        )
 
     def fake_scalar(mode, dtype=Float32):
         if mode == 0:
@@ -115,6 +129,25 @@ def _compile_gemm(
         add_to_output=add_to_output,
         rounding_mode=rounding_mode,
         sr_seed=fake_scalar(sr_seed_mode, dtype=Int32),
+        split_k_semaphore=(
+            # (ntile_m, ntile_n, L) per-tile completion flag; tile counts are
+            # runtime-symbolic. SERIAL: turnstile; PARALLEL: arrival counter.
+            fake_tensor(Int32, (cute.sym_int(), cute.sym_int(), cute.sym_int()), leading_dim=1)
+            if split_k > 1 and split_k_mode != SplitKMode.SEPARATE
+            else None
+        ),
+        split_k_workspace=(
+            # (cta_tile_m * cta_tile_n, ntile_m, ntile_n, L) raw-f32-partials regions,
+            # one flat fragment stripe per output tile.
+            fake_tensor(
+                Float32,
+                (cute.sym_int(), cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                leading_dim=0,
+                divisibility=4,
+            )
+            if split_k > 1 and split_k_mode != SplitKMode.SEPARATE
+            else None
+        ),
     )
     scheduler_args = make_fake_scheduler_args(
         (is_dynamic_persistent and device_capacity[0] <= 9), has_batch_idx_permute, l
@@ -152,6 +185,8 @@ def _compile_gemm(
         concat_layout=concat_layout or None,
         num_warps=num_warps,
         sf_vec_size=sf_vec_size,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
 
 
@@ -193,6 +228,8 @@ def gemm(
     # See AI/varlen_blockscaled_sf_layout.md.
     SFA: Optional[Tensor] = None,
     SFB: Optional[Tensor] = None,
+    split_k: int = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> None:
     varlen_m = cu_seqlens_m is not None
     varlen_k = cu_seqlens_k is not None
@@ -205,6 +242,22 @@ def gemm(
         assert cluster_N == 1, "gather_A requires cluster_N=1"
     if add_to_output:
         assert not varlen_m, "Add to output not supported with varlen_m"
+    assert split_k >= 1, "split_k must be >= 1"
+    if split_k > 1:
+        if split_k_mode not in tuple(SplitKMode):
+            raise ValueError(
+                f"split_k_mode must be a SplitKMode (SERIAL, PARALLEL, or SEPARATE), "
+                f"got {split_k_mode!r}"
+            )
+        split_k_mode = SplitKMode(split_k_mode)
+        if varlen or gather_A:
+            raise ValueError("split_k requires a dense GEMM (no varlen_m/varlen_k/gather_A)")
+        if rounding_mode != RoundingMode.RN:
+            raise ValueError("split_k does not support stochastic rounding")
+        if blockscaled and split_k_mode == SplitKMode.SEPARATE:
+            raise NotImplementedError(
+                "block-scaled split_k does not support SEPARATE yet; use SERIAL or PARALLEL"
+            )
     if varlen_m:
         assert A.stride(-1) == 1, "varlen_m requires A to be k-major"
         assert D.stride(-1) == 1, "varlen_m requires D to be n-major"
@@ -230,6 +283,8 @@ def gemm(
         sf_dtype, sf_vec_size = validate_blockscaled_sf(
             A, B, SFA, SFB, device_capacity, num_batches=num_batches, varlen_k=varlen_k
         )
+    if split_k > 1 and device_capacity[0] not in [9, 10, 11, 12]:
+        raise ValueError("split_k > 1 requires SM90, SM100, SM110, or SM120")
     if use_tma_gather:
         assert device_capacity[0] in [10, 11], "TMA gather currently requires SM100/SM110"
     if rounding_mode == RoundingMode.RS:
@@ -243,13 +298,80 @@ def gemm(
             C = D
             add_to_output = False
 
-    A_p, B_p, D_p, C_p = perm3d(A, B, D, C, varlen_m=varlen_m, varlen_k=varlen_k)
-    a_major, b_major, d_major, c_major = get_majors(A_p, B_p, D_p, C_p)
-    a_dtype, b_dtype, d_dtype, c_dtype = get_dtypes(A, B, D, C)
+    # Split-K: the full epilogue (alpha, beta*C, bias) runs exactly once per output tile,
+    # on the entity that owns the completed f32 sum; non-finalizing splits emit raw f32
+    # partials only.
+    # SEPARATE: the GEMM stores raw f32 partials into a workspace whose batch mode is the
+    # combined (l * split_k + split) index (majorness matches D, contiguous dim padded to
+    # 16 bytes for TMA); the separate reduction kernel sums the splits in fixed order and
+    # applies the epilogue — so all epi operands are routed there, not into the GEMM.
+    D_gemm = D
+    C_gemm = C
+    alpha_gemm, beta_gemm = alpha, beta
+    rowvec_gemm, colvec_gemm = rowvec_bias, colvec_bias
+    split_k_workspace = None
+    gemm_add_to_output = add_to_output
+    if split_k > 1 and split_k_mode == SplitKMode.SEPARATE:
+        num_l, len_m, len_n = D.shape
+        if D.stride(-1) == 1:  # n-major
+            n_pad = (len_n + 3) // 4 * 4
+            split_k_workspace = torch.empty(
+                (num_l * split_k, len_m, n_pad), dtype=torch.float32, device=D.device
+            )[..., :len_n]
+        else:  # m-major
+            m_pad = (len_m + 3) // 4 * 4
+            split_k_workspace = torch.empty(
+                (num_l * split_k, len_n, m_pad), dtype=torch.float32, device=D.device
+            )[..., :len_m].mT
+        D_gemm = split_k_workspace
+        # The epilogue (and the prior value of D for add_to_output) is applied once by
+        # the reduction kernel instead.
+        C_gemm = None
+        alpha_gemm, beta_gemm = 1.0, 1.0
+        rowvec_gemm, colvec_gemm = None, None
+        gemm_add_to_output = False
+    # SERIAL/PARALLEL: one Int32 completion flag per output tile (SERIAL: turnstile in
+    # split order, deterministic; PARALLEL: arrival counter, not deterministic) plus a
+    # flat f32 region per tile holding the non-finalizing splits' raw accumulator
+    # fragments. The scheduler's CTA tile ids are cluster-rounded (a boundary cluster can
+    # contain CTAs whose tile is fully out of bounds but which still run the protocol),
+    # so tile counts are rounded up to cluster multiples. The per-CTA tile M must match
+    # the kernel exactly (the workspace region stride is cta_tile_m * tile_N): SM100/110
+    # 2-CTA MMA (cluster_M even, tile_M 128/256) halves it.
+    split_k_semaphore = None
+    if split_k > 1 and split_k_mode != SplitKMode.SEPARATE:
+        num_l, len_m, len_n = D.shape
+        use_2cta = device_capacity[0] in (10, 11) and cluster_M % 2 == 0 and tile_M in (128, 256)
+        cta_tile_m = tile_M // 2 if use_2cta else tile_M
+        ntile_m = (len_m + cta_tile_m - 1) // cta_tile_m
+        ntile_n = (len_n + tile_N - 1) // tile_N
+        ntile_m = (ntile_m + cluster_M - 1) // cluster_M * cluster_M
+        ntile_n = (ntile_n + cluster_N - 1) // cluster_N * cluster_N
+        # Kernel-facing layouts are (ntile_m, ntile_n, L) and (E, ntile_m, ntile_n, L):
+        # the CuTe layouts own the address computation, so the kernel just slices them
+        # at (pid_m, pid_n, batch).
+        split_k_semaphore = torch.zeros(
+            (num_l, ntile_m, ntile_n), dtype=torch.int32, device=D.device
+        )
+        tile_elems = cta_tile_m * tile_N
+        if split_k_mode == SplitKMode.SERIAL:
+            # Split 0's in-order plain store initializes each region.
+            split_k_workspace = torch.empty(
+                (num_l, ntile_m, ntile_n, tile_elems), dtype=torch.float32, device=D.device
+            )
+        else:
+            # PARALLEL: every split red.adds in arrival order; no initializing store.
+            split_k_workspace = torch.zeros(
+                (num_l, ntile_m, ntile_n, tile_elems), dtype=torch.float32, device=D.device
+            )
 
-    alpha_mode = 2 if isinstance(alpha, Tensor) else (1 if alpha != 1.0 else 0)
-    beta_mode = 2 if isinstance(beta, Tensor) else (1 if beta != 1.0 else 0)
-    colvec_ndim = colvec_bias.ndim if colvec_bias is not None else 0
+    A_p, B_p, D_p, C_p = perm3d(A, B, D_gemm, C_gemm, varlen_m=varlen_m, varlen_k=varlen_k)
+    a_major, b_major, d_major, c_major = get_majors(A_p, B_p, D_p, C_p)
+    a_dtype, b_dtype, d_dtype, c_dtype = get_dtypes(A, B, D_gemm, C_gemm)
+
+    alpha_mode = 2 if isinstance(alpha_gemm, Tensor) else (1 if alpha_gemm != 1.0 else 0)
+    beta_mode = 2 if isinstance(beta_gemm, Tensor) else (1 if beta_gemm != 1.0 else 0)
+    colvec_ndim = colvec_gemm.ndim if colvec_gemm is not None else 0
     concat_layout = tuple(sorted(concat_layout)) if concat_layout else ()
 
     sr_seed_mode = (
@@ -270,12 +392,12 @@ def gemm(
         pingpong,
         persistent,
         is_dynamic_persistent,
-        torch2cute_dtype_map[rowvec_bias.dtype] if rowvec_bias is not None else None,
-        torch2cute_dtype_map[colvec_bias.dtype] if colvec_bias is not None else None,
+        torch2cute_dtype_map[rowvec_gemm.dtype] if rowvec_gemm is not None else None,
+        torch2cute_dtype_map[colvec_gemm.dtype] if colvec_gemm is not None else None,
         colvec_ndim,
         alpha_mode,
         beta_mode,
-        add_to_output,
+        gemm_add_to_output,
         concat_layout,
         varlen_m,
         varlen_k,
@@ -288,7 +410,38 @@ def gemm(
         num_warps,
         sf_dtype,
         sf_vec_size,
+        split_k,
+        split_k_mode,
     )
+
+    def reduce_staged_split_k():
+        # The reduction kernel wants the contiguous dim last; transpose the views for
+        # m-major outputs (the kernel is elementwise in (m, n), so this is free; the
+        # row/col vector roles swap in the transposed space).
+        ws_v, out_v, c_v = split_k_workspace, D, C
+        rowvec_v, colvec_v = rowvec_bias, colvec_bias
+        if D.stride(-1) != 1:
+            ws_v, out_v = ws_v.transpose(1, 2), out_v.transpose(1, 2)
+            c_v = c_v.transpose(1, 2) if c_v is not None else None
+            rowvec_v, colvec_v = colvec_v, rowvec_v
+        if c_v is not None and c_v.stride(-1) != 1:
+            # The reduce kernel requires C contiguous along out's contiguous dim; a C
+            # whose majorness differs from D's (legal in the GEMM epilogue, which
+            # tracks c_major independently) is materialized once here.
+            c_v = c_v.contiguous()
+        split_k_reduce(
+            ws_v,
+            out_v,
+            split_k,
+            alpha=alpha,
+            beta=beta,
+            C=c_v,
+            rowvec_bias=rowvec_v,
+            colvec_bias=colvec_v,
+            add_to_output=add_to_output,
+        )
+
+    staged_split_k = split_k > 1 and split_k_mode == SplitKMode.SEPARATE
 
     def scalar_arg(scalar, mode, dtype=Float32):
         if mode == 0:
@@ -304,13 +457,21 @@ def gemm(
     )
 
     epi_args = GemmDefaultEpiMixin.EpilogueArguments(
-        alpha=scalar_arg(alpha, alpha_mode),
-        beta=scalar_arg(beta, beta_mode),
-        mRowVecBroadcast=rowvec_bias,
-        mColVecBroadcast=colvec_bias,
+        alpha=scalar_arg(alpha_gemm, alpha_mode),
+        beta=scalar_arg(beta_gemm, beta_mode),
+        mRowVecBroadcast=rowvec_gemm,
+        mColVecBroadcast=colvec_gemm,
         add_to_output=None,
         rounding_mode=None,
         sr_seed=scalar_arg(sr_seed, sr_seed_mode, dtype=Int32),
+        split_k_semaphore=(
+            split_k_semaphore.permute(1, 2, 0) if split_k_semaphore is not None else None
+        ),
+        split_k_workspace=(
+            split_k_workspace.permute(3, 1, 2, 0)
+            if split_k_workspace is not None and split_k_mode != SplitKMode.SEPARATE
+            else None
+        ),
     )
     scheduler_args = make_scheduler_args(
         max_active_clusters,
@@ -327,3 +488,6 @@ def gemm(
         compiled_fn(A_p, B_p, D_p, C_p, epi_args, scheduler_args, varlen_args, SFA, SFB)
     else:
         compiled_fn(A_p, B_p, D_p, C_p, epi_args, scheduler_args, varlen_args)
+
+    if staged_split_k:
+        reduce_staged_split_k()

--- a/quack/gemm_base.py
+++ b/quack/gemm_base.py
@@ -13,7 +13,9 @@ from cutlass.cute.nvgpu import cpasync
 from cutlass.utils import LayoutEnum
 
 import quack.copy_utils as copy_utils
+import quack.utils as utils
 from quack.cute_dsl_utils import ParamsBase
+from quack.gemm_config import SplitKMode
 from quack.epi_ops import EpiSmemBytes
 from quack.pipeline import PipelineTmaAsync, PipelineTmaCpAsync
 from quack.rounding import RoundingMode, epilogue_sr_seed
@@ -46,6 +48,22 @@ class GemmBase:
     """Common non-mainloop pieces shared by GEMM architectures."""
 
     arch = 0
+    # Split-K along the contraction dim. Constexpr (lives on self): split_k == 1 compiles to
+    # exactly the non-split kernel. The epilogue (the full epi mixin: alpha, beta*C, bias,
+    # activations, aux outputs) runs exactly ONCE per output tile, on the entity that owns
+    # the completed f32 sum — CUTLASS-3.x stream-K fixup semantics. Non-finalizing splits
+    # run no epilogue at all: they dump raw f32 accumulator fragments into a per-tile
+    # workspace region (split_k_partial_commit) and bump the tile's completion flag.
+    # SERIAL: commits are turnstile-ordered by split index (bitwise deterministic); the
+    #   last split waits flag == S-1, folds the workspace into its accumulator, and runs
+    #   the full epilogue.
+    # PARALLEL: commits are release-counted in arrival order, no waiting (lowest latency,
+    #   NOT deterministic); the last split finalizes identically.
+    # SEPARATE: every split runs the (op-less) epilogue storing raw f32 partials to its own
+    #   workspace slice; a separate reduction kernel (quack/split_k_reduce.py) sums them
+    #   and applies the full epilogue math.
+    split_k = 1
+    split_k_mode = SplitKMode.SERIAL
 
     @dataclass
     class EpilogueArguments:
@@ -55,6 +73,15 @@ class GemmBase:
 
     def epi_smem_warp_shape_mnk(self):
         return (self.num_epi_warps, 1, 1)
+
+    def _init_split_k(self, split_k: int, split_k_mode: int):
+        """Validate and store the constexpr split-K configuration. Call after self.gather_A."""
+        assert split_k >= 1, "split_k must be >= 1"
+        assert split_k_mode in tuple(SplitKMode), f"invalid split_k_mode: {split_k_mode}"
+        self.split_k = split_k
+        self.split_k_mode = SplitKMode(split_k_mode)
+        if split_k > 1:
+            assert not self.gather_A, "split_k does not support gather_A"
 
     @cute.jit
     def epilogue(
@@ -83,6 +110,7 @@ class GemmBase:
         tile_scheduler,
         tidx: Int32,
         is_tma_warp: cutlass.Boolean,
+        split_k_ws: Optional[cute.Pointer] = None,
     ) -> Tuple[cutlass.pipeline.PipelineState, cutlass.pipeline.PipelineState]:
         has_C = const_expr(tRS_rC is not None)
         has_epi_load = const_expr(self.epi_c_stage > 0)
@@ -152,6 +180,21 @@ class GemmBase:
             epi_coord = epi_tile_layout.get_hier_coord(epi_idx)  # (epi_m, epi_n)
             # Copy from acc to D registers
             load_acc_subtile(tRS_rD, epi_coord)
+            if const_expr(split_k_ws is not None):
+                # Finalizing split: fold the other splits' raw f32 partials into the
+                # accumulator BEFORE any epilogue math. The tile's workspace region is a
+                # flat (epi_subtile, thread, fragment) stripe written by
+                # split_k_partial_commit with this exact partitioning, so a compact
+                # same-shape view lines up element-for-element.
+                tRS_gWs = cute.make_tensor(
+                    split_k_ws
+                    + (epi_idx * self.num_epi_warps * cute.arch.WARP_SIZE + tidx)
+                    * cute.size(tRS_rD),
+                    cute.make_layout(tRS_rD.shape),
+                )
+                tRS_rWs = cute.make_rmem_tensor(tRS_rD.shape, self.acc_dtype)
+                cute.autovec_copy(tRS_gWs, tRS_rWs)
+                tRS_rD.store(tRS_rD.load() + tRS_rWs.load())
             if const_expr(has_epi_load):
                 if const_expr(use_tma_c):
                     epi_pipeline.consumer_wait(epi_read_state)
@@ -273,6 +316,229 @@ class GemmBase:
 
         return epi_read_state, epi_producer_state
 
+    @cute.jit
+    def split_k_partial_commit(
+        self,
+        load_acc_subtile: Callable,
+        tRS_rD: cute.Tensor,
+        epi_tile: cute.Tile,
+        ws_ptr: cute.Pointer,
+        lock_ptr: cute.Pointer,
+        split_idx: Int32,
+        epilogue_barrier: cutlass.pipeline.NamedBarrier,
+        tidx: Int32,
+        is_tma_warp: cutlass.Boolean,
+    ) -> None:
+        """Non-finalizing split: commit the raw f32 accumulator partial, run no epilogue.
+
+        The tile's workspace region is a flat (epi_subtile, thread, fragment) stripe of
+        accumulator fragments — no (m, n) semantics, no predication; the finalizer reads
+        it back with the identical partitioning (see the split_k_ws block in epilogue()).
+        SERIAL: a turnstile (flag == number of committed splits) orders the f32 adds in
+        split order — bitwise deterministic; split 0's plain store initializes the
+        region, later splits red.add into it. PARALLEL: the workspace is host-zeroed and
+        every split red.adds immediately in arrival order (no waiting, NOT
+        deterministic), then release-increments the flag.
+        """
+        epi_tile_shape = cute.zipped_divide(
+            cute.make_layout(self.cta_tile_shape_mnk[:2]), epi_tile
+        ).shape[1]
+        epi_tile_layout = cute.make_ordered_layout(
+            epi_tile_shape, order=(0, 1) if const_expr(self.epi_m_major) else (1, 0)
+        )
+        num_epi_threads = self.num_epi_warps * cute.arch.WARP_SIZE
+        frag_elems = cute.size(tRS_rD)
+        if const_expr(self.split_k_mode == SplitKMode.SERIAL):
+            # Wait until all preceding splits have committed; the barrier broadcasts
+            # lane 0's acquire to every writing thread of the group.
+            if is_tma_warp:
+                utils.semaphore_wait_eq(lock_ptr, split_idx)
+            epilogue_barrier.arrive_and_wait()
+        for epi_idx in cutlass.range_constexpr(cute.size(epi_tile_shape)):
+            epi_coord = epi_tile_layout.get_hier_coord(epi_idx)
+            load_acc_subtile(tRS_rD, epi_coord)
+            frag_base = ws_ptr + (epi_idx * num_epi_threads + tidx) * frag_elems
+            if const_expr(self.split_k_mode == SplitKMode.SERIAL):
+                if split_idx == 0:
+                    # First split initializes the (uninitialized) region in-order.
+                    tRS_gWs = cute.make_tensor(frag_base, cute.make_layout(tRS_rD.shape))
+                    cute.autovec_copy(tRS_rD, tRS_gWs)
+                else:
+                    self._red_add_frag(frag_base, tRS_rD)
+            else:
+                # PARALLEL: no initializing store (the host zero-fills the workspace),
+                # every split reduces — in arrival order, hence not deterministic.
+                self._red_add_frag(frag_base, tRS_rD)
+        # The group barrier orders every thread's writes before lane 0's gpu-scope
+        # release of the flag (CTA-scope happens-before chains into the release).
+        epilogue_barrier.arrive_and_wait()
+        if is_tma_warp:
+            if const_expr(self.split_k_mode == SplitKMode.SERIAL):
+                utils.semaphore_release(lock_ptr, split_idx + 1, drain_tma_store=False)
+            else:
+                utils.semaphore_arrive_inc(lock_ptr)
+
+    @cute.jit
+    def _red_add_frag(self, frag_base: cute.Pointer, tRS_rD: cute.Tensor) -> None:
+        """red.add the fragment into gmem at frag_base — one-way L2 reductions (no
+        read-back; the turnstile-latency-critical path in serial mode), vectorized
+        v4.f32 when the fragment allows."""
+        frag_elems = cute.size(tRS_rD)
+        if const_expr(frag_elems % 4 == 0 and self.acc_dtype == cutlass.Float32):
+            for v in cutlass.range_constexpr(frag_elems // 4):
+                chunk = cute.make_tensor(tRS_rD.iterator + 4 * v, cute.make_layout(4))
+                cute.arch.atomic_add(frag_base + 4 * v, chunk.load())
+        else:
+            for v in cutlass.range_constexpr(frag_elems):
+                cute.arch.atomic_add(frag_base + v, tRS_rD[v])
+
+    @cute.jit
+    def epilogue_split_k(
+        self,
+        params: EpilogueParams,
+        epi_smem_tensors: Dict[str, cute.Tensor],
+        epi_pipeline: Optional[cutlass.pipeline.PipelineAsync],
+        epi_store_pipeline: Optional[cutlass.pipeline.PipelineAsync],
+        epi_read_state: Optional[cutlass.pipeline.PipelineState],
+        epi_producer_state: Optional[cutlass.pipeline.PipelineState],
+        epi_tile: cute.Tile,
+        load_acc_subtile: Callable,
+        tRS_rD: cute.Tensor,
+        tRS_rC: Optional[cute.Tensor],
+        tiled_copy_t2r: Optional[cute.TiledCopy],
+        tiled_copy_r2s: cute.TiledCopy,
+        tRS_sD: cute.Tensor,
+        tiled_copy_s2r: Optional[cute.ThrCopy],
+        tSR_rC: Optional[cute.Tensor],
+        tSR_sC: Optional[cute.Tensor],
+        copy_D: Optional[Callable],
+        copy_C: Optional[Callable],
+        tile_coord_mnkl: cute.Coord,
+        varlen_manager: VarlenManager,
+        epilogue_barrier: cutlass.pipeline.NamedBarrier,
+        tile_scheduler,
+        tidx: Int32,
+        is_tma_warp: cutlass.Boolean,
+    ) -> Tuple[cutlass.pipeline.PipelineState, cutlass.pipeline.PipelineState]:
+        """self.epilogue wrapped in the split-K finalization protocol.
+
+        split_k == 1 and SEPARATE pass straight through (SEPARATE splits store raw f32
+        partials to disjoint workspace slices via the normal TMA path; the host strips
+        the epi-op arguments so the visit is a no-op, and the separate reduction kernel
+        applies the full epilogue). SERIAL/PARALLEL: non-finalizing splits commit raw
+        partials and skip the epilogue entirely — including the C loads — while the
+        last split waits for the tile's completion flag, folds the workspace into its
+        accumulator, and runs the full epi mixin exactly once.
+        """
+        if const_expr(self.split_k == 1 or self.split_k_mode == SplitKMode.SEPARATE):
+            epi_read_state, epi_producer_state = self.epilogue(
+                params,
+                epi_smem_tensors,
+                epi_pipeline,
+                epi_store_pipeline,
+                epi_read_state,
+                epi_producer_state,
+                epi_tile,
+                load_acc_subtile,
+                tRS_rD,
+                tRS_rC,
+                tiled_copy_t2r,
+                tiled_copy_r2s,
+                tRS_sD,
+                tiled_copy_s2r,
+                tSR_rC,
+                tSR_sC,
+                copy_D,
+                copy_C,
+                tile_coord_mnkl,
+                varlen_manager,
+                epilogue_barrier,
+                tile_scheduler,
+                tidx,
+                is_tma_warp,
+            )
+        else:
+            # The flag and workspace are CuTe tensors over the (cluster-rounded) tile
+            # domain — their layouts own the address computation.
+            assert self.acc_dtype == cutlass.Float32, "split_k workspace is f32"
+            batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
+            lock_ptr = utils.elem_pointer(
+                params.split_k_semaphore,
+                (tile_coord_mnkl[0], tile_coord_mnkl[1], batch_idx),
+            )
+            ws_ptr = utils.elem_pointer(
+                params.split_k_workspace,
+                (0, tile_coord_mnkl[0], tile_coord_mnkl[1], batch_idx),
+            )
+            # The stripe must tile the host-allocated region exactly.
+            epi_tile_num = cute.size(
+                cute.zipped_divide(cute.make_layout(self.cta_tile_shape_mnk[:2]), epi_tile).shape[1]
+            )
+            assert (
+                cute.size(tRS_rD) * self.num_epi_warps * cute.arch.WARP_SIZE * epi_tile_num
+                == self.cta_tile_shape_mnk[0] * self.cta_tile_shape_mnk[1]
+            ), "split-K workspace stripe does not tile cta_tile_m * cta_tile_n"
+            if split_idx < self.split_k - 1:
+                self.split_k_partial_commit(
+                    load_acc_subtile,
+                    tRS_rD,
+                    epi_tile,
+                    ws_ptr,
+                    lock_ptr,
+                    split_idx,
+                    epilogue_barrier,
+                    tidx,
+                    is_tma_warp,
+                )
+            else:
+                # Finalizer (fixed: the last split, so e.g. the SM100 epi-load warp can
+                # gate C loads statically). Wait for all S-1 sibling commits; the flag
+                # counts committed splits in both modes.
+                if is_tma_warp:
+                    utils.semaphore_wait_eq(lock_ptr, self.split_k - 1)
+                epilogue_barrier.arrive_and_wait()
+                epi_read_state, epi_producer_state = self.epilogue(
+                    params,
+                    epi_smem_tensors,
+                    epi_pipeline,
+                    epi_store_pipeline,
+                    epi_read_state,
+                    epi_producer_state,
+                    epi_tile,
+                    load_acc_subtile,
+                    tRS_rD,
+                    tRS_rC,
+                    tiled_copy_t2r,
+                    tiled_copy_r2s,
+                    tRS_sD,
+                    tiled_copy_s2r,
+                    tSR_rC,
+                    tSR_sC,
+                    copy_D,
+                    copy_C,
+                    tile_coord_mnkl,
+                    varlen_manager,
+                    epilogue_barrier,
+                    tile_scheduler,
+                    tidx,
+                    is_tma_warp,
+                    split_k_ws=ws_ptr,
+                )
+                # Self-clean the flag (fresh-zeros allocation also works, but this keeps
+                # the tensor reusable if the host ever caches it).
+                if is_tma_warp:
+                    utils.semaphore_release(lock_ptr, Int32(0), drain_tma_store=False)
+                # Drain this tile's TMA stores. The epi smem buffer rotation is seeded
+                # by num_tiles_executed, which also counts the SKIPPED non-finalizing
+                # tiles, so the next executed epilogue's first buffer index jumps by
+                # (skipped * epi_tile_num) mod epi_stage — producer_acquire's
+                # "<= epi_stage - 1 outstanding groups" guard is only safe for
+                # consecutive (+1) rotation. Draining here makes any start index safe.
+                if const_expr(epi_store_pipeline is not None):
+                    if is_tma_warp:
+                        epi_store_pipeline.producer_tail()
+        return epi_read_state, epi_producer_state
+
     def get_scheduler_class(self, varlen_m: bool = False):
         """Return the scheduler class to use. Override in subclasses for custom schedulers."""
         return TileScheduler if not varlen_m else VarlenMTileScheduler
@@ -309,6 +575,11 @@ class GemmBase:
                     else varlen_args.mCuSeqlensK.shape[0] - 1
                 )
             )
+            if const_expr(self.split_k > 1 and self.split_k_mode == SplitKMode.SEPARATE):
+                # mD is the f32 partials workspace whose batch extent is L * split_k; the
+                # scheduler needs the true L (it scales the work-id space by num_split_k
+                # itself). B always carries the true L here (varlen is rejected).
+                num_problems = mB.shape[2]
             problem_shape_ntile_mnl = (
                 cute.ceil_div(cute.size(mA, mode=[0]), self.cta_tile_shape_mnk[0]),
                 cute.ceil_div(cute.size(mB, mode=[0]), self.cta_tile_shape_mnk[1]),
@@ -322,8 +593,10 @@ class GemmBase:
                 tile_count_semaphore=scheduler_args.tile_count_semaphore,
                 batch_idx_permute=scheduler_args.batch_idx_permute,
                 persistence_mode=persistence_mode,
+                num_split_k=self.split_k,
             )
         else:
+            assert self.split_k == 1, "split_k does not support varlen_m"
             assert (mD is not None) or (epilogue_args.mAuxOut is not None) or (not self.gather_A)
             problem_shape_ntile_mnl = (
                 None,
@@ -514,6 +787,7 @@ class GemmTmaBase(GemmBase):
         producer_state: cutlass.pipeline.PipelineState,
         copy_fns: Sequence[Optional[Callable]],
         k_tile_cnt: Int32,
+        k_tile_start: Int32 | int = 0,
     ) -> cutlass.pipeline.PipelineState:
         # Peek (try_wait) AB buffer empty for k_block = prefetch_k_tile_cnt.
         peek_empty_status = Boolean(True)
@@ -528,7 +802,7 @@ class GemmTmaBase(GemmBase):
             smem_idx = producer_state.index
             for copy_fn in copy_fns:
                 if const_expr(copy_fn is not None):
-                    copy_fn(k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
+                    copy_fn(k_tile_start + k_tile, smem_idx, tma_bar_ptr=tma_bar_ptr)
             # Mainloop pipeline's producer commit is a NOP for TMA pipelines.
             pipeline.producer_commit(producer_state)
             producer_state.advance()
@@ -600,6 +874,12 @@ class GemmTmaBase(GemmBase):
         epilogue_args,
         varlen_m: bool,
     ):
+        add_to_output = const_expr(
+            hasattr(epilogue_args, "add_to_output") and epilogue_args.add_to_output
+        )
+        # Split-K needs no special D atom: only the finalizing entity stores D (a plain
+        # store, or the reduce-add atom with add_to_output, exactly like the non-split
+        # kernel); partials travel through the f32 workspace, not through D.
         tma_atom_d, tma_tensor_d = None, None
         if const_expr(mD is not None):
             tma_atom_d, tma_tensor_d = self._make_tma_epi_atoms_and_tensors(
@@ -608,16 +888,19 @@ class GemmTmaBase(GemmBase):
                 else mD,
                 self.epi_smem_layout_staged,
                 self.epi_tile,
-                op_type="store"
-                if not (hasattr(epilogue_args, "add_to_output") and epilogue_args.add_to_output)
-                else "add",
+                op_type="store" if not add_to_output else "add",
             )
         tma_atom_c, tma_tensor_c = None, None
         if const_expr(mC is not None):
             tma_atom_c, tma_tensor_c = self._make_tma_epi_atoms_and_tensors(
                 mC, self.epi_c_smem_layout_staged, self.epi_tile, op_type="load"
             )
-        return tma_atom_d, tma_tensor_d, tma_atom_c, tma_tensor_c
+        return (
+            tma_atom_d,
+            tma_tensor_d,
+            tma_atom_c,
+            tma_tensor_c,
+        )
 
     def epilog_gmem_copy_and_partition(
         self,

--- a/quack/gemm_config.py
+++ b/quack/gemm_config.py
@@ -1,8 +1,36 @@
 # Copyright (C) 2025, Tri Dao.
 import itertools
+from enum import IntEnum
 from typing import Optional, List
 from functools import partial
 from dataclasses import dataclass
+
+
+class SplitKMode(IntEnum):
+    """How split-K partial results are combined into the output.
+
+    The canonical public import path is ``from quack.gemm_interface import SplitKMode``
+    (re-exported there next to the gemm entry points that take it). The definition has
+    to live in this leaf module: the kernel layer (gemm_base / gemm_sm*) consumes it at
+    import time, and gemm_interface sits above quack.gemm in the import graph, so
+    defining it there would be a circular import.
+
+    IntEnum (like RoundingMode) so values cross the torch.library custom-op schema
+    boundary as plain ints and pickle stably for the jit-cache key.
+    """
+
+    # All modes commit raw f32 partials; the full epilogue runs exactly once, on the
+    # entity that owns the completed sum (f32 accumulation in every mode).
+    # Per-output-tile turnstile orders the partial commits in split order; the last
+    # split finalizes: bitwise deterministic run to run.
+    SERIAL = 0
+    # Partials commit in arrival order (no waiting); the last split finalizes after an
+    # arrival counter fills: lowest latency, NOT deterministic run to run.
+    PARALLEL = 1
+    # Each split stores f32 partials to its own workspace slice; a separate reduction
+    # kernel (quack/split_k_reduce.py) sums them in a deterministic order and applies
+    # the epilogue.
+    SEPARATE = 2
 
 
 @dataclass(frozen=True)
@@ -17,6 +45,7 @@ class GemmConfig:
     cluster_m: int = 2
     cluster_n: int = 1
     cluster_k: int = 1
+    split_k: int = 1
     swap_ab: bool = False
     # raster_order: int = 1
     max_swizzle_size: int = 8

--- a/quack/gemm_default_epi.py
+++ b/quack/gemm_default_epi.py
@@ -17,6 +17,45 @@ import quack.layout_utils as layout_utils
 import quack.utils as utils
 
 
+@cute.jit
+def apply_linear_epilogue(
+    tRS_rD: cute.Tensor,
+    tRS_rC: Optional[cute.Tensor],
+    alpha,
+    beta,
+    tDrRowVec: Optional[cute.Tensor],
+    tDrColVec: Optional[cute.Tensor],
+) -> None:
+    """The default (linear) epilogue math: D = alpha * D + beta * C + rowvec + colvec.
+
+    tRS_rD is mutated in place (acc dtype). alpha/beta are scalar-or-pointer params
+    (None means the term's default: alpha absent, beta = 1.0). The vec operands are
+    register fragments shaped like tRS_rD. Shared by GemmDefaultEpiMixin and the
+    split-K staged reduction kernel (quack/split_k_reduce.py) so the two apply
+    bitwise-identical math.
+    """
+    if const_expr(alpha is not None):
+        a = utils.load_scalar_or_pointer(alpha)
+        rD = tRS_rD.load() * a
+        tRS_rD.store(rD)
+    # Apply C with beta scaling
+    if const_expr(tRS_rC is not None):
+        rD = tRS_rD.load()
+        if const_expr(beta is None):
+            # beta is None, default behavior: add C (beta=1.0)
+            rD += tRS_rC.load().to(tRS_rD.element_type)
+        else:
+            b = utils.load_scalar_or_pointer(beta)
+            rD += b * tRS_rC.load().to(tRS_rD.element_type)
+        tRS_rD.store(rD)
+    if const_expr(tDrRowVec is not None):
+        for i in cutlass.range(cute.size(tDrRowVec), unroll_full=True):
+            tRS_rD[i] += tDrRowVec[i]
+    if const_expr(tDrColVec is not None):
+        for i in cutlass.range(cute.size(tDrColVec), unroll_full=True):
+            tRS_rD[i] += tDrColVec[i]
+
+
 class GemmDefaultEpiMixin(ComposableEpiMixin):
     _epi_ops = (
         Scalar("alpha"),
@@ -24,6 +63,16 @@ class GemmDefaultEpiMixin(ComposableEpiMixin):
         Scalar("sr_seed", dtype=Int32),
         RowVecLoad("mRowVecBroadcast"),
         ColVecLoad("mColVecBroadcast"),
+    )
+    # Split-K (serial/parallel): the epilogue runs only on the finalizing split, which
+    # needs the per-tile completion flag and the raw-f32-partials workspace. Both are
+    # CuTe tensors over the (cluster-rounded) tile domain; their layouts own the
+    # address computation. Flag: (ntile_m, ntile_n, L) Int32. Workspace:
+    # (cta_tile_m * cta_tile_n, ntile_m, ntile_n, L) Float32, each tile's region a
+    # flat (epi_subtile, thread, fragment)-striped dump of the accumulator fragments.
+    _extra_param_fields = (
+        ("split_k_semaphore", Optional[cute.Tensor], None),
+        ("split_k_workspace", Optional[cute.Tensor], None),
     )
 
     @mlir_namedtuple
@@ -35,6 +84,8 @@ class GemmDefaultEpiMixin(ComposableEpiMixin):
         add_to_output: cutlass.Constexpr[bool] = False
         rounding_mode: cutlass.Constexpr[int] = RoundingMode.RN
         sr_seed: Optional[Int32 | cute.Tensor] = None
+        split_k_semaphore: Optional[cute.Tensor] = None
+        split_k_workspace: Optional[cute.Tensor] = None
 
     # EpilogueParams auto-generated from _epi_ops
 
@@ -44,6 +95,8 @@ class GemmDefaultEpiMixin(ComposableEpiMixin):
         for key in ("mRowVecBroadcast", "mColVecBroadcast"):
             if key in self.concat_layout and key in d:
                 d[key] = layout_utils.concat_to_interleave(d[key], 1)
+        d["split_k_semaphore"] = getattr(args, "split_k_semaphore", None)
+        d["split_k_workspace"] = getattr(args, "split_k_workspace", None)
         return self.EpilogueParams(**d)
 
     @cute.jit
@@ -61,30 +114,16 @@ class GemmDefaultEpiMixin(ComposableEpiMixin):
         no aux outputs.
         """
         # Use .get(): inactive ops are filtered out of epi_loop_tensors.
-        alpha = epi_loop_tensors.get("alpha")
-        beta = epi_loop_tensors.get("beta")
-        tDrRowVec = epi_loop_tensors.get("mRowVecBroadcast")
-        tDrColVec = epi_loop_tensors.get("mColVecBroadcast")
-        rD = tRS_rD.load()
-        # Apply alpha scaling to accumulator if alpha is provided (not None)
-        if const_expr(hasattr(params, "alpha") and params.alpha is not None):
-            alpha = utils.load_scalar_or_pointer(params.alpha)
-            rD *= alpha
-        # Apply C with beta scaling
-        if const_expr(tRS_rC is not None):
-            if const_expr(not hasattr(params, "beta") or params.beta is None):
-                # beta is None, default behavior: add C (beta=1.0)
-                rD += tRS_rC.load().to(tRS_rD.element_type)
-            else:
-                beta = utils.load_scalar_or_pointer(params.beta)
-                rD += beta * tRS_rC.load().to(tRS_rD.element_type)
-        tRS_rD.store(rD)
-        if const_expr(tDrRowVec is not None):
-            for i in cutlass.range(cute.size(tDrRowVec), unroll_full=True):
-                tRS_rD[i] += tDrRowVec[i]
-        if const_expr(tDrColVec is not None):
-            for i in cutlass.range(cute.size(tDrColVec), unroll_full=True):
-                tRS_rD[i] += tDrColVec[i]
+        # Under split-K this runs exactly once per output tile, on the finalizing
+        # entity, with the fully reduced accumulator in tRS_rD — no per-split gating.
+        apply_linear_epilogue(
+            tRS_rD,
+            tRS_rC,
+            params.alpha if const_expr(hasattr(params, "alpha")) else None,
+            params.beta if const_expr(hasattr(params, "beta")) else None,
+            epi_loop_tensors.get("mRowVecBroadcast"),
+            epi_loop_tensors.get("mColVecBroadcast"),
+        )
         return ()
 
 

--- a/quack/gemm_interface.py
+++ b/quack/gemm_interface.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025, Tri Dao
+from dataclasses import replace
 from typing import Optional, Tuple, Literal
 from functools import partial
 
@@ -6,7 +7,10 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
-from quack.gemm_config import GemmConfig, get_all_configs
+# SplitKMode is re-exported here as its canonical public import path; it is *defined*
+# in the gemm_config leaf because the kernel layer needs it at import time and this
+# module sits above quack.gemm in the import graph (importing it from here would cycle).
+from quack.gemm_config import GemmConfig, SplitKMode, get_all_configs
 
 from quack.autotuner import autotune, AutotuneConfig
 from quack.cute_dsl_utils import get_device_capacity
@@ -105,6 +109,15 @@ Activation = Literal[
     "geglu",
     "glu",
 ]
+
+
+def _check_split_k_unsupported(name: str, split_k: int) -> None:
+    """For use in interface wrappers that do not support splitK yet."""
+    if split_k not in (None, 1):
+        raise NotImplementedError(
+            f"{name} does not support split_k > 1; split_k is currently supported by "
+            "gemm, gemm_add, and gemm_add_inplace."
+        )
 
 
 def _concat_interleave(t):
@@ -269,12 +282,44 @@ def nvmmh_config(A, B, device_capacity):
         return None
 
 
+def _expand_split_k_configs(configs, A, B, device_capacity):
+    """Add split_k > 1 variants of each surviving config for occupancy-starved shapes.
+
+    Only called when the user passed split_k=None ("let the autotuner choose the
+    factor"). Candidates are powers of two that lift the CTA count toward saturation
+    without over-decomposing K; the autotuner then picks by measurement. The split
+    MODE is never expanded (serial/parallel/staged differ in determinism semantics).
+    """
+    if A.ndim == 3:
+        L, M, K = A.shape
+    else:
+        (M, K), L = A.shape, 1
+    N = B.shape[-1]
+    sm_count = torch.cuda.get_device_properties(A.device).multi_processor_count
+    expanded = list(configs)
+    for conf in configs:
+        c = conf.kwargs["config"]
+        # SM100 2-CTA MMA halves the per-CTA tile M
+        cta_tile_m = (
+            c.tile_m // 2 if device_capacity in (10, 11) and c.cluster_m % 2 == 0 else c.tile_m
+        )
+        tile_m, tile_n = (cta_tile_m, c.tile_n) if not c.swap_ab else (c.tile_n, cta_tile_m)
+        ntiles = -(-M // tile_m) * -(-N // tile_n) * L
+        k_tiles = -(-K // (c.tile_k or 64))
+        for s in (2, 4, 8, 16):
+            starved = ntiles < sm_count and ntiles * s <= 4 * sm_count
+            if starved and 2 * s <= k_tiles:
+                expanded.append(AutotuneConfig(config=replace(c, split_k=s)))
+    return expanded
+
+
 def prune_invalid_gemm_configs(configs, named_args: dict, **kwargs):
     kwargs = named_args | kwargs
     device_capacity = get_device_capacity(kwargs["A"].device)[0]
     configs = [conf for conf in configs if conf.kwargs["config"].device_capacity == device_capacity]
     gather_A = kwargs.get("A_idx", None) is not None
     varlen_m = kwargs.get("cu_seqlens_m", None) is not None
+    varlen_k = kwargs.get("cu_seqlens_k", None) is not None
     if varlen_m or gather_A:  # Doesn't support swap_ab
         configs = [conf for conf in configs if not conf.kwargs["config"].swap_ab]
     if gather_A:
@@ -302,12 +347,21 @@ def prune_invalid_gemm_configs(configs, named_args: dict, **kwargs):
             )
 
         configs = [conf for conf in configs if _blockscaled_ok(conf.kwargs["config"])]
+    # Autotuned split-K: only the plain-gemm family exposes the knob; split_k=None means
+    # "tune the factor" (an explicit int is forced in gemm_tuned and needs no variants).
+    if (
+        "split_k" in kwargs
+        and kwargs["split_k"] is None
+        and not (varlen_m or varlen_k or gather_A)
+        and device_capacity in (9, 10, 11, 12)
+    ):
+        configs = _expand_split_k_configs(configs, kwargs["A"], kwargs["B"], device_capacity)
     return configs
 
 
 @autotune(
     configs=[AutotuneConfig(config=c) for c in get_all_configs()],
-    key=["dynamic_scheduler"],
+    key=["dynamic_scheduler", "split_k", "split_k_mode"],
     prune_configs_by={"early_config_prune": prune_invalid_gemm_configs},
 )
 def gemm_tuned(
@@ -331,6 +385,8 @@ def gemm_tuned(
     concat_layout: tuple | None = None,  # tensors whose non-contiguous dim is concat [gate; up]
     SFA: Optional[Tensor] = None,  # (L, rm, rk, 32, 4, 4) blocked scale factors
     SFB: Optional[Tensor] = None,  # (L, rn, rk, 32, 4, 4)
+    split_k: Optional[int] = 1,  # None: let the autotuner choose the factor (config.split_k)
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> None:
     blockscaled = SFA is not None
     if blockscaled:
@@ -354,6 +410,9 @@ def gemm_tuned(
                 config = nvmmh_config(A, B, device_capacity)
             if config is None:
                 config = default_config(A.device)
+    if split_k is None:
+        # Autotuned split-K: the factor comes from the (possibly split_k-expanded) config.
+        split_k = config.split_k
     varlen_m = cu_seqlens_m is not None
     varlen_k = cu_seqlens_k is not None
     varlen = varlen_m or varlen_k
@@ -442,6 +501,8 @@ def gemm_tuned(
         tile_K=config.tile_k,
         SFA=SFA,
         SFB=SFB,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
 
 
@@ -617,6 +678,8 @@ def gemm(
     rounding_mode: int = RoundingMode.RN,
     sr_seed: int | Tensor = 0,
     concat_layout: tuple | None = None,  # tensors whose non-contiguous dim is concat [gate; up]
+    split_k: Optional[int] = 1,  # K-dim CTAs per tile; None = let the autotuner choose
+    split_k_mode: int = SplitKMode.SERIAL,  # see SplitKMode: SERIAL/SEPARATE deterministic, PARALLEL fastest but arrival-order
 ) -> Tensor:
     """GEMM with optional output tensor and tuning control."""
     A, SFA = _unpack_operand(A)
@@ -676,6 +739,8 @@ def gemm(
         concat_layout=concat_str,
         SFA=SFA,
         SFB=SFB,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
     return out
 
@@ -711,6 +776,8 @@ def gemm_out(
     # schemas have no (Tensor, Tensor) argument type.
     SFA: Optional[Tensor] = None,
     SFB: Optional[Tensor] = None,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> None:
     """GEMM with pre-allocated output tensor."""
     fn = gemm_tuned if tuned else partial(gemm_tuned.fn, config=None)
@@ -735,6 +802,8 @@ def gemm_out(
         concat_layout=_parse_concat_layout(concat_layout),
         SFA=SFA,
         SFB=SFB,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
 
 
@@ -856,6 +925,8 @@ def gemm_add(
     dynamic_scheduler: bool = False,
     tuned: bool = True,
     concat_layout: tuple | None = None,  # tensors whose non-contiguous dim is concat [gate; up]
+    split_k: Optional[int] = 1,  # K-dim CTAs per tile; None = let the autotuner choose
+    split_k_mode: int = SplitKMode.SERIAL,  # see SplitKMode: SERIAL/SEPARATE deterministic, PARALLEL fastest but arrival-order
 ) -> Tensor:
     """GEMM with addition and optional output tensor."""
     A, SFA = _unpack_operand(A)
@@ -913,6 +984,8 @@ def gemm_add(
             dynamic_scheduler=dynamic_scheduler,
             tuned=tuned,
             concat_layout=concat_str,
+            split_k=split_k,
+            split_k_mode=split_k_mode,
         )
     else:
         gemm_add_out(
@@ -934,6 +1007,8 @@ def gemm_add(
             concat_layout=concat_str,
             SFA=SFA,
             SFB=SFB,
+            split_k=split_k,
+            split_k_mode=split_k_mode,
         )
     return out
 
@@ -966,6 +1041,8 @@ def gemm_add_out(
     concat_layout: Optional[str] = None,
     SFA: Optional[Tensor] = None,  # blocked scale factors, (L, rm, rk, 32, 4, 4) (see gemm_out)
     SFB: Optional[Tensor] = None,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> None:
     """GEMM with addition and pre-allocated output tensor."""
     fn = gemm_tuned if tuned else partial(gemm_tuned.fn, config=None)
@@ -987,6 +1064,8 @@ def gemm_add_out(
         add_to_output=add_to_output,
         dynamic_scheduler=dynamic_scheduler,
         concat_layout=_parse_concat_layout(concat_layout),
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
 
 
@@ -1086,6 +1165,8 @@ def gemm_add_inplace(
     dynamic_scheduler: bool = False,
     tuned: bool = True,
     concat_layout: tuple | None = None,  # tensors whose non-contiguous dim is concat [gate; up]
+    split_k: Optional[int] = 1,  # K-dim CTAs per tile; None = let the autotuner choose
+    split_k_mode: int = SplitKMode.SERIAL,  # see SplitKMode: SERIAL/SEPARATE deterministic, PARALLEL fastest but arrival-order
 ) -> None:
     """In-place GEMM with addition: out = alpha * A @ B + beta * out.
     Args:
@@ -1136,6 +1217,8 @@ def gemm_add_inplace(
         else concat_layout,
         SFA=SFA,
         SFB=SFB,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
 
 
@@ -1165,6 +1248,8 @@ def gemm_add_inplace_op(
     concat_layout: Optional[str] = None,
     SFA: Optional[Tensor] = None,  # blocked scale factors, (L, rm, rk, 32, 4, 4) (see gemm_out)
     SFB: Optional[Tensor] = None,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> None:
     fn = gemm_tuned if tuned else partial(gemm_tuned.fn, config=None)
     alpha = _merge_tensor(alpha, alpha_tensor)
@@ -1187,6 +1272,8 @@ def gemm_add_inplace_op(
         concat_layout=_parse_concat_layout(concat_layout),
         SFA=SFA,
         SFB=SFB,
+        split_k=split_k,
+        split_k_mode=split_k_mode,
     )
 
 
@@ -1210,8 +1297,11 @@ def gemm_act(
     dynamic_scheduler: bool = False,
     tuned: bool = True,
     concat_layout: tuple | None = None,  # tensors whose non-contiguous dim is concat [gate; up]
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> Tuple[Optional[Tensor], Tensor]:
     """GEMM with activation (or gated activation) and optional output tensors."""
+    _check_split_k_unsupported("gemm_act", split_k)
     A, SFA = _unpack_operand(A)
     B, SFB = _unpack_operand(B)
     assert (SFA is None) == (SFB is None), "A and B must both (or neither) carry scale factors"
@@ -1378,8 +1468,11 @@ def gemm_dact(
     A_idx: Optional[Tensor] = None,  # (total_M,) if gather_A with varlen_m
     dynamic_scheduler: bool = True,
     tuned: bool = True,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ):
     """GEMM with activation (or gated activation) gradient and optional output tensors."""
+    _check_split_k_unsupported("gemm_dact", split_k)
     is_dgated = activation in gated_to_pytorch_fn_map
     out_dtype = A.dtype if out_dtype is None else out_dtype
     postact_dtype = PreAct.dtype if postact_dtype is None else postact_dtype
@@ -1593,8 +1686,11 @@ def gemm_symmetric(
     dynamic_scheduler: bool = False,
     alpha: float | Tensor = 1.0,
     beta: float | Tensor = 1.0,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> Tuple[Optional[Tensor], Tensor]:
     """GEMM with symmetric output."""
+    _check_split_k_unsupported("gemm_symmetric", split_k)
     out_dtype = A.dtype if out_dtype is None else out_dtype
     # Determine output shape based on gather_A
     if A.ndim == 2:
@@ -1958,6 +2054,8 @@ def gemm_add_inplace_fake(
     concat_layout: Optional[str] = None,
     SFA: Optional[Tensor] = None,
     SFB: Optional[Tensor] = None,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> None:
     # Pure no-op: the op only mutates ``out``; kernel compilation is owned
     # by jit_cache + the async compile pool at real execution time.
@@ -2202,6 +2300,8 @@ def gemm_rms(
     eps: float = 1e-6,
     dynamic_scheduler: bool = False,
     tuned: bool = True,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> Tuple[Tensor, Tensor]:
     """GEMM + RMS statistics + optional rowvec scaling.
 
@@ -2209,6 +2309,7 @@ def gemm_rms(
     If premult_out is provided, D_raw (the pre-norm_weight value) is also written to it.
     Returns (D_out, rstd).
     """
+    _check_split_k_unsupported("gemm_rms", split_k)
     out_dtype = A.dtype if out_dtype is None else out_dtype
     N = B.shape[-1]
     if out is None:
@@ -2433,12 +2534,15 @@ def gemm_norm_act(
     store_preact: bool = False,
     dynamic_scheduler: bool = False,
     tuned: bool = True,
+    split_k: Optional[int] = 1,
+    split_k_mode: int = SplitKMode.SERIAL,
 ) -> Tuple[Optional[Tensor], Tensor]:
     """GEMM + normalize + activation: PostAct = act((A @ B + C) * rstd).
 
     rstd is a column vector (M,).
     Returns (preact, postact) where preact is the normalized value before activation.
     """
+    _check_split_k_unsupported("gemm_norm_act", split_k)
     is_gated = activation in gated_to_pytorch_fn_map
     out_dtype = A.dtype if out_dtype is None else out_dtype
     postact_dtype = A.dtype if postact_dtype is None else postact_dtype

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -39,6 +39,7 @@ from quack.dsl.smem_struct import Reserved, partitioned_struct
 from quack.tile_scheduler import TileSchedulerOptions
 from quack.varlen_utils import VarlenArguments, VarlenManager
 from quack.gemm_base import GemmTmaBase, NamedBarrierGemm
+from quack.gemm_config import SplitKMode
 from quack import layout_utils
 import quack.copy_utils as copy_utils
 import quack.sm100_utils as quack_sm100_utils
@@ -153,6 +154,8 @@ class GemmSm100(GemmTmaBase):
         use_clc_persistence: bool = True,
         concat_layout: tuple | None = None,
         use_pdl: bool = True,
+        split_k: int = 1,
+        split_k_mode: int = SplitKMode.SERIAL,
     ):
         """Initializes the configuration for a Blackwell dense GEMM kernel.
 
@@ -200,6 +203,17 @@ class GemmSm100(GemmTmaBase):
             assert cluster_shape_mnk[1] == 1, "Cluster shape N must be 1 for gather A "
         if use_tma_gather:
             assert gather_A, "TMA gather requires gather_A=True"
+        self._init_split_k(split_k, split_k_mode)
+        if split_k > 1 and self.blockscaled:
+            # Block-scaled composes with the finalizer-only split-K device path as-is:
+            # the SF (scale-factor) TMA loads ride the same k_tile_start-offset copy_fn
+            # list as A/B, and the accumulator is already descaled f32 before the
+            # epilogue, so summing raw f32 partials over disjoint K-ranges is exact.
+            # SEPARATE additionally needs a block-scaled-reachable reduction kernel, which
+            # the block-scaled host does not yet wire.
+            assert self.split_k_mode != SplitKMode.SEPARATE, (
+                "block-scaled split_k does not support SEPARATE yet; use SERIAL or PARALLEL"
+            )
 
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
 
@@ -743,9 +757,14 @@ class GemmSm100(GemmTmaBase):
         self.num_tma_load_bytes *= atom_thr_size
 
         # Setup TMA store for D and TMA load for C.
-        tma_atom_d, tma_tensor_d, tma_atom_c, tma_tensor_c = (
-            self.make_tma_epilogue_atoms_and_tensors(mD, mC, epilogue_args, varlen_m)
-        )
+        if const_expr(self.split_k > 1):
+            assert mD is not None, "split_k requires an output tensor D"
+        (
+            tma_atom_d,
+            tma_tensor_d,
+            tma_atom_c,
+            tma_tensor_c,
+        ) = self.make_tma_epilogue_atoms_and_tensors(mD, mC, epilogue_args, varlen_m)
 
         epilogue_params = self.epi_to_underlying_arguments(epilogue_args)
         varlen_params = VarlenManager.to_underlying_arguments(varlen_args)
@@ -1088,8 +1107,9 @@ class GemmSm100(GemmTmaBase):
                 )
             while work_tile.is_valid_tile:
                 tile_scheduler.throttle_producer_commit(is_throttle_producer)
+                # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                 tile_coord_mnkl = work_tile.tile_idx
-                batch_idx = tile_coord_mnkl[3]
+                batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                 # Local_tile partition global tensors
                 mma_tile_coord_mnl = (
                     tile_coord_mnkl[0] // cute.size(tiled_mma.thr_id.shape),
@@ -1218,7 +1238,10 @@ class GemmSm100(GemmTmaBase):
                         dst_tensor=sSFB_chunks,
                         tma_multicast=sfb_tma_multicast,
                     )
-                k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                k_tile_start, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                    k_tile_total, split_idx
+                )
                 iket.range_push("tma_load")
                 if const_expr(not self.gather_A):
                     ab_producer_state = self.load_tma(
@@ -1226,6 +1249,7 @@ class GemmSm100(GemmTmaBase):
                         ab_producer_state,
                         [copy_A, copy_B, copy_SFA, copy_SFB],
                         k_tile_cnt,
+                        k_tile_start=k_tile_start,
                     )
                 elif const_expr(self.use_tma_gather):
                     ab_producer_state, a_prefetch_consumer_state = self.load_AB_tma_gather(
@@ -1385,8 +1409,9 @@ class GemmSm100(GemmTmaBase):
                 work_tile = tile_scheduler.initial_work_tile_info()
                 while work_tile.is_valid_tile:
                     # Get tile coord from tile scheduler
+                    # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                     tile_coord_mnkl = work_tile.tile_idx
-                    batch_idx = tile_coord_mnkl[3]
+                    batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                     copy_C = None
                     if const_expr(has_C):
                         copy_C_fn, _, _ = self.epilog_gmem_copy_and_partition(
@@ -1419,12 +1444,26 @@ class GemmSm100(GemmTmaBase):
                             mode=[1],
                         )
                     )
-                    for epi_idx in cutlass.range(epi_tile_num, unroll=1):
-                        epi_pipeline.producer_acquire(epi_producer_state)
-                        copy_epi_load(src_idx=epi_idx, producer_state=epi_producer_state)
-                        # Epi pipeline's producer commit is a NOP
-                        epi_pipeline.producer_commit(epi_producer_state)
-                        epi_producer_state.advance()
+                    # Split-K (serial/parallel): only the finalizing split runs the
+                    # epilogue, so only its tiles consume C — skip the loads (and the
+                    # pipeline slots) for non-finalizing splits, symmetric with the
+                    # epilogue warps' skip in epilogue_split_k. The outer branch is
+                    # constexpr so split_k == 1 codegen is untouched.
+                    if const_expr(self.split_k > 1 and self.split_k_mode != SplitKMode.SEPARATE):
+                        if split_idx == self.split_k - 1:
+                            for epi_idx in cutlass.range(epi_tile_num, unroll=1):
+                                epi_pipeline.producer_acquire(epi_producer_state)
+                                copy_epi_load(src_idx=epi_idx, producer_state=epi_producer_state)
+                                # Epi pipeline's producer commit is a NOP
+                                epi_pipeline.producer_commit(epi_producer_state)
+                                epi_producer_state.advance()
+                    else:
+                        for epi_idx in cutlass.range(epi_tile_num, unroll=1):
+                            epi_pipeline.producer_acquire(epi_producer_state)
+                            copy_epi_load(src_idx=epi_idx, producer_state=epi_producer_state)
+                            # Epi pipeline's producer commit is a NOP
+                            epi_pipeline.producer_commit(epi_producer_state)
+                            epi_producer_state.advance()
                     # Advance to next tile
                     tile_scheduler.advance_to_next_work()
                     work_tile = tile_scheduler.get_current_work()
@@ -1493,10 +1532,12 @@ class GemmSm100(GemmTmaBase):
             )
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
+                # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                 tile_coord_mnkl = work_tile.tile_idx
-                batch_idx = tile_coord_mnkl[3]
+                batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                 k_len = varlen_manager.len_k(batch_idx)
-                k_tile_cnt = cute.ceil_div(k_len, self.mma_tiler[2])
+                k_tile_total = cute.ceil_div(k_len, self.mma_tiler[2])
+                _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(k_tile_total, split_idx)
                 # Set tensor memory buffer for current tile
                 # (MMA, MMA_M, MMA_N)
                 acc_stage_idx = (
@@ -1638,8 +1679,9 @@ class GemmSm100(GemmTmaBase):
                 # count completed tiles during the body (sD stage cycling).
                 next_work_tile = tile_scheduler.get_current_work()
                 # Get tile coord from tile scheduler
+                # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                 tile_coord_mnkl = work_tile.tile_idx
-                batch_idx = tile_coord_mnkl[3]
+                batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                 # Set tensor memory buffer for current tile
                 # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
                 epi_acc_stage = (
@@ -1653,14 +1695,20 @@ class GemmSm100(GemmTmaBase):
 
                 copy_D = None
                 if const_expr(has_D):
+                    # Staged split-K: D is the f32 partials workspace, whose batch mode is the
+                    # combined (l * split_k + split) index from the scheduler.
+                    d_batch_idx = batch_idx
+                    if const_expr(self.split_k > 1 and self.split_k_mode == SplitKMode.SEPARATE):
+                        d_batch_idx = tile_scheduler.get_combined_batch_idx(batch_idx, split_idx)
                     copy_D, _, _ = self.epilog_gmem_copy_and_partition(
                         tma_atom_d,
-                        varlen_manager.offset_batch_epi(mD_mnl, batch_idx),
+                        varlen_manager.offset_batch_epi(mD_mnl, d_batch_idx),
                         self.cta_tile_shape_mnk[:2],
                         epi_tile,
                         sD,
                         tile_coord_mnkl,
                     )
+
                 copy_C = None  # We're using a separate warp to load C
 
                 tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
@@ -1669,6 +1717,15 @@ class GemmSm100(GemmTmaBase):
                     cute.zipped_divide(cute.make_layout(self.cta_tile_shape_mnk[:2]), epi_tile),
                     mode=[1],
                 )
+                clear_acc = varlen_k and k_len == 0
+                if const_expr(self.split_k > 1):
+                    # An empty split (split_k > total k-tiles) still runs the epilogue with a
+                    # zero contribution so the serial-semaphore turnstile advances.
+                    k_tile_total = cute.ceil_div(k_len, self.cta_tile_shape_mnk[2])
+                    _, k_tile_cnt_split = tile_scheduler.get_split_k_tile_range(
+                        k_tile_total, split_idx
+                    )
+                    clear_acc = k_tile_cnt_split == 0
                 load_acc_subtile = partial(
                     self.epi_load_acc_subtile,
                     tiled_copy_t2r,
@@ -1680,11 +1737,15 @@ class GemmSm100(GemmTmaBase):
                     acc_release_idx=self.iter_acc_early_release
                     if const_expr(self.overlap_accum_sf)
                     else epi_tile_num - 1,
-                    clear_acc=(varlen_k and k_len == 0),
+                    clear_acc=clear_acc,
                 )
 
+                # Split-K (serial/parallel): non-finalizing splits commit raw f32 partials
+                # to the tile's workspace and skip the epilogue; the last split waits for
+                # the tile's completion flag and runs the full epilogue on the summed
+                # accumulator (CUTLASS-3.x stream-K fixup semantics).
                 iket.range_push("epilogue")
-                epi_read_state, _ = self.epilogue(
+                epi_read_state, _ = self.epilogue_split_k(
                     epilogue_params,
                     epi_smem_tensors,
                     epi_pipeline,

--- a/quack/gemm_sm120.py
+++ b/quack/gemm_sm120.py
@@ -23,6 +23,7 @@ from quack.varlen_utils import VarlenManager
 from quack.pipeline import make_pipeline_state
 from quack import copy_utils
 from quack.gemm_sm90 import GemmSm90, NamedBarrierGemm
+from quack.gemm_config import SplitKMode
 from quack import sm80_utils
 
 
@@ -50,6 +51,8 @@ class GemmSm120(GemmSm90):
         gather_A: bool = False,
         concat_layout: tuple | None = None,
         use_pdl: bool = True,
+        split_k: int = 1,
+        split_k_mode: int = SplitKMode.SERIAL,
     ):
         # Don't call super().__init__ — we set up our own config
         self.acc_dtype = acc_dtype
@@ -64,6 +67,7 @@ class GemmSm120(GemmSm90):
             assert self.is_persistent, "Pingpong gemm requires persistent scheduler"
         if gather_A:
             assert cluster_shape_mnk[1] == 1
+        self._init_split_k(split_k, split_k_mode)
 
         self.cluster_shape_mnk = cluster_shape_mnk
         assert len(tile_shape_mnk) in [2, 3], "CTA tile shape must be (M, N) or (M, N, K)"
@@ -210,7 +214,12 @@ class GemmSm120(GemmSm90):
         sched_pipeline = None
         sched_data = None
         if const_expr(self.is_persistent):
-            sched_pipeline = self.make_sched_pipeline(cluster_layout_mnk, varlen_k=varlen_k)
+            sched_pipeline = self.make_sched_pipeline(
+                cluster_layout_mnk,
+                # split_k > 1 makes per-tile k-tile counts dynamic, so pingpong consumes
+                # work tiles one at a time, exactly like varlen_k.
+                varlen_k=varlen_k or self.split_k > 1,
+            )
             # Keep scheduler scratch out of SharedStorage. A small buffer before
             # the 1024-byte aligned epilogue tensors can add a 1 KiB pad; CLC
             # responses also use i128 copies, so this stays 16-byte aligned.
@@ -282,8 +291,9 @@ class GemmSm120(GemmSm90):
                 )
                 while work_tile.is_valid_tile:
                     iket.range_push("tma_load")
+                    # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                     tile_coord_mnkl = work_tile.tile_idx
-                    batch_idx = tile_coord_mnkl[3]
+                    batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                     # Local_tile partition global tensors
                     copy_A, prefetch_A = None, None
                     if const_expr(not self.gather_A):
@@ -319,10 +329,17 @@ class GemmSm120(GemmSm90):
                         tma_multicast=b_tma_multicast,
                     )
                     len_k = varlen_manager.len_k(batch_idx)
-                    k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                    k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                    k_tile_start, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                        k_tile_total, split_idx
+                    )
                     if const_expr(not self.gather_A):
                         ab_producer_state = self.load_tma(
-                            ab_pipeline, ab_producer_state, [copy_A, copy_B], k_tile_cnt
+                            ab_pipeline,
+                            ab_producer_state,
+                            [copy_A, copy_B],
+                            k_tile_cnt,
+                            k_tile_start=k_tile_start,
                         )
                     else:
                         ab_producer_state = self.load_AB_gather_A(
@@ -338,7 +355,7 @@ class GemmSm120(GemmSm90):
                     tile_scheduler.advance_to_next_work(is_scheduler_warp=is_scheduler_warp)
                     work_tile = tile_scheduler.get_current_work()
                     # End of persistent scheduler loop
-                if const_expr(self.pingpong and not varlen_k):
+                if const_expr(self.pingpong and not varlen_k and self.split_k == 1):
                     # Need to write the tile_idx to smem for the next WG in the pingpong mode
                     if is_scheduler_warp:
                         tile_scheduler.write_work_tile_to_smem(work_tile)
@@ -409,21 +426,41 @@ class GemmSm120(GemmSm90):
             if const_expr(self.pingpong):
                 if warp_idx >= 4:
                     # Advance 2nd Math WG pipeline states to the end of 1st Math WG
-                    epi_read_state.advance_iters(c_tile_cnt)
-                    epi_producer_state.advance_iters(c_tile_cnt)
-                    if const_expr(not varlen_k):
+                    if const_expr(not varlen_k and self.split_k == 1):
+                        epi_read_state.advance_iters(c_tile_cnt)
+                        epi_producer_state.advance_iters(c_tile_cnt)
                         ab_read_state.advance_iters(k_tile_cnt_static)
                     else:
-                        len_k = varlen_manager.len_k(batch_idx=work_tile.tile_idx[3])
-                        k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                        # varlen_k and split_k > 1 both make the per-tile k-tile count dynamic
+                        batch_idx_pp, split_idx_pp = (
+                            work_tile.tile_idx[3],
+                            work_tile.tile_idx[2],
+                        )
+                        len_k = varlen_manager.len_k(batch_idx=batch_idx_pp)
+                        k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                        _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                            k_tile_total, split_idx_pp
+                        )
                         ab_read_state.advance_iters(k_tile_cnt)
+                        # Under split-K, only finalizer tiles run the epilogue (and thus
+                        # produce/consume C stages); the peer advance must match.
+                        c_cnt = Int32(c_tile_cnt)
+                        if const_expr(
+                            self.split_k > 1 and self.split_k_mode != SplitKMode.SEPARATE
+                        ):
+                            if split_idx_pp != self.split_k - 1:
+                                c_cnt = Int32(0)
+                        epi_read_state.advance_iters(c_cnt)
+                        epi_producer_state.advance_iters(c_cnt)
                     tile_scheduler.advance_to_next_work()
                     work_tile = tile_scheduler.get_current_work()
             while work_tile.is_valid_tile:
+                # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                 tile_coord_mnkl = work_tile.tile_idx
-                batch_idx = tile_coord_mnkl[3]
+                batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                 len_k = varlen_manager.len_k(batch_idx)
-                k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(k_tile_total, split_idx)
                 acc.fill(0.0)
                 if const_expr(self.pingpong):
                     self.pingpong_barrier_sync(warp_group_idx, stage="mma")
@@ -455,14 +492,20 @@ class GemmSm120(GemmSm90):
 
                 copy_D = None
                 if const_expr(has_D):
+                    # Staged split-K: D is the f32 partials workspace, whose batch mode is the
+                    # combined (l * split_k + split) index from the scheduler.
+                    d_batch_idx = batch_idx
+                    if const_expr(self.split_k > 1 and self.split_k_mode == SplitKMode.SEPARATE):
+                        d_batch_idx = tile_scheduler.get_combined_batch_idx(batch_idx, split_idx)
                     copy_D, _, _ = self.epilog_gmem_copy_and_partition(
                         tma_atom_d,
-                        varlen_manager.offset_batch_epi(mD_mnl, tile_coord_mnkl[3]),
+                        varlen_manager.offset_batch_epi(mD_mnl, d_batch_idx),
                         self.cta_tile_shape_mnk[:2],
                         self.epi_tile,
                         sD,
                         tile_coord_mnkl,
                     )
+
                 copy_C = None
                 if const_expr(has_C):
                     copy_C_fn, _, _ = self.epilog_gmem_copy_and_partition(
@@ -500,7 +543,11 @@ class GemmSm120(GemmSm90):
 
                 self.epi_visit_acc(epilogue_params, acc, tiled_mma, tile_coord_mnkl, tidx)
 
-                epi_read_state, epi_producer_state = self.epilogue(
+                # Split-K (serial/parallel): non-finalizing splits commit raw f32 partials
+                # to the tile's workspace and skip the epilogue; the last split waits for
+                # the tile's completion flag and runs the full epilogue on the summed
+                # accumulator (CUTLASS-3.x stream-K fixup semantics).
+                epi_read_state, epi_producer_state = self.epilogue_split_k(
                     epilogue_params,
                     epi_smem_tensors,
                     epi_pipeline,
@@ -540,11 +587,10 @@ class GemmSm120(GemmSm90):
                     tile_scheduler.advance_to_next_work()
                     work_tile = tile_scheduler.get_current_work()
                 else:  # Skip a tile for pingpong
-                    # Update starting load/store pipeline states for the next tile
-                    epi_read_state.advance_iters(c_tile_cnt)
-                    epi_producer_state.advance_iters(c_tile_cnt)
-                    # Update starting mainloop pipeline state for the next tile
-                    if const_expr(not varlen_k):
+                    # Update starting load/store/mainloop pipeline states for the next tile
+                    if const_expr(not varlen_k and self.split_k == 1):
+                        epi_read_state.advance_iters(c_tile_cnt)
+                        epi_producer_state.advance_iters(c_tile_cnt)
                         ab_read_state.advance_iters(k_tile_cnt_static)
                         tile_scheduler.advance_to_next_work(advance_count=self.mma_warp_groups)
                         work_tile = tile_scheduler.get_current_work()
@@ -552,9 +598,26 @@ class GemmSm120(GemmSm90):
                         tile_scheduler.advance_to_next_work()
                         work_tile = tile_scheduler.get_current_work()
                         if work_tile.is_valid_tile:
-                            len_k = varlen_manager.len_k(batch_idx=work_tile.tile_idx[3])
-                            k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                            batch_idx_pp, split_idx_pp = (
+                                work_tile.tile_idx[3],
+                                work_tile.tile_idx[2],
+                            )
+                            len_k = varlen_manager.len_k(batch_idx=batch_idx_pp)
+                            k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                            _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                                k_tile_total, split_idx_pp
+                            )
                             ab_read_state.advance_iters(k_tile_cnt)
+                            # Under split-K, only finalizer tiles run the epilogue (and
+                            # thus produce/consume C stages); the peer advance must match.
+                            c_cnt = Int32(c_tile_cnt)
+                            if const_expr(
+                                self.split_k > 1 and self.split_k_mode != SplitKMode.SEPARATE
+                            ):
+                                if split_idx_pp != self.split_k - 1:
+                                    c_cnt = Int32(0)
+                            epi_read_state.advance_iters(c_cnt)
+                            epi_producer_state.advance_iters(c_cnt)
                             tile_scheduler.advance_to_next_work()
                             work_tile = tile_scheduler.get_current_work()
 

--- a/quack/gemm_sm90.py
+++ b/quack/gemm_sm90.py
@@ -22,6 +22,7 @@ from cutlass.utils import LayoutEnum, SmemPartition
 
 from quack import layout_utils
 from quack.gemm_base import GemmTmaBase, NamedBarrierGemm
+from quack.gemm_config import SplitKMode
 from quack.tile_scheduler import TileSchedulerOptions
 from quack.varlen_utils import VarlenArguments, VarlenManager
 
@@ -123,6 +124,8 @@ class GemmSm90(GemmTmaBase):
         use_clc_persistence: bool = False,
         concat_layout: tuple | None = None,
         use_pdl: bool = True,
+        split_k: int = 1,
+        split_k_mode: int = SplitKMode.SERIAL,
     ):
         """
         Initializes the configuration for a Hopper dense GEMM kernel.
@@ -152,6 +155,7 @@ class GemmSm90(GemmTmaBase):
         self.concat_layout = concat_layout or ()
         if gather_A:
             assert cluster_shape_mnk[1] == 1, "Cluster shape N must be 1 for gather A "
+        self._init_split_k(split_k, split_k_mode)
 
         self.cluster_shape_mnk = cluster_shape_mnk
         assert len(tile_shape_mnk) in [2, 3], "CTA tile shape must be (M, N) or (M, N, K)"
@@ -433,9 +437,14 @@ class GemmSm90(GemmTmaBase):
         if const_expr(not self.gather_A):
             self.num_tma_load_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
 
-        tma_atom_d, tma_tensor_d, tma_atom_c, tma_tensor_c = (
-            self.make_tma_epilogue_atoms_and_tensors(mD, mC, epilogue_args, varlen_m)
-        )
+        if const_expr(self.split_k > 1):
+            assert mD is not None, "split_k requires an output tensor D"
+        (
+            tma_atom_d,
+            tma_tensor_d,
+            tma_atom_c,
+            tma_tensor_c,
+        ) = self.make_tma_epilogue_atoms_and_tensors(mD, mC, epilogue_args, varlen_m)
 
         epilogue_params = self.epi_to_underlying_arguments(epilogue_args)
         varlen_params = VarlenManager.to_underlying_arguments(varlen_args)
@@ -601,7 +610,12 @@ class GemmSm90(GemmTmaBase):
         sched_pipeline = None
         sched_data = None
         if const_expr(self.is_persistent):
-            sched_pipeline = self.make_sched_pipeline(cluster_layout_mnk, varlen_k=varlen_k)
+            sched_pipeline = self.make_sched_pipeline(
+                cluster_layout_mnk,
+                # split_k > 1 makes per-tile k-tile counts dynamic, so pingpong consumes
+                # work tiles one at a time, exactly like varlen_k.
+                varlen_k=varlen_k or self.split_k > 1,
+            )
             # Keep scheduler scratch out of SharedStorage. A small buffer before
             # the 1024-byte aligned epilogue tensors can add a 1 KiB pad; CLC
             # responses also use i128 copies, so this stays 16-byte aligned.
@@ -677,8 +691,9 @@ class GemmSm90(GemmTmaBase):
                 )
                 while work_tile.is_valid_tile:
                     iket.range_push("tma_load")
+                    # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                     tile_coord_mnkl = work_tile.tile_idx
-                    batch_idx = tile_coord_mnkl[3]
+                    batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                     # Local_tile partition global tensors
                     copy_A, prefetch_A = None, None
                     if const_expr(not self.gather_A):
@@ -714,10 +729,17 @@ class GemmSm90(GemmTmaBase):
                         tma_multicast=b_tma_multicast,
                     )
                     len_k = varlen_manager.len_k(batch_idx)
-                    k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                    k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                    k_tile_start, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                        k_tile_total, split_idx
+                    )
                     if const_expr(not self.gather_A):
                         ab_producer_state = self.load_tma(
-                            ab_pipeline, ab_producer_state, [copy_A, copy_B], k_tile_cnt
+                            ab_pipeline,
+                            ab_producer_state,
+                            [copy_A, copy_B],
+                            k_tile_cnt,
+                            k_tile_start=k_tile_start,
                         )
                     else:
                         ab_producer_state = self.load_AB_gather_A(
@@ -733,7 +755,7 @@ class GemmSm90(GemmTmaBase):
                     tile_scheduler.advance_to_next_work(is_scheduler_warp=is_scheduler_warp)
                     work_tile = tile_scheduler.get_current_work()
                     # End of persistent scheduler loop
-                if const_expr(self.pingpong and not varlen_k):
+                if const_expr(self.pingpong and not varlen_k and self.split_k == 1):
                     # Need to write the tile_idx to smem for the next WG in the pingpong mode
                     if is_scheduler_warp:
                         tile_scheduler.write_work_tile_to_smem(work_tile)
@@ -795,29 +817,49 @@ class GemmSm90(GemmTmaBase):
             if const_expr(self.pingpong):
                 if warp_idx >= 4:
                     # Advance 2nd Math WG pipeline states to the end of 1st Math WG
-                    epi_read_state.advance_iters(c_tile_cnt)
-                    epi_producer_state.advance_iters(c_tile_cnt)
-                    if const_expr(not varlen_k):
+                    if const_expr(not varlen_k and self.split_k == 1):
+                        epi_read_state.advance_iters(c_tile_cnt)
+                        epi_producer_state.advance_iters(c_tile_cnt)
                         ab_read_state.advance_iters(k_tile_cnt_static)
                     else:
-                        len_k = varlen_manager.len_k(batch_idx=work_tile.tile_idx[3])
-                        k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                        # varlen_k and split_k > 1 both make the per-tile k-tile count dynamic
+                        batch_idx_pp, split_idx_pp = (
+                            work_tile.tile_idx[3],
+                            work_tile.tile_idx[2],
+                        )
+                        len_k = varlen_manager.len_k(batch_idx=batch_idx_pp)
+                        k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                        _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                            k_tile_total, split_idx_pp
+                        )
                         ab_read_state.advance_iters(k_tile_cnt)
+                        # Under split-K, only finalizer tiles run the epilogue (and thus
+                        # produce/consume C stages); the peer advance must match.
+                        c_cnt = Int32(c_tile_cnt)
+                        if const_expr(
+                            self.split_k > 1 and self.split_k_mode != SplitKMode.SEPARATE
+                        ):
+                            if split_idx_pp != self.split_k - 1:
+                                c_cnt = Int32(0)
+                        epi_read_state.advance_iters(c_cnt)
+                        epi_producer_state.advance_iters(c_cnt)
                     # TODO: do we need to check if work_tile is valid?
                     tile_scheduler.advance_to_next_work()
                     work_tile = tile_scheduler.get_current_work()
             while work_tile.is_valid_tile:
+                # (pid_m, pid_n, split_idx | None, batch_idx), decoded by the scheduler
                 tile_coord_mnkl = work_tile.tile_idx
-                batch_idx = tile_coord_mnkl[3]
+                batch_idx, split_idx = tile_coord_mnkl[3], tile_coord_mnkl[2]
                 len_k = varlen_manager.len_k(batch_idx)
-                k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(k_tile_total, split_idx)
                 if const_expr(self.pingpong):
                     self.pingpong_barrier_sync(warp_group_idx, stage="mma")
                 iket.range_push("mma")
                 ab_read_state = self.mma(
                     ab_pipeline, ab_read_state, mma_fn, acc, acc_slow, k_tile_cnt, warp_group_idx
                 )
-                if const_expr(varlen_k):
+                if const_expr(varlen_k or self.split_k > 1):
                     if k_tile_cnt == 0:
                         acc.fill(0.0)
                 iket.range_pop()
@@ -829,14 +871,20 @@ class GemmSm90(GemmTmaBase):
 
                 copy_D = None
                 if const_expr(has_D):
+                    # Staged split-K: D is the f32 partials workspace, whose batch mode is the
+                    # combined (l * split_k + split) index from the scheduler.
+                    d_batch_idx = batch_idx
+                    if const_expr(self.split_k > 1 and self.split_k_mode == SplitKMode.SEPARATE):
+                        d_batch_idx = tile_scheduler.get_combined_batch_idx(batch_idx, split_idx)
                     copy_D, _, _ = self.epilog_gmem_copy_and_partition(
                         tma_atom_d,
-                        varlen_manager.offset_batch_epi(mD_mnl, batch_idx),
+                        varlen_manager.offset_batch_epi(mD_mnl, d_batch_idx),
                         self.cta_tile_shape_mnk[:2],
                         self.epi_tile,
                         sD,
                         tile_coord_mnkl,
                     )
+
                 copy_C = None
                 if const_expr(has_C):
                     copy_C_fn, _, _ = self.epilog_gmem_copy_and_partition(
@@ -874,7 +922,11 @@ class GemmSm90(GemmTmaBase):
 
                 self.epi_visit_acc(epilogue_params, acc, tiled_mma, tile_coord_mnkl, tidx)
 
-                epi_read_state, epi_producer_state = self.epilogue(
+                # Split-K (serial/parallel): non-finalizing splits commit raw f32 partials
+                # to the tile's workspace and skip the epilogue; the last split waits for
+                # the tile's completion flag and runs the full epilogue on the summed
+                # accumulator (CUTLASS-3.x stream-K fixup semantics).
+                epi_read_state, epi_producer_state = self.epilogue_split_k(
                     epilogue_params,
                     epi_smem_tensors,
                     epi_pipeline,
@@ -914,11 +966,10 @@ class GemmSm90(GemmTmaBase):
                     tile_scheduler.advance_to_next_work()
                     work_tile = tile_scheduler.get_current_work()
                 else:  # Skip a tile for pingpong
-                    # Update starting load/store pipeline states for the next tile
-                    epi_read_state.advance_iters(c_tile_cnt)
-                    epi_producer_state.advance_iters(c_tile_cnt)
-                    # Update starting mainloop pipeline state for the next tile
-                    if const_expr(not varlen_k):
+                    # Update starting load/store/mainloop pipeline states for the next tile
+                    if const_expr(not varlen_k and self.split_k == 1):
+                        epi_read_state.advance_iters(c_tile_cnt)
+                        epi_producer_state.advance_iters(c_tile_cnt)
                         ab_read_state.advance_iters(k_tile_cnt_static)
                         tile_scheduler.advance_to_next_work(advance_count=self.mma_warp_groups)
                         work_tile = tile_scheduler.get_current_work()
@@ -926,9 +977,26 @@ class GemmSm90(GemmTmaBase):
                         tile_scheduler.advance_to_next_work()
                         work_tile = tile_scheduler.get_current_work()
                         if work_tile.is_valid_tile:
-                            len_k = varlen_manager.len_k(batch_idx=work_tile.tile_idx[3])
-                            k_tile_cnt = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                            batch_idx_pp, split_idx_pp = (
+                                work_tile.tile_idx[3],
+                                work_tile.tile_idx[2],
+                            )
+                            len_k = varlen_manager.len_k(batch_idx=batch_idx_pp)
+                            k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
+                            _, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
+                                k_tile_total, split_idx_pp
+                            )
                             ab_read_state.advance_iters(k_tile_cnt)
+                            # Under split-K, only finalizer tiles run the epilogue (and
+                            # thus produce/consume C stages); the peer advance must match.
+                            c_cnt = Int32(c_tile_cnt)
+                            if const_expr(
+                                self.split_k > 1 and self.split_k_mode != SplitKMode.SEPARATE
+                            ):
+                                if split_idx_pp != self.split_k - 1:
+                                    c_cnt = Int32(0)
+                            epi_read_state.advance_iters(c_cnt)
+                            epi_producer_state.advance_iters(c_cnt)
                             tile_scheduler.advance_to_next_work()
                             work_tile = tile_scheduler.get_current_work()
                 # End of persistent scheduler loop

--- a/quack/gemm_tvm_ffi_utils.py
+++ b/quack/gemm_tvm_ffi_utils.py
@@ -10,6 +10,7 @@ from cutlass import Int32, Float32
 from cutlass.cute.runtime import make_ptr
 
 from quack.compile_utils import make_fake_tensor as fake_tensor
+from quack.gemm_config import SplitKMode
 from quack.cute_dsl_utils import torch2cute_dtype_map
 from quack.tile_scheduler import TileSchedulerOptions
 from quack.varlen_utils import VarlenArguments
@@ -313,20 +314,27 @@ def compile_gemm_kernel(
     concat_layout=None,
     num_warps=None,
     sf_vec_size=None,
+    split_k=1,
+    split_k_mode=SplitKMode.SERIAL,
 ):
     """Build GemmCls instance, apply SM90 partial, and cute.compile with TVM-FFI."""
+    split_k_kwargs = {}
+    if split_k != 1:
+        assert device_capacity[0] in [9, 10, 11, 12], "split_k requires SM90/SM100/SM120"
+        split_k_kwargs = {"split_k": split_k, "split_k_mode": split_k_mode}
     if device_capacity[0] == 8:
         sm8x_kwargs = {"is_persistent": persistent, "num_warps": num_warps}
         sm8x_kwargs["arch"] = device_capacity[0] * 10 + device_capacity[1]
         GemmCls = partial(GemmCls, **sm8x_kwargs)
     elif device_capacity[0] in [9, 12]:
-        GemmCls = partial(GemmCls, pingpong=pingpong, is_persistent=persistent)
+        GemmCls = partial(GemmCls, pingpong=pingpong, is_persistent=persistent, **split_k_kwargs)
     elif device_capacity[0] in [10, 11]:
         GemmCls = partial(
             GemmCls,
             use_clc_persistence=is_dynamic_persistent,
             use_tma_gather=use_tma_gather,
             sf_vec_size=sf_vec_size,
+            **split_k_kwargs,
         )
     gemm_obj = GemmCls(
         Float32,

--- a/quack/split_k_reduce.py
+++ b/quack/split_k_reduce.py
@@ -1,0 +1,387 @@
+# Copyright (c) 2026, QuACK team.
+# Staged split-K reduction with the full (linear) epilogue:
+#   D[m, n, l] = convert(alpha * sum_s Ws[m, n, l*split_k + s] + beta*C + rowvec + colvec (+ D))
+# This is the second kernel of the staged split-K GEMM pipeline: the GEMM kernel writes
+# RAW per-split f32 accumulator partials (no epilogue math at all) to the workspace, and
+# this kernel sums the splits in fixed ascending order and applies the epilogue exactly
+# once on the completed sum — mirroring the serial/parallel modes' finalizing split. The
+# reduction order is deterministic, so results are bitwise reproducible run to run. The
+# epilogue math is shared with the GEMM mixin via gemm_default_epi.apply_linear_epilogue.
+
+import math
+from typing import Optional, Type
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, const_expr
+from cutlass.cute.runtime import make_ptr
+
+from torch import Tensor
+
+import quack.copy_utils as copy_utils
+import quack.utils as utils
+from quack.compile_utils import make_fake_tensor as fake_tensor
+from quack.cache import jit_cache
+from quack.cute_dsl_utils import torch2cute_dtype_map
+from quack.dsl import cute_op
+
+# The shared linear-epilogue math (also used by the GEMM mixins' epi_visit_subtile), so
+# the reduction kernel and the in-GEMM finalizer apply bitwise-identical epilogues.
+from quack.gemm_default_epi import apply_linear_epilogue
+
+
+class SplitKReduce:
+    """Sum split_k f32 partial slices, apply the linear epilogue, store in out_dtype.
+
+    mWs has shape (M, N, L * split_k) with the combined (l * split_k + s) batch mode the
+    staged split-K GEMM stored to; mOut has shape (M, N, L); mC (M, N, L), mRowVec (N, L)
+    and mColVec (M, L) are the optional epilogue operands. All matrix views must be
+    M-row/N-contiguous (the host wrapper transposes M/N views — and swaps the vector
+    roles — for m-major outputs). With add_to_output, the prior value of D is added once
+    (after the epilogue terms, unscaled).
+
+    vec_elems must divide N: predicate_k gates whole vectors by their first element's
+    column, so a vector must never straddle the N boundary (same contract as
+    rms_final_reduce, where the host derives vec_elems = gcd(N, max_vec)).
+    """
+
+    num_threads = 128
+    threads_per_row = 16
+
+    def __init__(
+        self,
+        out_dtype: Type[cutlass.Numeric],
+        split_k: int,
+        add_to_output: bool,
+        vec_elems: int,
+        c_dtype: Optional[Type[cutlass.Numeric]] = None,
+        rowvec_dtype: Optional[Type[cutlass.Numeric]] = None,
+        colvec_dtype: Optional[Type[cutlass.Numeric]] = None,
+    ):
+        assert split_k >= 1
+        assert vec_elems in (1, 2, 4)
+        self.out_dtype = out_dtype
+        self.split_k = split_k
+        self.add_to_output = add_to_output
+        self.vec_elems = vec_elems
+        self.c_dtype = c_dtype
+        self.rowvec_dtype = rowvec_dtype
+        self.colvec_dtype = colvec_dtype
+        self.tiler_mn = (
+            self.num_threads // self.threads_per_row,
+            self.threads_per_row * self.vec_elems,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        mWs: cute.Tensor,
+        mOut: cute.Tensor,
+        mC: Optional[cute.Tensor],
+        mRowVec: Optional[cute.Tensor],
+        mColVec: Optional[cute.Tensor],
+        alpha: Optional[Float32 | cute.Pointer],
+        beta: Optional[Float32 | cute.Pointer],
+        stream: cuda.CUstream,
+    ):
+        assert mWs.element_type == Float32
+        assert mOut.element_type == self.out_dtype
+        tiled_copy_ws = copy_utils.tiled_copy_2d(
+            Float32, self.threads_per_row, self.num_threads, num_copy_elems=self.vec_elems
+        )
+        tiled_copy_out = copy_utils.tiled_copy_2d(
+            self.out_dtype, self.threads_per_row, self.num_threads, num_copy_elems=self.vec_elems
+        )
+        tiled_copy_c = None
+        if const_expr(mC is not None):
+            tiled_copy_c = copy_utils.tiled_copy_2d(
+                self.c_dtype, self.threads_per_row, self.num_threads, num_copy_elems=self.vec_elems
+            )
+        tiled_copy_rv = None
+        if const_expr(mRowVec is not None):
+            tiled_copy_rv = copy_utils.tiled_copy_2d(
+                self.rowvec_dtype,
+                self.threads_per_row,
+                self.num_threads,
+                num_copy_elems=self.vec_elems,
+            )
+        self.kernel(
+            mWs,
+            mOut,
+            mC,
+            mRowVec,
+            mColVec,
+            alpha,
+            beta,
+            tiled_copy_ws,
+            tiled_copy_out,
+            tiled_copy_c,
+            tiled_copy_rv,
+        ).launch(
+            grid=[
+                cute.ceil_div(mOut.shape[0], self.tiler_mn[0]),
+                cute.ceil_div(mOut.shape[1], self.tiler_mn[1]),
+                mOut.shape[2],
+            ],
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mWs: cute.Tensor,
+        mOut: cute.Tensor,
+        mC: Optional[cute.Tensor],
+        mRowVec: Optional[cute.Tensor],
+        mColVec: Optional[cute.Tensor],
+        alpha: Optional[Float32 | cute.Pointer],
+        beta: Optional[Float32 | cute.Pointer],
+        tiled_copy_ws: cute.TiledCopy,
+        tiled_copy_out: cute.TiledCopy,
+        tiled_copy_c: Optional[cute.TiledCopy],
+        tiled_copy_rv: Optional[cute.TiledCopy],
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        shape_mn = (mOut.shape[0], mOut.shape[1])
+
+        thr_copy_ws = tiled_copy_ws.get_slice(tidx)
+        thr_copy_out = tiled_copy_out.get_slice(tidx)
+
+        idMN = cute.make_identity_tensor(shape_mn)
+        cMN = cute.local_tile(idMN, self.tiler_mn, (bidx, bidy))
+        # Each thread owns one row of the tile and vec_elems consecutive columns;
+        # predicate the column dim, guard the row dim with an if (same scheme as
+        # rms_final_reduce).
+        tXcX = thr_copy_ws.partition_S(cMN)[(0, None), None, None]
+        row = tXcX[0][0]
+        tXpX = copy_utils.predicate_k(thr_copy_ws.partition_S(cMN), limit=shape_mn[1])
+        row_ok = row < shape_mn[0]
+
+        gOut = cute.local_tile(mOut[None, None, bidz], self.tiler_mn, (bidx, bidy))
+        tXgOut = thr_copy_out.partition_S(gOut)
+
+        # Load all split partials (and the epilogue operands), then sum in fixed
+        # ascending split order for a deterministic reduction.
+        tXgWs = [
+            thr_copy_ws.partition_S(
+                cute.local_tile(
+                    mWs[None, None, bidz * self.split_k + s], self.tiler_mn, (bidx, bidy)
+                )
+            )
+            for s in range(self.split_k)
+        ]
+        frags = [cute.make_rmem_tensor_like(tXgW) for tXgW in tXgWs]
+        tXrC = None
+        if const_expr(mC is not None):
+            gC = cute.local_tile(mC[None, None, bidz], self.tiler_mn, (bidx, bidy))
+            tXgC = tiled_copy_c.get_slice(tidx).partition_S(gC)
+            tXrC = cute.make_rmem_tensor_like(tXgC)
+        tXrRowVec = None
+        if const_expr(mRowVec is not None):
+            # Broadcast (M, N) view of the (N, L) row vector: row stride 0, col stride 1
+            # (each thread loads its own duplicate — vectorized along the contiguous N).
+            mRV_mn = cute.make_tensor(
+                utils.elem_pointer(mRowVec, (0, bidz)),
+                cute.make_layout(shape_mn, stride=(0, 1)),
+            )
+            gRV = cute.local_tile(mRV_mn, self.tiler_mn, (bidx, bidy))
+            tXgRV = tiled_copy_rv.get_slice(tidx).partition_S(gRV)
+            tXrRV_in = cute.make_rmem_tensor_like(tXgRV)
+        tXrOut_in = None
+        if const_expr(self.add_to_output):
+            tXrOut_in = cute.make_rmem_tensor_like(tXgOut)
+        if row_ok:
+            for s in cutlass.range_constexpr(self.split_k):
+                copy_utils.copy(tXgWs[s], frags[s], pred=tXpX)
+            if const_expr(mC is not None):
+                copy_utils.copy(tXgC, tXrC, pred=tXpX)
+            if const_expr(mRowVec is not None):
+                copy_utils.copy(tXgRV, tXrRV_in, pred=tXpX)
+            if const_expr(self.add_to_output):
+                copy_utils.copy(tXgOut, tXrOut_in, pred=tXpX)
+        acc = frags[0].load().to(Float32)
+        for s in cutlass.range_constexpr(1, self.split_k):
+            acc = acc + frags[s].load().to(Float32)
+
+        # The epilogue, exactly once, on the completed f32 sum — the same shared math as
+        # the GEMM mixin (alpha * acc + beta * C + rowvec + colvec).
+        tXrD = cute.make_rmem_tensor_like(frags[0])
+        tXrD.store(acc)
+        if const_expr(mRowVec is not None):
+            tXrRowVec = cute.make_rmem_tensor_like(frags[0])
+            tXrRowVec.store(tXrRV_in.load().to(Float32))
+        tXrColVec = None
+        if const_expr(mColVec is not None):
+            cv = Float32(0.0)
+            if row_ok:
+                cv = Float32(mColVec[row, bidz])
+            tXrColVec = cute.make_rmem_tensor_like(frags[0])
+            for i in cutlass.range_constexpr(cute.size(tXrColVec)):
+                tXrColVec[i] = cv
+        apply_linear_epilogue(tXrD, tXrC, alpha, beta, tXrRowVec, tXrColVec)
+        acc = tXrD.load()
+        if const_expr(self.add_to_output):
+            acc = acc + tXrOut_in.load().to(Float32)
+
+        tXrOut = cute.make_rmem_tensor_like(tXgOut)
+        tXrOut.store(acc.to(self.out_dtype))
+        if row_ok:
+            copy_utils.copy(tXrOut, tXgOut, pred=tXpX)
+
+
+@jit_cache
+def _compile_split_k_reduce(
+    out_dtype,
+    split_k,
+    add_to_output,
+    vec_elems,
+    alpha_mode,
+    beta_mode,
+    c_dtype,
+    rowvec_dtype,
+    colvec_dtype,
+):
+    m_sym, n_sym, l_sym = cute.sym_int(), cute.sym_int(), cute.sym_int()
+    ls_sym = cute.sym_int()
+    # Workspace rows are padded to a multiple of 4 f32 elements (16 bytes) by the host.
+    ws_cute = fake_tensor(Float32, (m_sym, n_sym, ls_sym), divisibility=4, leading_dim=1)
+    out_cute = fake_tensor(
+        out_dtype, (m_sym, n_sym, l_sym), divisibility=128 // out_dtype.width, leading_dim=1
+    )
+    # The epilogue operands only need vec_elems-granular alignment (we vectorize by at
+    # most vec_elems); C/rowvec rows can be unpadded user tensors.
+    c_cute = (
+        fake_tensor(c_dtype, (m_sym, n_sym, l_sym), divisibility=vec_elems, leading_dim=1)
+        if c_dtype is not None
+        else None
+    )
+    rowvec_cute = (
+        fake_tensor(rowvec_dtype, (n_sym, l_sym), divisibility=vec_elems, leading_dim=0)
+        if rowvec_dtype is not None
+        else None
+    )
+    colvec_cute = (
+        fake_tensor(colvec_dtype, (m_sym, l_sym), divisibility=1, leading_dim=0)
+        if colvec_dtype is not None
+        else None
+    )
+
+    def fake_scalar(mode):
+        if mode == 0:
+            return None
+        elif mode == 1:
+            return Float32(1.0)
+        else:
+            return make_ptr(Float32, 0, cute.AddressSpace.gmem, assumed_align=4)
+
+    return cute.compile(
+        SplitKReduce(
+            out_dtype, split_k, add_to_output, vec_elems, c_dtype, rowvec_dtype, colvec_dtype
+        ),
+        ws_cute,
+        out_cute,
+        c_cute,
+        rowvec_cute,
+        colvec_cute,
+        fake_scalar(alpha_mode),
+        fake_scalar(beta_mode),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+
+
+@cute_op(
+    "quack::split_k_reduce_out",
+    mutates_args=("out",),
+    device_types="cuda",
+)
+def _split_k_reduce_out(
+    ws: Tensor,
+    out: Tensor,
+    split_k: int,
+    add_to_output: bool,
+    alpha: float,
+    alpha_t: Optional[Tensor],
+    beta: float,
+    beta_t: Optional[Tensor],
+    C: Optional[Tensor],
+    rowvec_bias: Optional[Tensor],
+    colvec_bias: Optional[Tensor],
+) -> None:
+    """out[l] = convert(alpha * sum_s ws[l*split_k+s] + beta*C + rowvec + colvec (+ out))."""
+    out_dtype = torch2cute_dtype_map[out.dtype]
+    # Vectors must not straddle the N boundary (predicate granularity is per vector); a
+    # non-N-contiguous C cannot be vector-loaded with the shared column predicate.
+    vec_elems = math.gcd(out.shape[-1], 4)
+    if C is not None and C.stride(-1) != 1:
+        vec_elems = 1
+    alpha_mode = 2 if alpha_t is not None else (1 if alpha != 1.0 else 0)
+    beta_mode = 2 if beta_t is not None else (1 if beta != 1.0 else 0)
+    compiled_fn = _compile_split_k_reduce(
+        out_dtype,
+        split_k,
+        add_to_output,
+        vec_elems,
+        alpha_mode,
+        beta_mode,
+        torch2cute_dtype_map[C.dtype] if C is not None else None,
+        torch2cute_dtype_map[rowvec_bias.dtype] if rowvec_bias is not None else None,
+        torch2cute_dtype_map[colvec_bias.dtype] if colvec_bias is not None else None,
+    )
+
+    def scalar_arg(mode, imm, tens):
+        if mode == 0:
+            return None
+        elif mode == 1:
+            return Float32(imm)
+        else:
+            return tens.data_ptr()
+
+    # Kernel-facing layouts are (M, N, L) / (N, L) / (M, L): permute the torch views.
+    compiled_fn(
+        ws.permute(1, 2, 0),
+        out.permute(1, 2, 0),
+        C.permute(1, 2, 0) if C is not None else None,
+        rowvec_bias.permute(1, 0) if rowvec_bias is not None else None,
+        colvec_bias.permute(1, 0) if colvec_bias is not None else None,
+        scalar_arg(alpha_mode, alpha, alpha_t),
+        scalar_arg(beta_mode, beta, beta_t),
+    )
+
+
+def split_k_reduce(
+    ws: Tensor,  # (L * split_k, M, N) f32 raw partials, N-contiguous
+    out: Tensor,  # (L, M, N), N-contiguous
+    split_k: int,
+    alpha: float | Tensor = 1.0,
+    beta: float | Tensor = 1.0,
+    C: Optional[Tensor] = None,  # (L, M, N)
+    rowvec_bias: Optional[Tensor] = None,  # (L, N)
+    colvec_bias: Optional[Tensor] = None,  # (L, M)
+    add_to_output: bool = False,
+) -> None:
+    """Deterministically reduce staged split-K partials and apply the linear epilogue."""
+    assert ws.ndim == 3 and out.ndim == 3
+    assert ws.shape[0] == out.shape[0] * split_k
+    assert ws.shape[1:] == out.shape[1:]
+    alpha_t = alpha if isinstance(alpha, Tensor) else None
+    beta_t = beta if isinstance(beta, Tensor) else None
+    # Dispatch through the cute_op so torch.compile sees a registered custom op (the
+    # fake is a pure no-op; compilation is owned by jit_cache + the async compile pool).
+    _split_k_reduce_out(
+        ws,
+        out,
+        split_k,
+        add_to_output,
+        alpha if alpha_t is None else 1.0,
+        alpha_t,
+        beta if beta_t is None else 1.0,
+        beta_t,
+        C,
+        rowvec_bias,
+        colvec_bias,
+    )

--- a/quack/tile_scheduler.py
+++ b/quack/tile_scheduler.py
@@ -107,6 +107,42 @@ def get_raster_order_from_option(
     return raster_order
 
 
+class WorkTileInfo:
+    """Drop-in generalization of WorkTileInfo for split-K.
+
+    tile_idx is (pid_m, pid_n, split_idx, batch_idx), with split_idx a dynamic value
+    only when num_split_k > 1 (a static None otherwise, keeping the non-split case
+    identical to the DSL class). The DSL's WorkTileInfo asserts exactly 4 dynamic
+    loop-carried values in __new_from_mlir_values__; this one derives the counts from
+    the template so the decoded split-K coordinate can cross persistent-loop
+    boundaries.
+    """
+
+    def __init__(self, tile_idx: cute.Coord, is_valid_tile: Boolean):
+        self._tile_idx = tile_idx
+        self._is_valid_tile = Boolean(is_valid_tile)
+
+    @property
+    def tile_idx(self) -> cute.Coord:
+        return self._tile_idx
+
+    @property
+    def is_valid_tile(self) -> Boolean:
+        return self._is_valid_tile
+
+    def __extract_mlir_values__(self):
+        values = cutlass.extract_mlir_values(self._tile_idx)
+        values.extend(cutlass.extract_mlir_values(self._is_valid_tile))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        num_tile_idx_values = len(cutlass.extract_mlir_values(self._tile_idx))
+        return WorkTileInfo(
+            cutlass.new_from_mlir_values(self._tile_idx, values[:num_tile_idx_values]),
+            cutlass.new_from_mlir_values(self._is_valid_tile, values[num_tile_idx_values:]),
+        )
+
+
 # Grouping arguments together that should be passed to __call__
 @mlir_namedtuple
 class TileSchedulerOptions(NamedTuple):
@@ -126,6 +162,9 @@ class TileSchedulerArguments:
     tile_count_semaphore: Optional[cute.Pointer] = None
     batch_idx_permute: Optional[cute.Tensor] = None
     persistence_mode: cutlass.Constexpr[PersistenceMode] = PersistenceMode.NONE
+    # Split-K: the L (z) dimension of the work-id space is multiplied by num_split_k, with the
+    # split index as the fastest-varying component. problem_shape_ntile_mnl[2] stays the true L.
+    num_split_k: cutlass.Constexpr[int] = 1
 
 
 class TileScheduler:
@@ -149,6 +188,7 @@ class TileScheduler:
         batch_idx_permute: Optional[cute.Tensor]
         cluster_shape_mnk: cutlass.Constexpr[cute.Shape]
         persistence_mode: cutlass.Constexpr[PersistenceMode]
+        num_split_k: cutlass.Constexpr[int] = 1
 
         @staticmethod
         @cute.jit
@@ -196,6 +236,7 @@ class TileScheduler:
                 args.batch_idx_permute,
                 args.cluster_shape_mnk,
                 args.persistence_mode,
+                args.num_split_k,
             )
 
     def __init__(
@@ -316,12 +357,16 @@ class TileScheduler:
             return (
                 params.cluster_shape_mnk[0] * cute.size(params.problem_shape_ncluster_mnl[:2]),
                 params.cluster_shape_mnk[1],
-                params.cluster_shape_mnk[2] * params.problem_shape_ncluster_mnl[2],
+                params.cluster_shape_mnk[2]
+                * params.problem_shape_ncluster_mnl[2]
+                * params.num_split_k,
             )
         else:
-            num_ctas_in_problem = cute.size(
-                params.problem_shape_ncluster_mnl, loc=loc, ip=ip
-            ) * cute.size(params.cluster_shape_mnk)
+            num_ctas_in_problem = (
+                cute.size(params.problem_shape_ncluster_mnl, loc=loc, ip=ip)
+                * cute.size(params.cluster_shape_mnk)
+                * params.num_split_k
+            )
             num_ctas_per_cluster = cute.size(params.cluster_shape_mnk, loc=loc, ip=ip)
             # Total ctas that can run in one wave
             num_ctas_per_wave = max_active_clusters * num_ctas_per_cluster
@@ -383,7 +428,7 @@ class TileScheduler:
         block_zero_only: bool = False,
         loc=None,
         ip=None,
-    ) -> cutlass.utils.WorkTileInfo:
+    ) -> WorkTileInfo:
         params = self.params
         if const_expr(is_valid is None):
             if const_expr(params.persistence_mode == PersistenceMode.NONE):
@@ -391,8 +436,11 @@ class TileScheduler:
             elif const_expr(params.persistence_mode == PersistenceMode.CLC):
                 is_valid = work_idx < cute.size(params.problem_shape_ncluster_mnl[:2])
             else:
-                is_valid = work_idx < cute.size(params.problem_shape_ncluster_mnl)
+                is_valid = (
+                    work_idx < cute.size(params.problem_shape_ncluster_mnl) * params.num_split_k
+                )
         pid_m, pid_n, batch_idx = Int32(0), Int32(0), Int32(0)
+        split_idx = Int32(0) if const_expr(params.num_split_k != 1) else None
         if is_valid:
             if const_expr(params.persistence_mode in [PersistenceMode.NONE, PersistenceMode.CLC]):
                 cluster_id_in_problem = work_idx
@@ -402,21 +450,77 @@ class TileScheduler:
                     else cluster_idx_from_block_idx(params.cluster_shape_mnk, loc=loc, ip=ip)[2]
                 )
             else:
-                bidz_, cluster_id_in_problem = divmod(work_idx, params.num_clusters_per_problem_fdd)
+                if const_expr(params.num_split_k == 1):
+                    bidz_, cluster_id_in_problem = divmod(
+                        work_idx, params.num_clusters_per_problem_fdd
+                    )
+                else:
+                    # Split index is the fastest-varying component of the linear work id, so all
+                    # splits of one output tile are temporally adjacent (L2 + semaphore wait).
+                    work_idx_tile = work_idx // params.num_split_k
+                    split_idx = work_idx - work_idx_tile * params.num_split_k
+                    l_idx, cluster_id_in_problem = divmod(
+                        work_idx_tile, params.num_clusters_per_problem_fdd
+                    )
+                    # bidz_ carries the combined (l, split) index, like grid z in NONE/CLC modes.
+                    bidz_ = l_idx * params.num_split_k + split_idx
             cid_m, cid_n = self._swizzle_cta(cluster_id_in_problem, loc=loc, ip=ip)
             pid_m, pid_n = self._cluster_id_to_cta_id(
                 cid_m, cid_n, block_zero_only=block_zero_only, loc=loc, ip=ip
             )
-            batch_idx = (
-                bidz_
-                if const_expr(params.batch_idx_permute is None)
-                else params.batch_idx_permute[bidz_]
-            )
-        tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
-        return cutlass.utils.WorkTileInfo(tile_coord_mnkl, is_valid)
+            if const_expr(params.num_split_k == 1):
+                batch_idx = (
+                    bidz_
+                    if const_expr(params.batch_idx_permute is None)
+                    else params.batch_idx_permute[bidz_]
+                )
+            else:
+                # bidz_ is the combined l * num_split_k + split index; the scheduler hands
+                # back the DECODED coordinate (split in the k slot, the true batch in the
+                # l slot). Permute applies to l only.
+                l_idx = bidz_ // params.num_split_k
+                split_idx = bidz_ - l_idx * params.num_split_k
+                if const_expr(params.batch_idx_permute is not None):
+                    l_idx = params.batch_idx_permute[l_idx]
+                batch_idx = l_idx
+        tile_coord_mnkl = (pid_m, pid_n, split_idx, batch_idx)
+        return WorkTileInfo(tile_coord_mnkl, is_valid)
 
     @cute.jit
-    def get_current_work(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
+    def get_split_k_tile_range(
+        self, k_tile_total: Int32, split_idx: Optional[Int32], *, loc=None, ip=None
+    ) -> Tuple[Int32, Int32]:
+        """K-tile subrange [start, start + cnt) owned by split_idx.
+
+        The scheduler is the sole owner of the K-dim work decomposition: every warp
+        (load, MMA, epilogue, pingpong bookkeeping) must derive its k-tile count from
+        this one method, or the AB pipeline producer/consumer counts desync and hang.
+        The first (k_tile_total % num_split_k) splits get one extra k-tile (balanced,
+        same as the CUTLASS 3.x scheduler). Splits beyond k_tile_total get an empty
+        range; they still run the epilogue (zero contribution) so the serial-mode
+        semaphore turnstile advances.
+        """
+        num_split_k = self.params.num_split_k
+        if const_expr(num_split_k == 1):
+            return 0, k_tile_total
+        k_tiles_per_split = k_tile_total // num_split_k
+        remainder = k_tile_total - k_tiles_per_split * num_split_k
+        k_tile_start = split_idx * k_tiles_per_split + cutlass.min(split_idx, remainder)
+        k_tile_cnt = k_tiles_per_split + Int32(split_idx < remainder)
+        return k_tile_start, k_tile_cnt
+
+    @cute.jit
+    def get_combined_batch_idx(
+        self, batch_idx: Int32, split_idx: Optional[Int32], *, loc=None, ip=None
+    ) -> Int32:
+        """Inverse of the work-tile (l, split) decode: the combined l * num_split_k +
+        split index. Staged split-K uses it as the partials-workspace batch coordinate."""
+        if const_expr(self.params.num_split_k == 1):
+            return batch_idx
+        return batch_idx * self.params.num_split_k + split_idx
+
+    @cute.jit
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
         params = self.params
         if const_expr(params.persistence_mode == PersistenceMode.CLC):
             return self._get_current_work_clc(loc=loc, ip=ip)
@@ -439,11 +543,17 @@ class TileScheduler:
             self._pipeline_state.advance()
             is_valid = Boolean(is_valid_i32)
             iket.range_pop()
-        tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
-        return cutlass.utils.WorkTileInfo(tile_coord_mnkl, Boolean(is_valid))
+        split_idx = None
+        if const_expr(params.num_split_k != 1):
+            # The 4-int smem record carries the combined (l, split) index in the batch slot.
+            zc = batch_idx
+            batch_idx = zc // params.num_split_k
+            split_idx = zc - batch_idx * params.num_split_k
+        tile_coord_mnkl = (pid_m, pid_n, split_idx, batch_idx)
+        return WorkTileInfo(tile_coord_mnkl, Boolean(is_valid))
 
     @cute.jit
-    def _get_current_work_clc(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
+    def _get_current_work_clc(self, *, loc=None, ip=None) -> WorkTileInfo:
         """Consumer side of the multicast CLC pipeline, called by every consumer warp
         in every CTA of the cluster. The hardware has multicast the 16-byte CLC response
         into this CTA's smem slot (completing the local full barrier), so each warp
@@ -564,7 +674,7 @@ class TileScheduler:
                 for _ in cutlass.range(budget):
                     cute.arch.issue_clc_query(mbar_ptr, resp_ptr, multicast=False, loc=loc, ip=ip)
 
-    def initial_work_tile_info(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
+    def initial_work_tile_info(self, *, loc=None, ip=None) -> WorkTileInfo:
         return self._delinearize_work_idx(self._current_work_idx, loc=loc, ip=ip)
 
     @cute.jit
@@ -586,7 +696,10 @@ class TileScheduler:
                         nvvm.atomicrmw(
                             op=nvvm.AtomicOpKind.INC,
                             ptr=params.tile_count_semaphore.llvm_ptr,
-                            a=Int32(cute.size(params.problem_shape_ncluster_mnl) - 1).ir_value(),
+                            a=Int32(
+                                cute.size(params.problem_shape_ncluster_mnl) * params.num_split_k
+                                - 1
+                            ).ir_value(),
                             loc=loc,
                             ip=ip,
                         )
@@ -598,17 +711,20 @@ class TileScheduler:
             return cute.arch.shuffle_sync(next_work_linear_idx, 0)
 
     @cute.jit
-    def write_work_tile_to_smem(
-        self, work_tile_info: cutlass.utils.WorkTileInfo, *, loc=None, ip=None
-    ):
+    def write_work_tile_to_smem(self, work_tile_info: WorkTileInfo, *, loc=None, ip=None):
         params = self.params
         if const_expr(self._sched_smem is not None):
             pipeline_state_producer = self._producer_state()
             self._scheduler_pipeline.producer_acquire(pipeline_state_producer)
+            batch_field = work_tile_info.tile_idx[3]
+            if const_expr(params.num_split_k != 1):
+                # The 4-int smem record carries the combined (l, split) index; consumers
+                # decode it back in get_current_work.
+                batch_field = batch_field * params.num_split_k + work_tile_info.tile_idx[2]
             sched_data = [
                 work_tile_info.tile_idx[0],
                 work_tile_info.tile_idx[1],
-                work_tile_info.tile_idx[3],
+                batch_field,
                 Int32(work_tile_info.is_valid_tile),
             ]
             lane_idx = cute.arch.lane_idx()
@@ -757,6 +873,7 @@ class TriangularTileScheduler(TileScheduler):
         tile_count_semaphore: Optional[cute.Pointer]
         cluster_shape_mnk: cutlass.Constexpr[cute.Shape]
         persistence_mode: cutlass.Constexpr[PersistenceMode]
+        num_split_k: cutlass.Constexpr[int] = 1
 
         @staticmethod
         @cute.jit
@@ -764,6 +881,7 @@ class TriangularTileScheduler(TileScheduler):
             args: TileSchedulerArguments, *, loc=None, ip=None
         ) -> "TriangularTileScheduler.Params":
             assert args.cluster_shape_mnk[2] == 1
+            assert args.num_split_k == 1, "split_k is not supported by TriangularTileScheduler"
             problem_shape_ntile_mn = cute.select(args.problem_shape_ntile_mnl, mode=[0, 1])
             problem_shape_ncluster_mn = (
                 cute.ceil_div(problem_shape_ntile_mn[0], args.cluster_shape_mnk[0]),
@@ -883,7 +1001,7 @@ class TriangularTileScheduler(TileScheduler):
         block_zero_only: bool = False,
         loc=None,
         ip=None,
-    ) -> cutlass.utils.WorkTileInfo:
+    ) -> WorkTileInfo:
         params = self.params
         if const_expr(is_valid is None):
             if const_expr(params.persistence_mode == PersistenceMode.NONE):
@@ -912,7 +1030,7 @@ class TriangularTileScheduler(TileScheduler):
             )
             batch_idx = bidz_
         tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
-        return cutlass.utils.WorkTileInfo(tile_coord_mnkl, is_valid)
+        return WorkTileInfo(tile_coord_mnkl, is_valid)
 
 
 @dataclass
@@ -927,6 +1045,7 @@ class VarlenMTileSchedulerArguments:
     cluster_shape_mnk: cutlass.Constexpr[cute.Shape]
     tile_count_semaphore: Optional[cute.Pointer] = None
     persistence_mode: cutlass.Constexpr[PersistenceMode] = PersistenceMode.NONE
+    num_split_k: cutlass.Constexpr[int] = 1
 
 
 class VarlenMTileScheduler(TileScheduler):
@@ -947,12 +1066,14 @@ class VarlenMTileScheduler(TileScheduler):
         tile_count_semaphore: Optional[cute.Pointer]
         cluster_shape_mnk: cutlass.Constexpr[cute.Shape]
         persistence_mode: cutlass.Constexpr[PersistenceMode]
+        num_split_k: cutlass.Constexpr[int] = 1
 
         @staticmethod
         @cute.jit
         def create(
             args: TileSchedulerArguments, *, loc=None, ip=None
         ) -> "VarlenMTileScheduler.Params":
+            assert args.num_split_k == 1, "split_k is not supported by VarlenMTileScheduler"
             # problem_shape_ntile_mnl[0] will be None for VarlenM
             problem_shape_ntile_mn = cute.select(args.problem_shape_ntile_mnl, mode=[0, 1])
             problem_shape_ncluster_mn = (
@@ -1119,7 +1240,7 @@ class VarlenMTileScheduler(TileScheduler):
         block_zero_only: bool = False,
         loc=None,
         ip=None,
-    ) -> cutlass.utils.WorkTileInfo:
+    ) -> WorkTileInfo:
         assert bidz is None
         params = self.params
         lane_idx = cute.arch.lane_idx()
@@ -1213,4 +1334,4 @@ class VarlenMTileScheduler(TileScheduler):
         self._num_work_idx_before_cur_batch = num_work_idx_before_cur_batch
         self._cur_batch_end = cur_batch_end
         self._cur_num_clusters_m = num_clusters_m
-        return cutlass.utils.WorkTileInfo(tile_coord_mnkl, is_valid)
+        return WorkTileInfo(tile_coord_mnkl, is_valid)

--- a/quack/utils.py
+++ b/quack/utils.py
@@ -186,6 +186,61 @@ def warp_prefix_sum(val: Int32, lane: Optional[Int32] = None) -> Int32:
     return val
 
 
+@cute.jit
+def semaphore_wait_eq(lock_ptr: cute.Pointer, expected: Int32):
+    """Warp-cooperative gmem semaphore wait: spin until *lock_ptr == expected.
+
+    Lane 0 spins with gpu-scope acquire loads; all lanes are synchronized after the
+    wait, and a fence.proxy.async.global orders subsequent async-proxy (TMA) accesses
+    after the acquire so they observe the releaser's completed stores. Wait-for-equal
+    gives turnstile semantics: releasers passing monotonically increasing values
+    serialize waiters in a fixed order (e.g. CUTLASS-style serial split-K).
+    """
+    if cute.arch.lane_idx() == 0:
+        state = cute.arch.load(lock_ptr, Int32, sem="acquire", scope="gpu")
+        while state != expected:
+            state = cute.arch.load(lock_ptr, Int32, sem="acquire", scope="gpu")
+    cute.arch.sync_warp()
+    cute.arch.fence_proxy("async.global")
+
+
+@cute.jit
+def semaphore_release(
+    lock_ptr: cute.Pointer, value: Int32, drain_tma_store: cutlass.Constexpr[bool] = True
+):
+    """Warp-cooperative gmem semaphore release: store value to *lock_ptr.
+
+    With drain_tma_store (default), first waits for ALL of the calling threads'
+    outstanding bulk async-groups to COMPLETE and cross-proxy fences, so TMA
+    stores/reduces issued before the release are visible to the next acquirer. This
+    must be the non-.read wait: tma_store_wait's .read variant only protects smem
+    reuse, not the visibility of the gmem writes themselves. All lanes then sync
+    (ordering the issuing lane's completed work before the flag) and lane 0 performs
+    a gpu-scope release store.
+    """
+    if const_expr(drain_tma_store):
+        cute.arch.cp_async_bulk_wait_group(0)
+        cute.arch.fence_proxy("async.global")
+    cute.arch.sync_warp()
+    if cute.arch.lane_idx() == 0:
+        cute.arch.store(lock_ptr, value, sem="release", scope="gpu")
+
+
+@cute.jit
+def semaphore_arrive_inc(lock_ptr: cute.Pointer, value: Int32 = 1):
+    """Warp-cooperative gmem arrival counter: gpu-scope release-increment *lock_ptr.
+
+    The unordered counterpart of semaphore_release: arrivers in any order each add
+    `value`; a waiter using semaphore_wait_eq(expected=total) observes all arrivers'
+    prior (generic-proxy) writes once the count is reached. The caller must order
+    its own threads' writes before this call (e.g. a CTA/group barrier); lane 0's
+    release-RMW then publishes the chain.
+    """
+    cute.arch.sync_warp()
+    if cute.arch.lane_idx() == 0:
+        cute.arch.atomic_add(lock_ptr, Int32(value), sem="release", scope="gpu")
+
+
 @dsl_user_op
 def domain_offset_aligned(
     coord: cute.Coord, tensor: cute.Tensor, *, loc=None, ip=None

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -1008,3 +1008,77 @@ def test_blockscaled_mxfp8_strided_sf(rk_pad):
         f"strided-SF output differs from contig-SF: "
         f"max_abs_err={(mD_strided.float() - mD_contig.float()).abs().max().item()}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Split-K (MXFP8 block-scaled)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("split_k_mode", ["serial", "parallel"])
+@pytest.mark.parametrize("split_k", [2, 4])
+@pytest.mark.parametrize("batched", [False, True])
+def test_mxfp8_split_k(batched, split_k, split_k_mode):
+    """MXFP8 block-scaled split-K: the dense finalizer-only split-K device path composes
+    with block-scaled as-is (the SF loads ride the same k_tile_start-offset copy list as
+    A/B; the accumulator is already descaled f32 before the epilogue). split-K must match
+    the plain (split_k=1) MXFP8 kernel to within ~1 bf16 ULP and stay deterministic for
+    serial."""
+    _skip_if_not_sm100()
+    from quack.blockscaled.utils import blockscaled_quantize
+    from quack.gemm_config import SplitKMode
+    from quack.gemm_interface import gemm, gemm_blockscaled_ref
+
+    mode = SplitKMode[split_k_mode.upper()]
+    # Small M/N, large K -> the regime split-K targets. K a multiple of 32 (sf_vec).
+    M, N, K = 256, 256, 8192
+    L = 2 if batched else 1
+    torch.manual_seed(0)
+    shape_A = (L, M, K) if batched else (M, K)
+    shape_W = (L, N, K) if batched else (N, K)
+    A_hp = torch.randn(*shape_A, device="cuda", dtype=torch.bfloat16) * K**-0.5
+    W_hp = torch.randn(*shape_W, device="cuda", dtype=torch.bfloat16) * K**-0.5
+    A_q, A_sc = blockscaled_quantize(A_hp, "mxfp8")
+    W_q, W_sc = blockscaled_quantize(W_hp, "mxfp8")
+    A_op, B_op = (A_q, A_sc), (W_q.mT, W_sc)  # B = (..., K, N) K-contig view
+
+    ref = gemm_blockscaled_ref(A_op, B_op)
+    base = gemm(A_op, B_op, tuned=False)  # plain (split_k=1) MXFP8 kernel
+    out = gemm(A_op, B_op, split_k=split_k, split_k_mode=mode, tuned=False)
+    assert out.shape == ((L, M, N) if batched else (M, N))
+
+    # f32 partials accumulation -> split-K is no less accurate than the plain kernel.
+    err = (out.float() - ref.float()).abs().max().item()
+    base_err = (base.float() - ref.float()).abs().max().item()
+    assert err < 2 * base_err + 5e-3, f"split-K err={err} vs base_err={base_err}"
+    # Differs from the plain kernel only by f32 reassociation (~1 bf16 ULP at O(1)).
+    assert (out.float() - base.float()).abs().max().item() < 1e-2
+
+    if mode != SplitKMode.PARALLEL:  # arrival-order reduction is not deterministic
+        for _ in range(3):
+            out2 = gemm(A_op, B_op, split_k=split_k, split_k_mode=mode, tuned=False)
+            assert torch.equal(out, out2), "serial split-K is not bitwise deterministic"
+
+
+def test_mxfp8_split_k_staged_rejected():
+    """SEPARATE needs a block-scaled-reachable reduction kernel (not yet wired); it must
+    raise a clear error rather than silently misconfigure."""
+    _skip_if_not_sm100()
+    from quack.blockscaled.utils import blockscaled_quantize
+    from quack.gemm_config import SplitKMode
+    from quack.gemm_interface import gemm
+
+    M, N, K = 256, 256, 2048
+    torch.manual_seed(0)
+    A_q, A_sc = blockscaled_quantize(
+        torch.randn(M, K, device="cuda", dtype=torch.bfloat16) * K**-0.5, "mxfp8"
+    )
+    W_q, W_sc = blockscaled_quantize(
+        torch.randn(N, K, device="cuda", dtype=torch.bfloat16) * K**-0.5, "mxfp8"
+    )
+    with pytest.raises(NotImplementedError, match="SEPARATE"):
+        gemm(
+            (A_q, A_sc),
+            (W_q.mT, W_sc),
+            split_k=2,
+            split_k_mode=SplitKMode.SEPARATE,
+            tuned=False,
+        )

--- a/tests/test_gemm_split_k.py
+++ b/tests/test_gemm_split_k.py
@@ -1,0 +1,570 @@
+# Copyright (c) 2026, QuACK team.
+# Split-K GEMM: correctness vs fp32 reference, run-to-run bitwise determinism, exact
+# equivalence of split_k=1 with the baseline kernel, and serial/staged agreement.
+
+import pytest
+import torch
+
+from quack.cute_dsl_utils import get_device_capacity
+from quack.gemm import gemm as quack_gemm
+from quack.gemm_interface import SplitKMode, gemm, gemm_add, gemm_add_inplace, gemm_ref
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or get_device_capacity(torch.device("cuda"))[0] not in (9, 10, 11, 12),
+    reason="split_k requires SM90/SM100/SM120",
+)
+
+DETERMINISM_RUNS = 3
+
+
+def _assert_close_double_baseline(out, out_ref, out_pt, mult=2, atol=1e-4):
+    assert (out.float() - out_ref).abs().max().item() < mult * (
+        out_pt.float() - out_ref
+    ).abs().max().item() + atol
+
+
+def _make_inputs(m, n, k, L, dtype, seed=0):
+    torch.manual_seed(seed)
+    shape_a = (m, k) if L is None else (L, m, k)
+    shape_b = (k, n) if L is None else (L, k, n)
+    A = torch.randn(shape_a, dtype=dtype, device="cuda") / 4
+    B = torch.randn(shape_b, dtype=dtype, device="cuda") / 4
+    return A, B
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+@pytest.mark.parametrize("split_k", [2, 5])
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("L", [None, 3])
+def test_gemm_split_k(L, out_dtype, split_k, split_k_mode):
+    # Small M/N, large ragged K (65 k-tiles of 64 -> uneven splits for split_k=2 and 5)
+    m, n, k = 192, 480, 4160
+    A, B = _make_inputs(m, n, k, L, torch.bfloat16)
+    out_ref = gemm_ref(A.float(), B.float())
+    out_pt = (A.float() @ B.float()).to(out_dtype)
+    out = gemm(A, B, out_dtype=out_dtype, tuned=False, split_k=split_k, split_k_mode=split_k_mode)
+    # All modes accumulate raw partials in f32 and convert exactly once (the epilogue
+    # runs only on the finalizing entity), so the baseline tolerance applies as-is.
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+    if split_k_mode == SplitKMode.PARALLEL:
+        return  # arrival-order reduction: not deterministic run to run by design
+    # Run-to-run bitwise determinism with fresh output buffers
+    runs = [
+        gemm(A, B, out_dtype=out_dtype, tuned=False, split_k=split_k, split_k_mode=split_k_mode)
+        for _ in range(DETERMINISM_RUNS)
+    ]
+    for r in runs:
+        assert torch.equal(out, r), "split_k result is not bitwise deterministic"
+
+
+@pytest.mark.parametrize(
+    "persistent,dynamic_persistent", [(False, False), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_split_k_schedulers(split_k_mode, persistent, dynamic_persistent):
+    """Exercise NONE (non-persistent), STATIC, and CLC/DYNAMIC persistent schedulers."""
+    device_capacity = get_device_capacity(torch.device("cuda"))[0]
+    if not persistent and device_capacity in (10, 11):
+        pytest.skip("SM100 GEMM is always persistent")
+    m, n, k, L, split_k = 256, 512, 8192, 2, 4
+    A, B = _make_inputs(m, n, k, L, torch.bfloat16)
+    D = torch.empty((L, m, n), dtype=torch.bfloat16, device="cuda")
+    tile_count_semaphore = (
+        torch.zeros(1, dtype=torch.int32, device="cuda")
+        if dynamic_persistent and device_capacity == 9
+        else None
+    )
+
+    def run(out):
+        quack_gemm(
+            A,
+            B.mT,  # quack.gemm takes B as (L, N, K)
+            out,
+            None,
+            tile_count_semaphore,
+            tile_M=128,
+            tile_N=128,
+            cluster_M=1,
+            cluster_N=1,
+            persistent=persistent,
+            is_dynamic_persistent=dynamic_persistent,
+            split_k=split_k,
+            split_k_mode=split_k_mode,
+        )
+        if tile_count_semaphore is not None:
+            tile_count_semaphore.zero_()
+        return out
+
+    run(D)
+    out_ref = gemm_ref(A.float(), B.float())
+    out_pt = A @ B
+    _assert_close_double_baseline(D, out_ref, out_pt, mult=2)
+    if split_k_mode == SplitKMode.PARALLEL:
+        return  # arrival-order reduction: not deterministic run to run by design
+    for _ in range(DETERMINISM_RUNS):
+        D2 = run(torch.empty_like(D))
+        assert torch.equal(D, D2), "split_k result is not bitwise deterministic"
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_split_k_bias_alpha(split_k_mode):
+    """The full epilogue (alpha, bias) runs exactly once, on the finalizing entity
+    (the last split in serial/parallel, the reduction kernel in staged)."""
+    m, n, k, split_k = 192, 512, 6144, 4
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    bias = torch.randn(n, dtype=torch.float32, device="cuda")
+    alpha = 0.5
+    out_ref = alpha * (A.float() @ B.float()) + bias
+    out_pt = (alpha * (A @ B).float() + bias).to(torch.bfloat16)
+    out = gemm(
+        A, B, bias=bias, alpha=alpha, tuned=False, split_k=split_k, split_k_mode=split_k_mode
+    )
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_add_split_k(split_k_mode):
+    """beta * C is applied exactly once, by the finalizing entity, on the full sum."""
+    m, n, k, split_k = 192, 512, 6144, 4
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    C = torch.randn(m, n, dtype=torch.bfloat16, device="cuda")
+    alpha, beta = 1.0, 0.5
+    out_ref = alpha * (A.float() @ B.float()) + beta * C.float()
+    out_pt = alpha * (A @ B) + beta * C
+    out = gemm_add(
+        A, B, C, alpha=alpha, beta=beta, tuned=False, split_k=split_k, split_k_mode=split_k_mode
+    )
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_add_inplace_split_k(split_k_mode):
+    """add_to_output: the prior value of D is added exactly once — by the finalizer's
+    TMA reduce-add store (serial/parallel, one extra D-dtype rounding) or in f32 by the
+    reduction kernel (staged)."""
+    m, n, k, split_k = 192, 512, 6144, 4
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    C0 = torch.randn(m, n, dtype=torch.bfloat16, device="cuda")
+    out_ref = C0.float() + A.float() @ B.float()
+    out_pt = C0 + A @ B
+    out = C0.clone()
+    gemm_add_inplace(A, B, out, tuned=False, split_k=split_k, split_k_mode=split_k_mode)
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=3)
+    if split_k_mode == SplitKMode.PARALLEL:
+        return  # arrival-order reduction: not deterministic run to run by design
+    out2 = C0.clone()
+    gemm_add_inplace(A, B, out2, tuned=False, split_k=split_k, split_k_mode=split_k_mode)
+    assert torch.equal(out, out2), "split_k result is not bitwise deterministic"
+
+
+def test_gemm_split_k_staged_grid_not_inflated():
+    """The scheduler must see the true L in staged mode (the workspace batch extent is
+    L*split_k and the scheduler scales by split_k itself): the staged GEMM grid must
+    equal the serial one (regression for split_k x phantom work units)."""
+    m, n, k, L, split_k = 256, 512, 8192, 2, 4
+    A, B = _make_inputs(m, n, k, L, torch.bfloat16)
+
+    def max_kernel_grid_z(mode):
+        return _max_gemm_grid_z(lambda: gemm(A, B, tuned=False, split_k=split_k, split_k_mode=mode))
+
+    serial_z = max_kernel_grid_z(SplitKMode.SERIAL)
+    staged_z = max_kernel_grid_z(SplitKMode.SEPARATE)
+    if serial_z is None or staged_z is None:
+        pytest.skip("profiler does not expose kernel grids in this torch build")
+    # The GEMM dominates grid z in both modes (the reduce kernel's z is just L)
+    assert staged_z <= serial_z, f"staged GEMM grid z inflated: {staged_z} vs serial {serial_z}"
+
+
+def _max_gemm_grid_z(fn):
+    """Largest kernel grid.z launched by fn() (the GEMM dominates; reduce z is just L)."""
+    import json
+    import tempfile
+
+    fn()  # warm compile
+    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
+        fn()
+        torch.cuda.synchronize()
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        trace_path = f.name
+    prof.export_chrome_trace(trace_path)
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    zs = [
+        e["args"]["grid"][2]
+        for e in events
+        if e.get("cat") == "kernel" and "grid" in e.get("args", {})
+    ]
+    return max(zs) if zs else None
+
+
+def test_gemm_split_k_config_autotuner_surface():
+    """split_k is a GemmConfig field on the autotuner surface: split_k=None defers to
+    config.split_k, an explicit split_k overrides the config, and the prune hook expands
+    split-k variants for occupancy-starved shapes (and only when split_k is None)."""
+    from dataclasses import replace
+
+    from quack.autotuner import AutotuneConfig
+    from quack.gemm_interface import default_config, gemm_tuned, prune_invalid_gemm_configs
+
+    m, n, k = 256, 512, 16384
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    out_ref = gemm_ref(A.float(), B.float())
+    cfg = replace(default_config(A.device), split_k=4)
+
+    def run(split_k):
+        out = torch.empty(m, n, dtype=torch.bfloat16, device="cuda")
+        gemm_tuned.fn(A, B, out, config=cfg, split_k=split_k)
+        _assert_close_double_baseline(out, out_ref, A @ B, mult=2)
+        return out
+
+    z_from_config = _max_gemm_grid_z(lambda: run(split_k=None))
+    z_override = _max_gemm_grid_z(lambda: run(split_k=2))
+    if z_from_config is None or z_override is None:
+        pytest.skip("profiler does not expose kernel grids in this torch build")
+    assert z_from_config == 4, f"config.split_k not honored: grid z = {z_from_config}"
+    assert z_override == 2, f"explicit split_k must override config: grid z = {z_override}"
+
+    # Prune-hook expansion: split_k=None on a starved shape adds split-k variants...
+    base = [AutotuneConfig(config=default_config(A.device))]
+    expanded = prune_invalid_gemm_configs(base, {"A": A, "B": B, "split_k": None})
+    assert any(c.kwargs["config"].split_k > 1 for c in expanded), "no split-k variants expanded"
+    # ...but a forced factor (or an unexposed knob) expands nothing.
+    forced = prune_invalid_gemm_configs(base, {"A": A, "B": B, "split_k": 2})
+    assert all(c.kwargs["config"].split_k == 1 for c in forced)
+    no_knob = prune_invalid_gemm_configs(base, {"A": A, "B": B})
+    assert all(c.kwargs["config"].split_k == 1 for c in no_knob)
+
+
+def test_gemm_split_k_one_matches_baseline():
+    """split_k=1 must compile to the exact baseline kernel: bitwise-identical output."""
+    m, n, k = 256, 512, 4096
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    out_base = gemm(A, B, tuned=False)
+    for mode in SplitKMode:
+        out1 = gemm(A, B, tuned=False, split_k=1, split_k_mode=mode)
+        assert torch.equal(out_base, out1)
+
+
+def test_gemm_split_k_serial_staged_f32_bitwise_equal():
+    """Both modes sum raw f32 partials in ascending split order (serial: turnstile-ordered
+    red.add.f32 into the workspace + the finalizer's register add; staged: the reduction
+    kernel's register adds) and run the identical shared epilogue once, so f32 outputs
+    must agree bitwise. (red.add.f32 flushes subnormals where FADD does not — randn
+    inputs keep everything normal.)"""
+    m, n, k, split_k = 192, 480, 8192, 4
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    out_serial = gemm(
+        A, B, out_dtype=torch.float32, tuned=False, split_k=split_k, split_k_mode=SplitKMode.SERIAL
+    )
+    out_staged = gemm(
+        A,
+        B,
+        out_dtype=torch.float32,
+        tuned=False,
+        split_k=split_k,
+        split_k_mode=SplitKMode.SEPARATE,
+    )
+    assert torch.equal(out_serial, out_staged)
+
+
+def test_gemm_split_k_cluster_rounded_tiles():
+    """Tile count not divisible by the cluster shape: boundary clusters contain CTAs
+    whose tile is fully out of bounds, but which still run the serial lock protocol.
+    Lock indexing must use cluster-rounded tile counts or CTAs alias locks and deadlock
+    (regression for the under-sized/mis-indexed semaphore array)."""
+    # default SM100 config: mma tiler (256, 256), cluster (2, 1) -> CTA tile m = 128.
+    # m = 320 gives 3 CTA tiles in M, rounded up to 4 by the cluster.
+    m, n, k, split_k = 320, 512, 8192, 4
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    out_ref = gemm_ref(A.float(), B.float())
+    out_pt = A @ B
+    for mode in SplitKMode:
+        out = gemm(A, B, tuned=False, split_k=split_k, split_k_mode=mode)
+        _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+        if mode != SplitKMode.PARALLEL:  # arrival-order reduction is not deterministic
+            out2 = gemm(A, B, tuned=False, split_k=split_k, split_k_mode=mode)
+            assert torch.equal(out, out2)
+
+
+def test_gemm_split_k_ragged_n_strided_out():
+    """N a multiple of 8 (the bf16 16-byte contract) but not of the tile width, with the
+    output a slice of a larger buffer: boundary tiles/vectors must not clobber adjacent
+    user data (regression for per-vector predication in split_k_reduce)."""
+    m, n_alloc, n, k, split_k = 64, 128, 104, 2048, 2
+    torch.manual_seed(0)
+    A = torch.randn(m, k, dtype=torch.bfloat16, device="cuda") / 4
+    # B's non-contiguous stride must satisfy the 16-byte contract: slice a padded buffer
+    B = (torch.randn(k, n_alloc, dtype=torch.bfloat16, device="cuda") / 4)[:, :n]
+    out_ref = gemm_ref(A.float(), B.float())
+    for mode in SplitKMode:
+        big = torch.full((m, n_alloc), 7.0, dtype=torch.bfloat16, device="cuda")
+        out = big[:, :n]
+        gemm(A, B, out=out, tuned=False, split_k=split_k, split_k_mode=mode)
+        assert (big[:, n:] == 7.0).all(), f"{mode} split-K clobbered memory next to out"
+        _assert_close_double_baseline(out, out_ref, A @ B, mult=2)
+
+
+def test_gemm_split_k_larger_than_k_tiles():
+    """split_k > number of k-tiles: trailing splits are empty but must still
+    participate in the reduction protocol."""
+    m, n, k, split_k = 192, 256, 128, 6  # at most 2 k-tiles
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    out_ref = gemm_ref(A.float(), B.float())
+    out_pt = A @ B
+    for mode in SplitKMode:
+        out = gemm(A, B, tuned=False, split_k=split_k, split_k_mode=mode)
+        _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+def test_gemm_split_k_m_major_out():
+    """m-major output exercises the transposed staged workspace path."""
+    m, n, k, split_k = 192, 512, 6144, 4
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    out_ref = gemm_ref(A.float(), B.float())
+    out_pt = A @ B
+    for mode in SplitKMode:
+        out = torch.empty((n, m), dtype=torch.bfloat16, device="cuda").mT
+        gemm(A, B, out=out, tuned=False, split_k=split_k, split_k_mode=mode)
+        _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+def test_gemm_split_k_rejects_unsupported():
+    m, n, k = 128, 256, 1024
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    cu_seqlens_m = torch.tensor([0, m], dtype=torch.int32, device="cuda")
+    with pytest.raises(Exception, match="split_k"):
+        gemm(A, B, cu_seqlens_m=cu_seqlens_m, tuned=False, split_k=2)
+    with pytest.raises(Exception, match="split_k"):
+        gemm(A, B, tuned=False, split_k=2, split_k_mode="bogus")
+    from quack.gemm_interface import gemm_act, gemm_symmetric
+
+    with pytest.raises(NotImplementedError, match="split_k"):
+        gemm_act(A, B, activation="relu", split_k=2)
+    with pytest.raises(NotImplementedError, match="split_k"):
+        gemm_symmetric(A, A.mT.contiguous().mT, split_k=2)
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_add_inplace_beta_split_k(split_k_mode):
+    """C aliasing the output (gemm_add_inplace with beta != 1) is legal in every mode:
+    only the finalizing entity reads C and D is written exactly once, after the full
+    reduction (this was rejected for parallel mode under the old reduce-into-D design)."""
+    m, n, k = 192, 512, 6144
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    C0 = torch.randn(m, n, dtype=torch.bfloat16, device="cuda")
+    out_ref = 0.5 * C0.float() + A.float() @ B.float()
+    out_pt = 0.5 * C0 + A @ B
+    out = C0.clone()
+    gemm_add_inplace(A, B, out, beta=0.5, tuned=False, split_k=4, split_k_mode=split_k_mode)
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_split_k_full_linear_epilogue(split_k_mode):
+    """alpha, beta*C, rowvec AND colvec bias together, applied once on the full sum —
+    exercises every operand path of the staged reduction kernel's shared epilogue and
+    of the serial/parallel finalizer."""
+    m, n, k, L, split_k = 256, 512, 8192, 2, 4
+    A, B = _make_inputs(m, n, k, L, torch.bfloat16)
+    C = torch.randn(L, m, n, dtype=torch.bfloat16, device="cuda")
+    rowvec = torch.randn(L, n, dtype=torch.float32, device="cuda")
+    colvec = torch.randn(L, m, dtype=torch.float32, device="cuda")
+    alpha, beta = 0.5, 2.0
+    acc = gemm_ref(A.float(), B.float())
+    out_ref = alpha * acc + beta * C.float() + rowvec[:, None, :] + colvec[:, :, None]
+    D_base = torch.empty(L, m, n, dtype=torch.bfloat16, device="cuda")
+
+    def run(out, **kw):
+        quack_gemm(
+            A,
+            B.mT,  # quack.gemm takes B as (L, N, K)
+            out,
+            C,
+            None,
+            tile_M=128,
+            tile_N=128,
+            cluster_M=1,
+            cluster_N=1,
+            persistent=True,
+            alpha=alpha,
+            beta=beta,
+            rowvec_bias=rowvec,
+            colvec_bias=colvec,
+            **kw,
+        )
+        return out
+
+    run(D_base)
+    D = run(torch.empty_like(D_base), split_k=split_k, split_k_mode=split_k_mode)
+    _assert_close_double_baseline(D, out_ref, D_base, mult=2)
+    if split_k_mode != SplitKMode.PARALLEL:
+        D2 = run(torch.empty_like(D_base), split_k=split_k, split_k_mode=split_k_mode)
+        assert torch.equal(D, D2), "split_k result is not bitwise deterministic"
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_split_k_mixed_c_majorness(split_k_mode):
+    """C m-major with an n-major output: legal in the GEMM epilogue (c_major is tracked
+    independently); the staged reduce kernel materializes a contiguous C view
+    (regression: the staged path used to raise a TVM-FFI stride mismatch)."""
+    m, n, k = 192, 512, 6144
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    C = torch.randn(n, m, dtype=torch.bfloat16, device="cuda").mT  # m-major
+    out_ref = A.float() @ B.float() + 0.5 * C.float()
+    out_pt = A @ B + 0.5 * C
+    out = gemm_add(A, B, C, beta=0.5, tuned=False, split_k=4, split_k_mode=split_k_mode)
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_split_k_m_major_out_with_epilogue(split_k_mode):
+    """m-major output WITH rowvec+colvec+C: the staged host view transposes m/n and
+    must SWAP the vector roles (a swapped-but-not-transposed bug passes the plain
+    m-major test)."""
+    m, n, k, L = 192, 512, 6144, 2
+    A, B = _make_inputs(m, n, k, L, torch.bfloat16)
+    C = torch.randn(L, m, n, dtype=torch.bfloat16, device="cuda")
+    rowvec = torch.randn(L, n, dtype=torch.float32, device="cuda")
+    colvec = torch.randn(L, m, dtype=torch.float32, device="cuda")
+    acc = gemm_ref(A.float(), B.float())
+    out_ref = 0.5 * acc + 2.0 * C.float() + rowvec[:, None, :] + colvec[:, :, None]
+    base = torch.empty(L, n, m, dtype=torch.bfloat16, device="cuda").mT
+
+    def run(out, **kw):
+        quack_gemm(
+            A,
+            B.mT,
+            out,
+            C,
+            None,
+            tile_M=128,
+            tile_N=128,
+            cluster_M=1,
+            cluster_N=1,
+            persistent=True,
+            alpha=0.5,
+            beta=2.0,
+            rowvec_bias=rowvec,
+            colvec_bias=colvec,
+            **kw,
+        )
+        return out
+
+    run(base)
+    out = run(
+        torch.empty(L, n, m, dtype=torch.bfloat16, device="cuda").mT,
+        split_k=4,
+        split_k_mode=split_k_mode,
+    )
+    _assert_close_double_baseline(out, out_ref, base, mult=2)
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+def test_gemm_split_k_tensor_alpha_beta(split_k_mode):
+    """Tensor-valued (pointer-mode) alpha/beta through both finalizers."""
+    m, n, k = 192, 512, 6144
+    A, B = _make_inputs(m, n, k, None, torch.bfloat16)
+    C = torch.randn(m, n, dtype=torch.bfloat16, device="cuda")
+    alpha = torch.tensor(0.5, dtype=torch.float32, device="cuda")
+    beta = torch.tensor(2.0, dtype=torch.float32, device="cuda")
+    out_ref = 0.5 * (A.float() @ B.float()) + 2.0 * C.float()
+    out_pt = 0.5 * (A @ B) + 2.0 * C
+    out = gemm_add(
+        A, B, C, alpha=alpha, beta=beta, tuned=False, split_k=4, split_k_mode=split_k_mode
+    )
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or get_device_capacity(torch.device("cuda"))[0] not in (10, 11),
+    reason="tf32 (float32 inputs -> TFloat32 MMA) is SM100/SM110 only",
+)
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+@pytest.mark.parametrize("split_k", [2, 5])
+def test_gemm_split_k_tf32(split_k, split_k_mode):
+    """tf32 GEMM (float32 inputs, TFloat32 MMA): split-K must match the plain tf32 kernel
+    at the baseline tolerance and stay deterministic for serial/staged. The partials
+    workspace is f32 regardless of input dtype, so tf32 needs no special handling."""
+    m, n, k, L = 256, 512, 8192, 2
+    A, B = _make_inputs(m, n, k, L, torch.float32)
+    out_ref = gemm_ref(A.float(), B.float())  # true f32 matmul
+    # The plain (split_k=1) tf32 kernel is the same-precision baseline.
+    out_pt = gemm(A, B, out_dtype=torch.float32, tuned=False)
+    out = gemm(
+        A, B, out_dtype=torch.float32, tuned=False, split_k=split_k, split_k_mode=split_k_mode
+    )
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+    if split_k_mode == SplitKMode.PARALLEL:
+        return  # arrival-order reduction: not deterministic run to run by design
+    for _ in range(DETERMINISM_RUNS):
+        out2 = gemm(
+            A, B, out_dtype=torch.float32, tuned=False, split_k=split_k, split_k_mode=split_k_mode
+        )
+        assert torch.equal(out, out2), "split_k tf32 result is not bitwise deterministic"
+
+
+@pytest.mark.parametrize("split_k_mode", list(SplitKMode), ids=lambda m: m.name.lower())
+@pytest.mark.parametrize("split_k", [2, 5])
+@pytest.mark.parametrize(
+    "in_dtype", [torch.float8_e4m3fn, torch.float8_e5m2], ids=["e4m3fn", "e5m2"]
+)
+def test_gemm_split_k_fp8(in_dtype, split_k, split_k_mode):
+    """fp8 (e4m3fn / e5m2) GEMM with bf16 output: split-K matches the plain fp8 kernel at
+    the baseline tolerance and stays deterministic for serial/staged. fp8 needs k-major
+    A and B; the f32 partials workspace makes the finalizer dtype-agnostic."""
+    m, n, k, L = 256, 512, 8192, 2
+    torch.manual_seed(0)
+    # fp8 requires k-major A (m, k) and B (k, n): k contiguous in both.
+    A = (torch.randn(L, m, k, device="cuda") / 4).to(in_dtype)
+    B = (torch.randn(L, n, k, device="cuda") / 4).to(in_dtype).mT  # (L, k, n), k-major
+    out_ref = gemm_ref(A.float(), B.float())
+    out_pt = gemm(A, B, out_dtype=torch.bfloat16, tuned=False)  # plain fp8 baseline
+    out = gemm(
+        A, B, out_dtype=torch.bfloat16, tuned=False, split_k=split_k, split_k_mode=split_k_mode
+    )
+    _assert_close_double_baseline(out, out_ref, out_pt, mult=2)
+    if split_k_mode == SplitKMode.PARALLEL:
+        return  # arrival-order reduction: not deterministic run to run by design
+    for _ in range(DETERMINISM_RUNS):
+        out2 = gemm(
+            A, B, out_dtype=torch.bfloat16, tuned=False, split_k=split_k, split_k_mode=split_k_mode
+        )
+        assert torch.equal(out, out2), "split_k fp8 result is not bitwise deterministic"
+
+
+def test_gemm_split_k_odd_epi_subtile_count():
+    """A tile shape whose epi-subtile count is not a multiple of the epi smem stage
+    count: skipped (non-finalizing) tiles jump the smem buffer rotation by a
+    non-multiple of the stage count, so the finalizer must drain its TMA stores before
+    the next tile reuses an arbitrary buffer (regression for the rotation/drain
+    desync — silent D corruption without the producer_tail in epilogue_split_k)."""
+    m, n, k, L, split_k = 512, 448, 8192, 2, 4
+    A, B = _make_inputs(m, n, k, L, torch.bfloat16)
+    out_ref = gemm_ref(A.float(), B.float())
+    D_base = torch.empty(L, m, n, dtype=torch.bfloat16, device="cuda")
+
+    def run(out, **kw):
+        quack_gemm(
+            A,
+            B.mT,
+            out,
+            None,
+            None,
+            tile_M=128,
+            tile_N=224,
+            cluster_M=1,
+            cluster_N=1,
+            persistent=True,
+            **kw,
+        )
+        return out
+
+    run(D_base)
+    for mode in (SplitKMode.SERIAL, SplitKMode.PARALLEL):
+        D = run(torch.empty_like(D_base), split_k=split_k, split_k_mode=mode)
+        _assert_close_double_baseline(D, out_ref, D_base, mult=2)
+    D = run(torch.empty_like(D_base), split_k=split_k, split_k_mode=SplitKMode.SERIAL)
+    for _ in range(DETERMINISM_RUNS):
+        D2 = run(torch.empty_like(D_base), split_k=split_k, split_k_mode=SplitKMode.SERIAL)
+        assert torch.equal(D, D2), "split_k result is not bitwise deterministic"


### PR DESCRIPTION
Adds split-K to the QuACK GEMMs (SM90/SM100/SM120) for small-M/N, large-K shapes that starve a 2D grid of occupancy. `split_k` and `split_k_mode` are exposed on every `gemm_interface.py` entry point and the autotuner surface (`GemmConfig.split_k`, `split_k=None` lets the tuner pick).

### Features

- `split_k` is a constexpr kernel specialization captured by the jit cache; `split_k == 1` compiles to exactly the pre-existing kernel (all new code is behind `const_expr`).
- The tile scheduler owns the K-mode decomposition: `gridDim.z` is scaled by `split_k` with the split index fastest-varying (splits of a tile stay L2-adjacent), balanced k-tile ranges, and a quack-owned `WorkTileInfo` that returns the decoded `(m, n, split, batch)` coordinate.
- The full epilogue (alpha, beta*C, bias, activations) runs exactly **once** per output tile, on the entity owning the final reduction determined by `is_splitk_leader`.
- Partials accumulate in f32, so the finalizer is dtype-agnostic: split-K works for bf16/fp16, tf32 (f32 inputs), and fp8 (e4m3/e5m2) inputs with any output dtype.
- Block-scaled MXFP8 GEMM composes with the same device path (SERIAL/PARALLEL) at no kernel cost - the scale-factor loads ride each split's K-range and the accumulator is already descaled f32 before the epilogue; only the block-scaled host gained the workspace/flag wiring (`mxfp8_gemm(..., split_k=, split_k_mode=)`). SEPARATE pending.
- Three `split_k` modes are supported:

| mode | fused reduction | run-to-run deterministic | performance | 
| ---- | --------------- | ------------------ | ----------- | 
| `SERIAL` | yes | yes | good |
| `PARALLEL` | yes | no | better |
| `SEPARATE` | no | yes | best |

### Performance against no splitK across the modes
<img width="2198" height="873" alt="image" src="https://github.com/user-attachments/assets/ccaa9e70-d5a9-4c25-b739-749d1dcbc5fa" />

Best speedup over the un-split kernel (split_k=1) across split-K {2,4,8,16,32}, per reduction mode (SERIAL / PARALLEL / SEPARATE), bf16 x bf16 -> fp32. X = M = N, Y = K; each cell is the speedup, annotated with the winning split factor (diverging scale centered at 1x: red = split-K slower, green = faster). GB200, CUDA graphs + L2 rotation, 500 iters.

### Performance against cuBLAS (splitK) baseline

<img width="2186" height="873" alt="image" src="https://github.com/user-attachments/assets/8ebd8fda-27dd-4058-847e-5cd42ce53457" />

### Performance against CUTLASS DSMEM Split-K Example

Best QuACK was selected over `split_k {1,2,4,8,16,32}` and `{SERIAL, PARALLEL, SEPARATE}`. CUTLASS was selected over `cluster_split_k {1,2,4,8,16}` from `dense_gemm_persistent_dynamic.py`.

`QuACK ms / CUTLASS ms`:

| K \ M=N | 64 | 128 | 256 | 512 | 1024 | 2048 |
|---:|---:|---:|---:|---:|---:|---:|
| 2K | 0.86 | 0.66 | 0.68 | 0.75 | 0.62 | 0.52 |
| 4K | 1.27 | 0.67 | 0.79 | 0.78 | 0.85 | 0.69 |
| 8K | 1.28 | 0.73 | 0.81 | 0.78 | 0.92 | 0.81 |
| 16K | 1.22 | 0.77 | 0.82 | 0.80 | 0.86 | 0.92 |
| 32K | 1.27 | 0.74 | 0.86 | 0.59 | 0.90 | 1.05 |
| 64K | 1.18 | 0.73 | 0.78 | 0.54 | 0.98 | 1.08 |
| 128K | 0.92 | 0.67 | 0.70 | 0.53 | 1.09 | 1.07 |
| 256K | 0.65 | 0.58 | 0.64 | 0.57 | 1.20 | 0.97 |

DSMEM reductions mainly won very small M/N `M=64` cases and a few large-M/high-K points; QuACK's best path was usually `SEPARATE`, often with `sk32` for long-K skinny/mid-sized shapes.

### Testing

`tests/test_gemm_split_k.py` runs each mode (and `split_k` 2/5, L 1/3, tf32/bf16/fp8 -> f32 out) end-to-end on GB200 and compile-only on SM90/SM120:
- Numerics vs an fp32 reference at the plain-kernel tolerance; `split_k=1` is bitwise identical to the baseline kernel; serial and staged f32 outputs agree bitwise.
- Run-to-run bitwise determinism (serial, staged); parallel is excluded by design.
- Full epilogue once on the sum: alpha, beta*C, rowvec + colvec bias, `add_to_output`, tensor-valued alpha/beta, and C aliasing the output (`gemm_add_inplace`, beta != 1).
- All three schedulers (non-persistent / static / CLC-dynamic) and m-major + mixed C/D majorness output paths.
- Edge cases: partial tiles, `split_k` > k-tiles (empty splits), cluster-rounded tile counts, odd epi-subtile counts (smem buffer rotation), staged grid not inflated, autotuner surface, and rejection of unsupported combos.
- Block-scaled MXFP8 split-K is covered in `tests/test_gemm_sm100_blockscaled.py` (SM100): SERIAL/PARALLEL across `split_k` 2/4 and batched, matching the plain MXFP8 kernel within ~1 bf16 ULP, serial deterministic, SEPARATE cleanly rejected.