### PR TITLE
[GemmSm100] Add MXFP8 grouped GEMM (offs) dispatcher

### DIFF
--- a/quack/blockscaled_gemm_utils.py
+++ b/quack/blockscaled_gemm_utils.py
@@ -608,6 +608,7 @@ def compile_blockscaled_gemm_tvm_ffi(
     use_clc_persistence: bool = True,
     varlen_m: bool = False,
     varlen_k: bool = False,
+    sfa_tile_aligned: bool = False,
 ) -> Callable:
     """Compile the SM100 blockscaled GEMM.
 
@@ -625,6 +626,7 @@ def compile_blockscaled_gemm_tvm_ffi(
         GemmDefaultSm100,
         sf_vec_size=sf_vec_size,
         use_clc_persistence=use_clc_persistence,
+        sfa_tile_aligned=sfa_tile_aligned,
     )(cutlass.Float32, ab_dtype, mma_tiler_mn, (*cluster_shape_mn, 1))
     compile_epi_args = gemm.EpilogueArguments()
     scheduler_args = make_scheduler_args(

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -142,6 +142,7 @@ class GemmSm100(GemmTmaBase):
         use_clc_persistence: bool = True,
         concat_layout: tuple | None = None,
         use_pdl: bool = True,
+        sfa_tile_aligned: bool = False,
     ):
         """Initializes the configuration for a Blackwell dense GEMM kernel.
 
@@ -168,6 +169,10 @@ class GemmSm100(GemmTmaBase):
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.sf_vec_size = sf_vec_size
         self.blockscaled = sf_vec_size is not None
+        # When True, SFA is in natural (unpadded) packed layout and per-expert offsets
+        # are computed as cu_seqlens[b] // 128 (valid only for 128-aligned varlen_m
+        # boundaries); when False, SFA is dQaccum-padded (cu // 128 + b).
+        self.sfa_tile_aligned = sfa_tile_aligned
         assert len(mma_tiler_mnk) in [2, 3], "MMA tiler must be (M, N) or (M, N, K)"
         valid_2cta_m = (128, 256) if not self.blockscaled else (256,)
         self.use_2cta_instrs = cluster_shape_mnk[0] % 2 == 0 and mma_tiler_mnk[0] in valid_2cta_m
@@ -1115,7 +1120,9 @@ class GemmSm100(GemmTmaBase):
                     # the A-data offset — allows varlen_m seqlens that aren't
                     # multiples of 128.
                     gSFA_mkl = cute.local_tile(
-                        varlen_manager.offset_batch_SFA(mSFA_mkl, batch_idx),
+                        varlen_manager.offset_batch_SFA(
+                            mSFA_mkl, batch_idx, tile_aligned=self.sfa_tile_aligned
+                        ),
                         cute.select(self.mma_tiler, [0, 2]),
                         (mma_tile_coord_mnl[0], None),
                     )

--- a/quack/mxfp8_grouped_gemm.py
+++ b/quack/mxfp8_grouped_gemm.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026, Tri Dao.
+"""MXFP8 grouped GEMM dispatcher for quack.
+
+Routes a grouped (per-expert) MXFP8 GEMM over cumulative ``offs`` onto quack's
+two existing SM100 blockscaled engines, mirroring ``torch._scaled_grouped_mm``:
+
+  * uniform 128-aligned groups -> batched-L dense (:func:`mxfp8_gemm_out`)
+  * ragged 128-aligned groups  -> varlen-M (:func:`compile_blockscaled_gemm_tvm_ffi`)
+  * ragged non-128 groups      -> pad to a 128 multiple, batched-L dense
+
+Contract (2D-A / 3D-B + offs, like ``torch._scaled_grouped_mm``)::
+
+    a:    (total_m, K)     float8_e4m3fn, K-contiguous
+    b:    (E, K, N)        float8_e4m3fn, K-contiguous (b.transpose(-2,-1).is_contiguous())
+    offs: (E,)             int32, CUMULATIVE per-group end rows; offs[-1] == total_m
+    sfa:  (total_m, K//32) float8_e8m0fnu, K-contiguous (raw per-block scales)
+    sfb:  (E, N, K//32)    float8_e8m0fnu, K-contiguous (raw per-block scales)
+    out:  optional (total_m, N) bfloat16, contiguous
+
+Returns bf16 ``(total_m, N)``.
+"""
+
+from functools import lru_cache
+from typing import List, Optional, Tuple
+
+import cutlass
+import torch
+from torch import Tensor
+
+from quack.blockscaled_gemm_utils import (
+    compile_blockscaled_gemm_tvm_ffi,
+    pack_scale_2d_to_blocked_contig,
+    scale_view_for_kernel,
+)
+from quack.gemm_blockscaled_interface import (
+    _compile_cached,
+    _default_tiler_cluster,
+    mxfp8_gemm_out,
+)
+
+SF_VEC = 32
+
+
+def _uniform_group_size(offsets_host: Tuple[int, ...]) -> Optional[int]:
+    prev, g = 0, None
+    for cur in offsets_host:
+        sz = cur - prev
+        if g is None:
+            g = sz
+        elif sz != g:
+            return None
+        prev = cur
+    return g
+
+
+def _group_sizes(offsets_host: Tuple[int, ...]) -> List[int]:
+    prev, out = 0, []
+    for cur in offsets_host:
+        out.append(cur - prev)
+        prev = cur
+    return out
+
+
+def _boundaries_128_aligned(offsets_host: Tuple[int, ...]) -> bool:
+    prev = 0
+    for cur in offsets_host:
+        if prev % 128 != 0 or cur % 128 != 0:
+            return False
+        prev = cur
+    return True
+
+
+def _dqaccum_padded_sfa(sfa: Tensor, group_sizes: List[int], sf_k: int, e: int) -> Tensor:
+    """Pack SFA for the varlen-M kernel in dQaccum-padded layout: expert i's
+    scale rows live at padded tile offset (cu_seqlens[i] // 128 + i) * 128,
+    matching VarlenManager.offset_batch_SFA. Returns packed (1, rm, rk, 512)."""
+    tile = 128
+    total_m = sum(group_sizes)
+    total_padded_m = ((total_m + tile - 1) // tile + (e - 1)) * tile
+    sa_padded = sfa.new_zeros(total_padded_m, sf_k)
+    off = 0
+    for i, m_i in enumerate(group_sizes):
+        off_padded = (off // tile + i) * tile
+        sa_padded[off_padded : off_padded + m_i] = sfa[off : off + m_i]
+        off += m_i
+    return pack_scale_2d_to_blocked_contig(sa_padded.view(1, total_padded_m, sf_k))
+
+
+@lru_cache(maxsize=32)
+def _varlen_runner(n: int, k: int, e: int, tiler, cluster):
+    # Compile once; the kernel uses cute.sym_int for total_m so one compile serves
+    # all group configurations with the same (n, k, e, tiler, cluster).
+    dev = torch.device("cuda")
+    sf_k = k // SF_VEC
+    fake_mA = torch.empty(128 * e, k, dtype=torch.float8_e4m3fn, device=dev)
+    fake_mB = torch.empty(e, n, k, dtype=torch.float8_e4m3fn, device=dev).permute(1, 2, 0)
+    fake_mD = torch.empty(128 * e, n, dtype=torch.bfloat16, device=dev)
+    fake_sfa = _dqaccum_padded_sfa(
+        torch.zeros(128 * e, sf_k, dtype=torch.float8_e8m0fnu, device=dev), [128] * e, sf_k, e
+    )
+    fake_sfb = pack_scale_2d_to_blocked_contig(
+        torch.zeros(e, n, sf_k, dtype=torch.float8_e8m0fnu, device=dev)
+    )
+    return compile_blockscaled_gemm_tvm_ffi(
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E8M0FNU,
+        SF_VEC,
+        cutlass.BFloat16,
+        tiler,
+        cluster,
+        fake_mA,
+        fake_mB,
+        fake_mD,
+        fake_sfa,
+        fake_sfb,
+        varlen_m=True,
+    )
+
+
+def mxfp8_grouped_gemm(
+    a: Tensor, b: Tensor, offs: Tensor, sfa: Tensor, sfb: Tensor, out: Optional[Tensor] = None
+) -> Tensor:
+    """Grouped MXFP8 GEMM. See module docstring for shape/layout contract."""
+    assert a.dim() == 2 and b.dim() == 3 and sfa.dim() == 2 and sfb.dim() == 3
+    assert a.dtype == torch.float8_e4m3fn and b.dtype == torch.float8_e4m3fn
+    assert sfa.dtype == torch.float8_e8m0fnu and sfb.dtype == torch.float8_e8m0fnu
+    total_m, k = a.shape
+    e, kb, n = b.shape
+    assert kb == k and k % SF_VEC == 0, f"K mismatch a={k} b={kb} (or not %{SF_VEC})"
+    sf_k = k // SF_VEC
+    assert tuple(sfa.shape) == (total_m, sf_k), f"sfa {tuple(sfa.shape)} != {(total_m, sf_k)}"
+    assert tuple(sfb.shape) == (e, n, sf_k), f"sfb {tuple(sfb.shape)} != {(e, n, sf_k)}"
+    if out is None:
+        out = torch.empty((total_m, n), dtype=torch.bfloat16, device=a.device)
+    if total_m == 0:
+        return out
+    offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
+    assert len(offsets_host) == e, f"offs len {len(offsets_host)} != E {e}"
+    assert offsets_host[-1] == total_m, f"offs[-1] {offsets_host[-1]} != total_m {total_m}"
+    g = _uniform_group_size(offsets_host)
+
+    # Route 1: uniform, 128-aligned -> batched-L dense (the fast uniform path).
+    if g is not None and g % 128 == 0:
+        # Natural (L, M, K)/(L, K, N)/(L, M, N); the dense interface permutes + packs.
+        # B_scale wants (E, sf_k, N); sfb is (E, N, sf_k) -> transpose (interface .mT's back).
+        mxfp8_gemm_out(
+            a.view(e, g, k), b, sfa.view(e, g, sf_k), sfb.transpose(1, 2), out.view(e, g, n)
+        )
+        return out
+
+    # Route 2: ragged, all boundaries 128-aligned -> varlen-M.
+    if _boundaries_128_aligned(offsets_host):
+        group_sizes = _group_sizes(offsets_host)
+        tiler, cluster = _default_tiler_cluster(max(group_sizes), n)
+        mB = b.permute(2, 1, 0)  # (N, K, E) K-major
+        mSFA = _dqaccum_padded_sfa(sfa, group_sizes, sf_k, e)  # dQaccum-padded, direct contig
+        mSFB = pack_scale_2d_to_blocked_contig(sfb)  # (E, rn, rk, 512), direct contig
+        cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
+        cu[0] = 0
+        cu[1:].copy_(offs.to(torch.int32))
+        runner = _varlen_runner(n, k, e, tiler, cluster)
+        runner(a, mB, out, mSFA, mSFB, cu)
+        return out
+
+    # Route 3: ragged non-128 -> pad each group to a 128 multiple, batched-L dense.
+    group_sizes = _group_sizes(offsets_host)
+    pad = (max(group_sizes) + 127) // 128 * 128
+    a_pad = a.new_zeros(e, pad, k)
+    sfa_pad = sfa.new_zeros(e, pad, sf_k)
+    out_pad = torch.empty(e, pad, n, dtype=torch.bfloat16, device=a.device)
+    start = 0
+    for i, end in enumerate(offsets_host):
+        gm = end - start
+        if gm > 0:
+            a_pad[i, :gm].copy_(a[start:end])
+            sfa_pad[i, :gm].copy_(sfa[start:end])
+        start = end
+    mxfp8_gemm_out(a_pad, b, sfa_pad, sfb.transpose(1, 2), out_pad)
+    start = 0
+    for i, end in enumerate(offsets_host):
+        gm = end - start
+        if gm > 0:
+            out[start:end].copy_(out_pad[i, :gm])
+        start = end
+    return out
+
+
+def make_mxfp8_grouped_gemm_runner(
+    a: Tensor, b: Tensor, offs: Tensor, sfa: Tensor, sfb: Tensor, out: Optional[Tensor] = None
+):
+    """Build a CUDA-graph-capturable runner that hoists ALL host work (routing,
+    the offs host-sync, kernel compile, output alloc) and PRE-PACKS the fixed
+    B-scale once. The returned ``run()`` does only per-call GPU work (A-scale
+    pack + the kernel) on the SAME tensor objects: update ``a`` / ``sfa`` / ``out``
+    in place between calls (and capture under a CUDA graph for replay). Falls
+    back to the eager dispatcher for the non-128 padded route.
+    """
+    assert a.dim() == 2 and b.dim() == 3 and sfa.dim() == 2 and sfb.dim() == 3
+    total_m, k = a.shape
+    e, kb, n = b.shape
+    assert kb == k and k % SF_VEC == 0
+    sf_k = k // SF_VEC
+    if out is None:
+        out = torch.empty((total_m, n), dtype=torch.bfloat16, device=a.device)
+    offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
+    assert len(offsets_host) == e and offsets_host[-1] == total_m
+    g = _uniform_group_size(offsets_host)
+
+    if g is not None and g % 128 == 0:
+        mA = a.view(e, g, k).permute(1, 2, 0)  # (g,k,e) K-major view of a
+        mB = b.mT.permute(1, 2, 0)  # (n,k,e) K-major view of b
+        mD = out.view(e, g, n).permute(1, 2, 0)  # (g,n,e) view of out
+        sfb_view = scale_view_for_kernel(pack_scale_2d_to_blocked_contig(sfb), n, sf_k, e)
+        tiler, cluster = _default_tiler_cluster(g, n)
+        runner = _compile_cached(
+            g, n, k, e, tiler, cluster, torch.bfloat16, cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU
+        )
+        sfa3 = sfa.view(e, g, sf_k)
+
+        def run():
+            sfa_view = scale_view_for_kernel(pack_scale_2d_to_blocked_contig(sfa3), g, sf_k, e)
+            runner(mA, mB, mD, sfa_view, sfb_view)
+            return out
+
+        return run
+
+    if _boundaries_128_aligned(offsets_host):
+        group_sizes = _group_sizes(offsets_host)
+        tiler, cluster = _default_tiler_cluster(max(group_sizes), n)
+        mB = b.permute(2, 1, 0)  # (N,K,E) K-major view of b
+        mSFB = pack_scale_2d_to_blocked_contig(sfb)  # packed once (fixed B weights)
+        cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
+        cu[0] = 0
+        cu[1:].copy_(offs.to(torch.int32))
+        runner = _varlen_runner(n, k, e, tiler, cluster)
+
+        def run():
+            mSFA = _dqaccum_padded_sfa(sfa, group_sizes, sf_k, e)  # dQaccum-padded per call
+            runner(a, mB, out, mSFA, mSFB, cu)
+            return out
+
+        return run
+
+    def run():  # non-128 padded: no clean hoist, fall back to eager
+        return mxfp8_grouped_gemm(a, b, offs, sfa, sfb, out)
+
+    return run

--- a/quack/mxfp8_grouped_gemm.py
+++ b/quack/mxfp8_grouped_gemm.py
@@ -87,17 +87,21 @@ def _dqaccum_padded_sfa(sfa: Tensor, group_sizes: List[int], sf_k: int, e: int) 
 
 
 @lru_cache(maxsize=32)
-def _varlen_runner(n: int, k: int, e: int, tiler, cluster):
+def _varlen_runner(n: int, k: int, e: int, tiler, cluster, sfa_tile_aligned: bool = True):
     # Compile once; the kernel uses cute.sym_int for total_m so one compile serves
-    # all group configurations with the same (n, k, e, tiler, cluster).
+    # all group configurations with the same (n, k, e, tiler, cluster). With
+    # sfa_tile_aligned=True the kernel reads SFA in natural (unpadded) packed layout
+    # (cu // 128 offset); =False expects the dQaccum-padded layout (cu // 128 + b).
     dev = torch.device("cuda")
     sf_k = k // SF_VEC
     fake_mA = torch.empty(128 * e, k, dtype=torch.float8_e4m3fn, device=dev)
     fake_mB = torch.empty(e, n, k, dtype=torch.float8_e4m3fn, device=dev).permute(1, 2, 0)
     fake_mD = torch.empty(128 * e, n, dtype=torch.bfloat16, device=dev)
-    fake_sfa = _dqaccum_padded_sfa(
-        torch.zeros(128 * e, sf_k, dtype=torch.float8_e8m0fnu, device=dev), [128] * e, sf_k, e
-    )
+    z = torch.zeros(128 * e, sf_k, dtype=torch.float8_e8m0fnu, device=dev)
+    if sfa_tile_aligned:
+        fake_sfa = pack_scale_2d_to_blocked_contig(z.view(1, 128 * e, sf_k))
+    else:
+        fake_sfa = _dqaccum_padded_sfa(z, [128] * e, sf_k, e)
     fake_sfb = pack_scale_2d_to_blocked_contig(
         torch.zeros(e, n, sf_k, dtype=torch.float8_e8m0fnu, device=dev)
     )
@@ -114,7 +118,23 @@ def _varlen_runner(n: int, k: int, e: int, tiler, cluster):
         fake_sfa,
         fake_sfb,
         varlen_m=True,
+        sfa_tile_aligned=sfa_tile_aligned,
     )
+
+
+def _run_varlen_natural(a, offs, sfa, mB, mSFB, out, e, k, n, sf_k, tiler, cluster):
+    """Run the varlen-M kernel with NATURAL (unpadded) SFA -- packs SFA like torch's
+    to_blocked (no dQaccum scatter) and uses the sfa_tile_aligned kernel path. Requires
+    128-aligned per-expert boundaries (caller-checked). ``mB`` / ``mSFB`` are the (fixed)
+    B operand + packed B-scale; ``cu_seqlens`` is built on-device from ``offs``."""
+    total_m = a.shape[0]
+    mSFA = pack_scale_2d_to_blocked_contig(sfa.view(1, total_m, sf_k))
+    cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
+    cu[0] = 0
+    cu[1:].copy_(offs.to(torch.int32))
+    runner = _varlen_runner(n, k, e, tiler, cluster, sfa_tile_aligned=True)
+    runner(a, mB, out, mSFA, mSFB, cu)
+    return out
 
 
 def mxfp8_grouped_gemm(
@@ -125,6 +145,7 @@ def mxfp8_grouped_gemm(
     sfb: Tensor,
     out: Optional[Tensor] = None,
     uniform: bool = False,
+    varlen: bool = False,
 ) -> Tensor:
     """Grouped MXFP8 GEMM. See module docstring for shape/layout contract.
 
@@ -133,10 +154,17 @@ def mxfp8_grouped_gemm(
     shapes alone, so ``offs`` is never read on the host -- no device->host sync,
     no launch bubble -- and the call runs the dense batched-L path directly. This
     is the sync-free path that stays >= torch._scaled_grouped_mm on uniform shapes.
+
+    If ``varlen=True`` the caller instead asserts ragged groups with 128-aligned
+    boundaries (e.g. capacity-padded MoE). ``offs`` is consumed only on device
+    (cu_seqlens), the SFA is packed in natural layout, and the varlen-M kernel uses
+    its sfa_tile_aligned path -- also sync-free, and >= torch on ragged shapes.
+    ``uniform`` and ``varlen`` are mutually exclusive.
     """
     assert a.dim() == 2 and b.dim() == 3 and sfa.dim() == 2 and sfb.dim() == 3
     assert a.dtype == torch.float8_e4m3fn and b.dtype == torch.float8_e4m3fn
     assert sfa.dtype == torch.float8_e8m0fnu and sfb.dtype == torch.float8_e8m0fnu
+    assert not (uniform and varlen), "uniform and varlen are mutually exclusive"
     total_m, k = a.shape
     e, kb, n = b.shape
     assert kb == k and k % SF_VEC == 0, f"K mismatch a={k} b={kb} (or not %{SF_VEC})"
@@ -160,6 +188,27 @@ def mxfp8_grouped_gemm(
         )
         return out
 
+    # Sync-free varlen fast path: ragged groups with 128-aligned boundaries (caller-
+    # asserted). offs is consumed only on device -> no host sync; natural SFA via the
+    # sfa_tile_aligned kernel path (no dQaccum scatter).
+    if varlen:
+        assert total_m % 128 == 0, f"varlen=True needs total_m {total_m} % 128 == 0"
+        tiler, cluster = _default_tiler_cluster(total_m // e, n)
+        return _run_varlen_natural(
+            a,
+            offs,
+            sfa,
+            b.permute(2, 1, 0),
+            pack_scale_2d_to_blocked_contig(sfb),
+            out,
+            e,
+            k,
+            n,
+            sf_k,
+            tiler,
+            cluster,
+        )
+
     offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
     assert len(offsets_host) == e, f"offs len {len(offsets_host)} != E {e}"
     assert offsets_host[-1] == total_m, f"offs[-1] {offsets_host[-1]} != total_m {total_m}"
@@ -174,19 +223,24 @@ def mxfp8_grouped_gemm(
         )
         return out
 
-    # Route 2: ragged, all boundaries 128-aligned -> varlen-M.
+    # Route 2: ragged, all boundaries 128-aligned -> varlen-M (natural SFA).
     if _boundaries_128_aligned(offsets_host):
         group_sizes = _group_sizes(offsets_host)
         tiler, cluster = _default_tiler_cluster(max(group_sizes), n)
-        mB = b.permute(2, 1, 0)  # (N, K, E) K-major
-        mSFA = _dqaccum_padded_sfa(sfa, group_sizes, sf_k, e)  # dQaccum-padded, direct contig
-        mSFB = pack_scale_2d_to_blocked_contig(sfb)  # (E, rn, rk, 512), direct contig
-        cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
-        cu[0] = 0
-        cu[1:].copy_(offs.to(torch.int32))
-        runner = _varlen_runner(n, k, e, tiler, cluster)
-        runner(a, mB, out, mSFA, mSFB, cu)
-        return out
+        return _run_varlen_natural(
+            a,
+            offs,
+            sfa,
+            b.permute(2, 1, 0),
+            pack_scale_2d_to_blocked_contig(sfb),
+            out,
+            e,
+            k,
+            n,
+            sf_k,
+            tiler,
+            cluster,
+        )
 
     # Route 3: ragged non-128 -> pad each group to a 128 multiple, batched-L dense.
     group_sizes = _group_sizes(offsets_host)
@@ -270,8 +324,10 @@ class MXFP8GroupedGemm:
         sfa: Tensor,
         out: Optional[Tensor] = None,
         uniform: Optional[bool] = None,
+        varlen: bool = False,
     ) -> Tensor:
         uniform = self.uniform if uniform is None else uniform
+        assert not (uniform and varlen), "uniform and varlen are mutually exclusive"
         e, k, n, sf_k = self.e, self.k, self.n, self.sf_k
         total_m, ka = a.shape
         assert ka == k, f"K mismatch a={ka} vs b={k}"
@@ -289,6 +345,14 @@ class MXFP8GroupedGemm:
             assert g % 128 == 0, f"uniform=True needs (total_m // E) = {g} % 128 == 0"
             return self._dense(a, g, sfa, out)
 
+        # Sync-free varlen path: ragged 128-aligned groups; natural SFA, cached B-scale.
+        if varlen:
+            assert total_m % 128 == 0, f"varlen=True needs total_m {total_m} % 128 == 0"
+            tiler, cluster = _default_tiler_cluster(total_m // e, n)
+            return _run_varlen_natural(
+                a, offs, sfa, self._mB_varlen, self._sfb_packed, out, e, k, n, sf_k, tiler, cluster
+            )
+
         # General route via offs (one host sync; B-scale already packed).
         offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
         assert len(offsets_host) == e, f"offs len {len(offsets_host)} != E {e}"
@@ -299,12 +363,8 @@ class MXFP8GroupedGemm:
         if _boundaries_128_aligned(offsets_host):
             group_sizes = _group_sizes(offsets_host)
             tiler, cluster = _default_tiler_cluster(max(group_sizes), n)
-            cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
-            cu[0] = 0
-            cu[1:].copy_(offs.to(torch.int32))
-            runner = _varlen_runner(n, k, e, tiler, cluster)
-            mSFA = _dqaccum_padded_sfa(sfa, group_sizes, sf_k, e)
-            runner(a, self._mB_varlen, out, mSFA, self._sfb_packed, cu)
-            return out
+            return _run_varlen_natural(
+                a, offs, sfa, self._mB_varlen, self._sfb_packed, out, e, k, n, sf_k, tiler, cluster
+            )
         # non-128 padded: no clean prepacked hoist, fall back to the eager dispatcher.
         return mxfp8_grouped_gemm(a, self._b, offs, sfa, self._sfb_raw, out)

--- a/quack/mxfp8_grouped_gemm.py
+++ b/quack/mxfp8_grouped_gemm.py
@@ -211,63 +211,100 @@ def mxfp8_grouped_gemm(
     return out
 
 
-def make_mxfp8_grouped_gemm_runner(
-    a: Tensor, b: Tensor, offs: Tensor, sfa: Tensor, sfb: Tensor, out: Optional[Tensor] = None
-):
-    """Build a CUDA-graph-capturable runner that hoists ALL host work (routing,
-    the offs host-sync, kernel compile, output alloc) and PRE-PACKS the fixed
-    B-scale once. The returned ``run()`` does only per-call GPU work (A-scale
-    pack + the kernel) on the SAME tensor objects: update ``a`` / ``sfa`` / ``out``
-    in place between calls (and capture under a CUDA graph for replay). Falls
-    back to the eager dispatcher for the non-128 padded route.
-    """
-    assert a.dim() == 2 and b.dim() == 3 and sfa.dim() == 2 and sfb.dim() == 3
-    total_m, k = a.shape
-    e, kb, n = b.shape
-    assert kb == k and k % SF_VEC == 0
-    sf_k = k // SF_VEC
-    if out is None:
-        out = torch.empty((total_m, n), dtype=torch.bfloat16, device=a.device)
-    offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
-    assert len(offsets_host) == e and offsets_host[-1] == total_m
-    g = _uniform_group_size(offsets_host)
+class MXFP8GroupedGemm:
+    """Prepared grouped MXFP8 GEMM with the fixed B operand baked in.
 
-    if g is not None and g % 128 == 0:
-        mA = a.view(e, g, k).permute(1, 2, 0)  # (g,k,e) K-major view of a
-        mB = b.mT.permute(1, 2, 0)  # (n,k,e) K-major view of b
-        mD = out.view(e, g, n).permute(1, 2, 0)  # (g,n,e) view of out
-        sfb_view = scale_view_for_kernel(pack_scale_2d_to_blocked_contig(sfb), n, sf_k, e)
+    Pre-packs the B-scale and reuses the cached compiled kernel, so each call does
+    only per-step work (A-scale pack + the kernel). Call it like
+    ``torch._scaled_grouped_mm``::
+
+        gemm = MXFP8GroupedGemm(b, sfb)        # b/sfb are the fixed expert weights
+        out = gemm(a, offs, sfa)               # per step (offs may change per call)
+        out = gemm(a, offs, sfa, out=buf)      # reuse an output buffer
+
+    With ``uniform=True`` (at construction or per call) the route is derived from
+    shapes (g = total_m // E), so ``offs`` is never read on the host -- no
+    device->host sync / launch bubble. Combined with the pre-packed B-scale this
+    stays >= ``torch._scaled_grouped_mm`` across group sizes, including small g where
+    the plain function's per-call B-pack would otherwise dominate the kernel.
+
+    Per-call work is on fresh tensors; for CUDA-graph replay, call once on the
+    capture tensors then update ``a`` / ``sfa`` / ``out`` in place between replays.
+    """
+
+    def __init__(self, b: Tensor, sfb: Tensor, uniform: bool = False):
+        assert b.dim() == 3 and sfb.dim() == 3
+        assert b.dtype == torch.float8_e4m3fn and sfb.dtype == torch.float8_e8m0fnu
+        e, k, n = b.shape
+        assert k % SF_VEC == 0, f"K={k} not a multiple of {SF_VEC}"
+        sf_k = k // SF_VEC
+        assert tuple(sfb.shape) == (e, n, sf_k), f"sfb {tuple(sfb.shape)} != {(e, n, sf_k)}"
+        self.e, self.k, self.n, self.sf_k = e, k, n, sf_k
+        self.uniform = uniform
+        self._b = b  # kept for the non-128 padded fallback
+        self._sfb_raw = sfb  # ditto
+        # Pre-pack the fixed B-scale once; shared across calls and routes.
+        self._sfb_packed = pack_scale_2d_to_blocked_contig(sfb)  # varlen passes this directly
+        self._sfb_view_dense = scale_view_for_kernel(self._sfb_packed, n, sf_k, e)  # dense view
+        self._mB_dense = b.mT.permute(1, 2, 0)  # (n,k,e) K-major view (dense/uniform)
+        self._mB_varlen = b.permute(2, 1, 0)  # (n,k,e) K-major view (varlen)
+
+    def _dense(self, a: Tensor, g: int, sfa: Tensor, out: Tensor) -> Tensor:
+        e, k, n, sf_k = self.e, self.k, self.n, self.sf_k
+        mA = a.view(e, g, k).permute(1, 2, 0)
+        mD = out.view(e, g, n).permute(1, 2, 0)
         tiler, cluster = _default_tiler_cluster(g, n)
         runner = _compile_cached(
             g, n, k, e, tiler, cluster, torch.bfloat16, cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU
         )
-        sfa3 = sfa.view(e, g, sf_k)
+        sfa_view = scale_view_for_kernel(
+            pack_scale_2d_to_blocked_contig(sfa.view(e, g, sf_k)), g, sf_k, e
+        )
+        runner(mA, self._mB_dense, mD, sfa_view, self._sfb_view_dense)
+        return out
 
-        def run():
-            sfa_view = scale_view_for_kernel(pack_scale_2d_to_blocked_contig(sfa3), g, sf_k, e)
-            runner(mA, mB, mD, sfa_view, sfb_view)
+    def __call__(
+        self,
+        a: Tensor,
+        offs: Tensor,
+        sfa: Tensor,
+        out: Optional[Tensor] = None,
+        uniform: Optional[bool] = None,
+    ) -> Tensor:
+        uniform = self.uniform if uniform is None else uniform
+        e, k, n, sf_k = self.e, self.k, self.n, self.sf_k
+        total_m, ka = a.shape
+        assert ka == k, f"K mismatch a={ka} vs b={k}"
+        assert a.dtype == torch.float8_e4m3fn and sfa.dtype == torch.float8_e8m0fnu
+        assert tuple(sfa.shape) == (total_m, sf_k), f"sfa {tuple(sfa.shape)} != {(total_m, sf_k)}"
+        if out is None:
+            out = torch.empty((total_m, n), dtype=torch.bfloat16, device=a.device)
+        if total_m == 0:
             return out
 
-        return run
+        # Sync-free uniform path: shape-derived route + pre-packed B-scale.
+        if uniform:
+            assert total_m % e == 0, f"uniform=True needs total_m {total_m} % E {e} == 0"
+            g = total_m // e
+            assert g % 128 == 0, f"uniform=True needs (total_m // E) = {g} % 128 == 0"
+            return self._dense(a, g, sfa, out)
 
-    if _boundaries_128_aligned(offsets_host):
-        group_sizes = _group_sizes(offsets_host)
-        tiler, cluster = _default_tiler_cluster(max(group_sizes), n)
-        mB = b.permute(2, 1, 0)  # (N,K,E) K-major view of b
-        mSFB = pack_scale_2d_to_blocked_contig(sfb)  # packed once (fixed B weights)
-        cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
-        cu[0] = 0
-        cu[1:].copy_(offs.to(torch.int32))
-        runner = _varlen_runner(n, k, e, tiler, cluster)
-
-        def run():
-            mSFA = _dqaccum_padded_sfa(sfa, group_sizes, sf_k, e)  # dQaccum-padded per call
-            runner(a, mB, out, mSFA, mSFB, cu)
+        # General route via offs (one host sync; B-scale already packed).
+        offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
+        assert len(offsets_host) == e, f"offs len {len(offsets_host)} != E {e}"
+        assert offsets_host[-1] == total_m, f"offs[-1] {offsets_host[-1]} != total_m {total_m}"
+        g = _uniform_group_size(offsets_host)
+        if g is not None and g % 128 == 0:
+            return self._dense(a, g, sfa, out)
+        if _boundaries_128_aligned(offsets_host):
+            group_sizes = _group_sizes(offsets_host)
+            tiler, cluster = _default_tiler_cluster(max(group_sizes), n)
+            cu = torch.empty(e + 1, dtype=torch.int32, device=offs.device)
+            cu[0] = 0
+            cu[1:].copy_(offs.to(torch.int32))
+            runner = _varlen_runner(n, k, e, tiler, cluster)
+            mSFA = _dqaccum_padded_sfa(sfa, group_sizes, sf_k, e)
+            runner(a, self._mB_varlen, out, mSFA, self._sfb_packed, cu)
             return out
-
-        return run
-
-    def run():  # non-128 padded: no clean hoist, fall back to eager
-        return mxfp8_grouped_gemm(a, b, offs, sfa, sfb, out)
-
-    return run
+        # non-128 padded: no clean prepacked hoist, fall back to the eager dispatcher.
+        return mxfp8_grouped_gemm(a, self._b, offs, sfa, self._sfb_raw, out)

--- a/quack/mxfp8_grouped_gemm.py
+++ b/quack/mxfp8_grouped_gemm.py
@@ -118,9 +118,22 @@ def _varlen_runner(n: int, k: int, e: int, tiler, cluster):
 
 
 def mxfp8_grouped_gemm(
-    a: Tensor, b: Tensor, offs: Tensor, sfa: Tensor, sfb: Tensor, out: Optional[Tensor] = None
+    a: Tensor,
+    b: Tensor,
+    offs: Tensor,
+    sfa: Tensor,
+    sfb: Tensor,
+    out: Optional[Tensor] = None,
+    uniform: bool = False,
 ) -> Tensor:
-    """Grouped MXFP8 GEMM. See module docstring for shape/layout contract."""
+    """Grouped MXFP8 GEMM. See module docstring for shape/layout contract.
+
+    If ``uniform=True`` the caller asserts every group has the same size
+    ``total_m // E`` (e.g. fixed-capacity MoE). The route is then determined from
+    shapes alone, so ``offs`` is never read on the host -- no device->host sync,
+    no launch bubble -- and the call runs the dense batched-L path directly. This
+    is the sync-free path that stays >= torch._scaled_grouped_mm on uniform shapes.
+    """
     assert a.dim() == 2 and b.dim() == 3 and sfa.dim() == 2 and sfb.dim() == 3
     assert a.dtype == torch.float8_e4m3fn and b.dtype == torch.float8_e4m3fn
     assert sfa.dtype == torch.float8_e8m0fnu and sfb.dtype == torch.float8_e8m0fnu
@@ -134,6 +147,19 @@ def mxfp8_grouped_gemm(
         out = torch.empty((total_m, n), dtype=torch.bfloat16, device=a.device)
     if total_m == 0:
         return out
+
+    # Sync-free uniform fast path: the route is shape-determined (g = total_m // E),
+    # so offs is never read on the host -> no device->host sync / launch bubble. The
+    # caller asserts the groups are equal & 128-aligned (e.g. fixed-capacity MoE).
+    if uniform:
+        assert total_m % e == 0, f"uniform=True needs total_m {total_m} % E {e} == 0"
+        g = total_m // e
+        assert g % 128 == 0, f"uniform=True needs (total_m // E) = {g} to be % 128 == 0"
+        mxfp8_gemm_out(
+            a.view(e, g, k), b, sfa.view(e, g, sf_k), sfb.transpose(1, 2), out.view(e, g, n)
+        )
+        return out
+
     offsets_host = tuple(int(v) for v in offs.detach().cpu().tolist())
     assert len(offsets_host) == e, f"offs len {len(offsets_host)} != E {e}"
     assert offsets_host[-1] == total_m, f"offs[-1] {offsets_host[-1]} != total_m {total_m}"

--- a/quack/varlen_utils.py
+++ b/quack/varlen_utils.py
@@ -122,23 +122,38 @@ class VarlenManager:
             mAIdx_mk = params.mAIdx[None, batch_idx]
         return mAIdx_mk
 
-    def offset_batch_SFA(self, mSFA_mkl: cute.Tensor, batch_idx: Int32) -> cute.Tensor:
-        """Offset SFA by padded per-expert offset (dQaccum-style).
+    def offset_batch_SFA(
+        self,
+        mSFA_mkl: cute.Tensor,
+        batch_idx: Int32,
+        tile_aligned: cutlass.Constexpr[bool] = False,
+    ) -> cute.Tensor:
+        """Offset SFA to expert ``batch_idx``'s scale tile.
 
-        The padded offset, in tile units (128 source-M or source-K per tile),
-        is simply `cu_seqlens[b] // 128 + b`. (Algebraically identical to
-        `(cu_seqlens[b] + b*128) // 128 * 128` / 128.) We pass it as a
-        compound coord `(0, offset_tile)` to `domain_offset` so the outer
-        rm/rk mode is shifted in tile units — no `* 128` needed, and the
-        compiler sees the tile alignment natively.
+        The default offset, in tile units (128 source-M or source-K per tile), is
+        ``cu_seqlens[b] // 128 + b`` (dQaccum-style). The ``+ b`` slack lets
+        per-expert seqlens be arbitrary: each rounds up to a whole 128-tile, and ``b``
+        tiles of cumulative padding keep every expert tile-aligned. SFA must then be
+        stored in that padded layout.
+
+        When the caller guarantees 128-aligned per-expert boundaries
+        (``tile_aligned=True``), each expert already starts on a tile boundary, so the
+        natural offset ``cu_seqlens[b] // 128`` is exact and SFA can be passed in
+        natural (unpadded) packed layout -- no dQaccum scatter/padding needed. We pass
+        the offset as a compound coord ``(0, offset_tile)`` to ``domain_offset`` so the
+        outer rm/rk mode is shifted in tile units (no ``* 128`` needed).
         """
         params = self.params
         tile = 128
         if const_expr(self.varlen_m):
-            offset_tile = params.cu_seqlens_m[batch_idx] // tile + batch_idx
+            offset_tile = params.cu_seqlens_m[batch_idx] // tile
+            if const_expr(not tile_aligned):
+                offset_tile = offset_tile + batch_idx
             return cute.domain_offset(((0, offset_tile), None), mSFA_mkl)
         elif const_expr(self.varlen_k):
-            offset_tile = params.cu_seqlens_k[batch_idx] // tile + batch_idx
+            offset_tile = params.cu_seqlens_k[batch_idx] // tile
+            if const_expr(not tile_aligned):
+                offset_tile = offset_tile + batch_idx
             return cute.domain_offset((None, (0, offset_tile)), mSFA_mkl)
         else:
             return mSFA_mkl[None, None, batch_idx]

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -757,6 +757,111 @@ def test_blockscaled_mxfp8_varlen_m_nonaligned(seqlens_m, b_major):
 
 
 @pytest.mark.parametrize(
+    "seqlens_m",
+    [
+        [128, 128, 128, 128],  # uniform
+        [128, 256, 384, 256],  # ragged, 128-aligned
+        [256, 0, 256, 256],  # empty expert
+        [1792, 128, 128, 128],  # heavy skew
+    ],
+)
+def test_blockscaled_mxfp8_varlen_m_sfa_tile_aligned(seqlens_m):
+    """sfa_tile_aligned=True: with 128-aligned per-expert boundaries, SFA is passed in
+    NATURAL (unpadded) packed layout and the kernel offsets per expert by
+    cu_seqlens[b] // 128 (no dQaccum +b padding -> no scatter). Must (a) match the
+    dequant reference and (b) be bit-identical to the default dQaccum-padded path --
+    same kernel math, only the SFA addressing differs."""
+    _skip_if_not_sm100()
+    from quack.blockscaled_gemm_utils import pack_scale_2d_to_blocked_contig
+    from quack.mx_utils import to_mx_compiled
+
+    e = len(seqlens_m)
+    n, k, sf_vec = 256, 256, 32
+    sf_k = k // sf_vec
+    mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+    assert all(m % 128 == 0 for m in seqlens_m), "this path requires 128-aligned seqlens"
+    total_m = sum(seqlens_m)
+    dev = "cuda"
+
+    torch.manual_seed(0)
+    qa, sa = to_mx_compiled(
+        (torch.randn(total_m, k, dtype=torch.bfloat16, device=dev) * k**-0.5).contiguous(), sf_vec
+    )
+    qbf, sb = to_mx_compiled(
+        (torch.randn(e, n, k, dtype=torch.bfloat16, device=dev) * k**-0.5)
+        .contiguous()
+        .view(e * n, k),
+        sf_vec,
+    )
+    qb = qbf.view(e, n, k)
+    sb = sb.view(e, n, sf_k)
+    mB = qb.transpose(1, 2).permute(2, 1, 0)  # (n, k, e)
+    mSFB = pack_scale_2d_to_blocked_contig(sb)
+    seq = torch.tensor(seqlens_m, dtype=torch.int32, device=dev)
+    cu = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=dev), torch.cumsum(seq, 0).to(torch.int32)]
+    )
+
+    a_ref = qa.float() * sa.float().repeat_interleave(sf_vec, -1)
+    b_ref = qbf.float().view(e, n, k) * sb.float().repeat_interleave(sf_vec, -1)
+    cul = cu.tolist()
+    ref = torch.cat(
+        [a_ref[cul[i] : cul[i + 1]] @ b_ref[i].T for i in range(e) if cul[i + 1] > cul[i]]
+    )
+
+    # (a) natural (unpadded) SFA + sfa_tile_aligned=True
+    mSFA_nat = pack_scale_2d_to_blocked_contig(sa.view(1, total_m, sf_k))
+    out_nat = torch.empty(total_m, n, dtype=torch.bfloat16, device=dev)
+    compile_blockscaled_gemm_tvm_ffi(
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E8M0FNU,
+        sf_vec,
+        cutlass.BFloat16,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        qa,
+        mB,
+        out_nat,
+        mSFA_nat,
+        mSFB,
+        varlen_m=True,
+        sfa_tile_aligned=True,
+    )(qa, mB, out_nat, mSFA_nat, mSFB, cu)
+
+    # (b) dQaccum-padded SFA + default path (per-expert +i*128 tile gap)
+    tile = 128
+    total_padded = ((total_m + tile - 1) // tile + (e - 1)) * tile
+    sa_pad = sa.new_zeros(total_padded, sf_k)
+    off = 0
+    for i, m_i in enumerate(seqlens_m):
+        dst = (off // tile + i) * tile
+        sa_pad[dst : dst + m_i] = sa[off : off + m_i]
+        off += m_i
+    mSFA_pad = pack_scale_2d_to_blocked_contig(sa_pad.view(1, total_padded, sf_k))
+    out_pad = torch.empty(total_m, n, dtype=torch.bfloat16, device=dev)
+    compile_blockscaled_gemm_tvm_ffi(
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E8M0FNU,
+        sf_vec,
+        cutlass.BFloat16,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        qa,
+        mB,
+        out_pad,
+        mSFA_pad,
+        mSFB,
+        varlen_m=True,
+        sfa_tile_aligned=False,
+    )(qa, mB, out_pad, mSFA_pad, mSFB, cu)
+    torch.cuda.synchronize()
+
+    err = (out_nat.float() - ref).abs().max().item()
+    assert err < 5e-3, f"natural-SFA seqlens_m={seqlens_m} max_err={err}"
+    assert torch.equal(out_nat, out_pad), f"natural != dQaccum for seqlens_m={seqlens_m}"
+
+
+@pytest.mark.parametrize(
     "seqlens_k",
     [
         [128, 128, 128],  # all aligned to 128

--- a/tests/test_mxfp8_grouped_gemm.py
+++ b/tests/test_mxfp8_grouped_gemm.py
@@ -103,3 +103,33 @@ def test_mxfp8_grouped_gemm_eager_prepared_bitwise(route, group_sizes, k, n):
         f"eager vs prepared not bit-identical: "
         f"{(eager != prepared).sum().item()}/{eager.numel()} elems differ"
     )
+
+
+@pytest.mark.parametrize("k,n", [(512, 512), (4096, 4096)])
+@pytest.mark.parametrize(
+    "group_sizes",
+    [
+        (1792, 128, 128, 128),  # 128-aligned, heavy load imbalance -> varlen-M
+        (512, 0, 0, 0),  # 128-aligned, single non-empty expert
+        (256, 0, 256, 256),  # 128-aligned, empty middle expert
+        (0, 256, 256, 256),  # 128-aligned, empty first expert
+        (256, 256, 256, 0),  # 128-aligned, empty last expert
+        (100, 0, 200, 224),  # non-128, empty expert -> padded route
+        (500, 12, 8, 4),  # non-128, heavy imbalance -> padded route
+    ],
+)
+def test_mxfp8_grouped_gemm_skew_and_empty(group_sizes, k, n):
+    """Realistic MoE routing: heavy load imbalance and empty experts (size-0 groups).
+    Exercises the varlen-M route's dQaccum-padded SFA build and the padded route with
+    m_i == 0. Checks both APIs vs the dequant reference and that they agree bitwise."""
+    _skip_if_not_sm100()
+    from quack.mxfp8_grouped_gemm import make_mxfp8_grouped_gemm_runner, mxfp8_grouped_gemm
+
+    qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
+    eager = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
+    prepared = make_mxfp8_grouped_gemm_runner(qa, b_disp, offs, sa, sb)()
+    assert eager.shape == (sum(group_sizes), n)
+    torch.testing.assert_close(
+        eager.float(), _ref_grouped(a_ref, b_ref, group_sizes), atol=1e-2, rtol=1e-2
+    )
+    assert torch.equal(eager, prepared)

--- a/tests/test_mxfp8_grouped_gemm.py
+++ b/tests/test_mxfp8_grouped_gemm.py
@@ -133,3 +133,21 @@ def test_mxfp8_grouped_gemm_skew_and_empty(group_sizes, k, n):
         eager.float(), _ref_grouped(a_ref, b_ref, group_sizes), atol=1e-2, rtol=1e-2
     )
     assert torch.equal(eager, prepared)
+
+
+@pytest.mark.parametrize("k,n", [(512, 512), (4096, 4096)])
+@pytest.mark.parametrize("group_sizes", [(256,) * 4, (128,) * 8])
+def test_mxfp8_grouped_gemm_uniform_fastpath(group_sizes, k, n):
+    """The sync-free uniform fast path (uniform=True derives g = total_m // E from
+    shapes and never reads offs) must be a pure shortcut of the default offs-routed
+    call -> bit-identical, and correct vs the dequant reference."""
+    _skip_if_not_sm100()
+    from quack.mxfp8_grouped_gemm import mxfp8_grouped_gemm
+
+    qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
+    routed = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
+    fast = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb, uniform=True)
+    torch.testing.assert_close(
+        fast.float(), _ref_grouped(a_ref, b_ref, group_sizes), atol=1e-2, rtol=1e-2
+    )
+    assert torch.equal(fast, routed)

--- a/tests/test_mxfp8_grouped_gemm.py
+++ b/tests/test_mxfp8_grouped_gemm.py
@@ -65,13 +65,13 @@ def _ref_grouped(a_ref, b_ref, group_sizes):
 )
 def test_mxfp8_grouped_gemm(api, route, group_sizes, k, n):
     _skip_if_not_sm100()
-    from quack.mxfp8_grouped_gemm import make_mxfp8_grouped_gemm_runner, mxfp8_grouped_gemm
+    from quack.mxfp8_grouped_gemm import MXFP8GroupedGemm, mxfp8_grouped_gemm
 
     qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
     if api == "eager":
         out = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
     else:
-        out = make_mxfp8_grouped_gemm_runner(qa, b_disp, offs, sa, sb)()
+        out = MXFP8GroupedGemm(b_disp, sb)(qa, offs, sa)
     assert out.shape == (sum(group_sizes), n)
     ref = _ref_grouped(a_ref, b_ref, group_sizes)
     torch.testing.assert_close(out.float(), ref, atol=1e-2, rtol=1e-2)
@@ -94,11 +94,11 @@ def test_mxfp8_grouped_gemm_eager_prepared_bitwise(route, group_sizes, k, n):
     bitwise check vs torch._scaled_grouped_mm, this is robust -- it does not
     depend on neither side picking split-K.)"""
     _skip_if_not_sm100()
-    from quack.mxfp8_grouped_gemm import make_mxfp8_grouped_gemm_runner, mxfp8_grouped_gemm
+    from quack.mxfp8_grouped_gemm import MXFP8GroupedGemm, mxfp8_grouped_gemm
 
     qa, b_disp, offs, sa, sb, _, _ = _make_grouped_mxfp8(group_sizes, k, n)
     eager = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
-    prepared = make_mxfp8_grouped_gemm_runner(qa, b_disp, offs, sa, sb)()
+    prepared = MXFP8GroupedGemm(b_disp, sb)(qa, offs, sa)
     assert torch.equal(eager, prepared), (
         f"eager vs prepared not bit-identical: "
         f"{(eager != prepared).sum().item()}/{eager.numel()} elems differ"
@@ -123,11 +123,11 @@ def test_mxfp8_grouped_gemm_skew_and_empty(group_sizes, k, n):
     Exercises the varlen-M route's dQaccum-padded SFA build and the padded route with
     m_i == 0. Checks both APIs vs the dequant reference and that they agree bitwise."""
     _skip_if_not_sm100()
-    from quack.mxfp8_grouped_gemm import make_mxfp8_grouped_gemm_runner, mxfp8_grouped_gemm
+    from quack.mxfp8_grouped_gemm import MXFP8GroupedGemm, mxfp8_grouped_gemm
 
     qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
     eager = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
-    prepared = make_mxfp8_grouped_gemm_runner(qa, b_disp, offs, sa, sb)()
+    prepared = MXFP8GroupedGemm(b_disp, sb)(qa, offs, sa)
     assert eager.shape == (sum(group_sizes), n)
     torch.testing.assert_close(
         eager.float(), _ref_grouped(a_ref, b_ref, group_sizes), atol=1e-2, rtol=1e-2
@@ -142,12 +142,14 @@ def test_mxfp8_grouped_gemm_uniform_fastpath(group_sizes, k, n):
     shapes and never reads offs) must be a pure shortcut of the default offs-routed
     call -> bit-identical, and correct vs the dequant reference."""
     _skip_if_not_sm100()
-    from quack.mxfp8_grouped_gemm import mxfp8_grouped_gemm
+    from quack.mxfp8_grouped_gemm import MXFP8GroupedGemm, mxfp8_grouped_gemm
 
     qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
     routed = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
     fast = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb, uniform=True)
+    cls_fast = MXFP8GroupedGemm(b_disp, sb, uniform=True)(qa, offs, sa)
     torch.testing.assert_close(
         fast.float(), _ref_grouped(a_ref, b_ref, group_sizes), atol=1e-2, rtol=1e-2
     )
-    assert torch.equal(fast, routed)
+    assert torch.equal(fast, routed)  # functional fast path == routed
+    assert torch.equal(cls_fast, routed)  # class uniform path == routed

--- a/tests/test_mxfp8_grouped_gemm.py
+++ b/tests/test_mxfp8_grouped_gemm.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, Tri Dao.
+"""Parity tests for the MXFP8 grouped GEMM dispatcher (quack/mxfp8_grouped_gemm.py).
+
+Exercises all three routes (uniform-batched, ragged-varlen-M, ragged-padded) and
+checks each against a per-group dequantized matmul reference.
+"""
+
+import itertools
+
+import pytest
+import torch
+
+from quack.cute_dsl_utils import get_device_capacity
+from quack.mx_utils import to_mx_compiled
+
+SF_VEC = 32
+
+
+def _skip_if_not_sm100():
+    if not torch.cuda.is_available() or get_device_capacity(torch.device("cuda"))[0] not in (
+        10,
+        11,
+    ):
+        pytest.skip("MXFP8 grouped GEMM requires SM100 (B200/B300) or SM110")
+
+
+def _make_grouped_mxfp8(group_sizes, k, n, seed=0):
+    """Build a grouped MXFP8 problem in the dispatcher's input layout + fp32 dequant refs."""
+    torch.manual_seed(seed)
+    e = len(group_sizes)
+    total_m = sum(group_sizes)
+    sf_k = k // SF_VEC
+    dev = torch.device("cuda")
+    std = k**-0.5
+    a_hp = (torch.randn(total_m, k, dtype=torch.bfloat16, device=dev) * std).contiguous()
+    qa, sa = to_mx_compiled(a_hp, SF_VEC)  # (total_m, k) e4m3, (total_m, sf_k) e8m0
+    b_hp = (torch.randn(e, n, k, dtype=torch.bfloat16, device=dev) * std).contiguous()
+    qb_flat, sb = to_mx_compiled(b_hp.view(e * n, k), SF_VEC)
+    qb = qb_flat.view(e, n, k)
+    sb = sb.view(e, n, sf_k)
+    b_disp = qb.transpose(1, 2)  # (E, K, N) K-contig (b.transpose(-2,-1) is contiguous)
+    a_ref = qa.float() * sa.float().repeat_interleave(SF_VEC, dim=-1)  # (total_m, k)
+    b_ref = qb_flat.float().view(e, n, k) * sb.float().repeat_interleave(SF_VEC, dim=-1)  # (e,n,k)
+    offs = torch.tensor(list(itertools.accumulate(group_sizes)), dtype=torch.int32, device=dev)
+    return qa, b_disp, offs, sa, sb, a_ref, b_ref
+
+
+def _ref_grouped(a_ref, b_ref, group_sizes):
+    outs, start = [], 0
+    for g, gs in enumerate(group_sizes):
+        outs.append(a_ref[start : start + gs] @ b_ref[g].T)  # (gs, n)
+        start += gs
+    return torch.cat(outs)
+
+
+@pytest.mark.parametrize("api", ["eager", "prepared"])
+@pytest.mark.parametrize("k,n", [(256, 256), (512, 512), (6144, 4096)])
+@pytest.mark.parametrize(
+    "route,group_sizes",
+    [
+        ("uniform", (256, 256, 256, 256)),  # uniform 128-aligned -> batched-L
+        ("varlen", (128, 256, 384, 256)),  # ragged 128-aligned   -> varlen-M
+        ("padded", (100, 300, 200, 424)),  # ragged non-128       -> padded
+    ],
+)
+def test_mxfp8_grouped_gemm(api, route, group_sizes, k, n):
+    _skip_if_not_sm100()
+    from quack.mxfp8_grouped_gemm import make_mxfp8_grouped_gemm_runner, mxfp8_grouped_gemm
+
+    qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
+    if api == "eager":
+        out = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
+    else:
+        out = make_mxfp8_grouped_gemm_runner(qa, b_disp, offs, sa, sb)()
+    assert out.shape == (sum(group_sizes), n)
+    ref = _ref_grouped(a_ref, b_ref, group_sizes)
+    torch.testing.assert_close(out.float(), ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("k,n", [(512, 512), (6144, 4096)])
+@pytest.mark.parametrize(
+    "route,group_sizes",
+    [
+        ("uniform", (256, 256, 256, 256)),
+        ("varlen", (128, 256, 384, 256)),
+        ("padded", (100, 300, 200, 424)),
+    ],
+)
+def test_mxfp8_grouped_gemm_eager_prepared_bitwise(route, group_sizes, k, n):
+    """The eager and prepared APIs compile the SAME GemmSm100 kernel, so their
+    outputs must be bit-identical -- not merely within tolerance. This pins the
+    scale-pack / reshape plumbing: a subtly-wrong prepared path could still pass
+    the 1e-2 dequant check above but would diverge here. (Unlike a cross-kernel
+    bitwise check vs torch._scaled_grouped_mm, this is robust -- it does not
+    depend on neither side picking split-K.)"""
+    _skip_if_not_sm100()
+    from quack.mxfp8_grouped_gemm import make_mxfp8_grouped_gemm_runner, mxfp8_grouped_gemm
+
+    qa, b_disp, offs, sa, sb, _, _ = _make_grouped_mxfp8(group_sizes, k, n)
+    eager = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
+    prepared = make_mxfp8_grouped_gemm_runner(qa, b_disp, offs, sa, sb)()
+    assert torch.equal(eager, prepared), (
+        f"eager vs prepared not bit-identical: "
+        f"{(eager != prepared).sum().item()}/{eager.numel()} elems differ"
+    )

--- a/tests/test_mxfp8_grouped_gemm.py
+++ b/tests/test_mxfp8_grouped_gemm.py
@@ -153,3 +153,30 @@ def test_mxfp8_grouped_gemm_uniform_fastpath(group_sizes, k, n):
     )
     assert torch.equal(fast, routed)  # functional fast path == routed
     assert torch.equal(cls_fast, routed)  # class uniform path == routed
+
+
+@pytest.mark.parametrize("k,n", [(512, 512), (4096, 4096)])
+@pytest.mark.parametrize(
+    "group_sizes",
+    [
+        (128, 256, 384, 256),  # ragged 128-aligned
+        (256, 0, 256, 256),  # empty expert
+        (1792, 128, 128, 128),  # heavy skew
+    ],
+)
+def test_mxfp8_grouped_gemm_varlen_fastpath(group_sizes, k, n):
+    """The sync-free varlen fast path (varlen=True: natural SFA via the kernel's
+    sfa_tile_aligned path; offs consumed only on device) is correct vs the dequant
+    reference, agrees with the default offs-routed call, and the function and class
+    varlen paths are bit-identical to each other."""
+    _skip_if_not_sm100()
+    from quack.mxfp8_grouped_gemm import MXFP8GroupedGemm, mxfp8_grouped_gemm
+
+    qa, b_disp, offs, sa, sb, a_ref, b_ref = _make_grouped_mxfp8(group_sizes, k, n)
+    ref = _ref_grouped(a_ref, b_ref, group_sizes)
+    routed = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb)
+    fast = mxfp8_grouped_gemm(qa, b_disp, offs, sa, sb, varlen=True)
+    cls_fast = MXFP8GroupedGemm(b_disp, sb)(qa, offs, sa, varlen=True)
+    torch.testing.assert_close(fast.float(), ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(fast.float(), routed.float(), atol=1e-2, rtol=1e-2)
+    assert torch.equal(fast, cls_fast)  # function and class varlen paths agree exactly


### PR DESCRIPTION
## Summary

Adds `mxfp8_grouped_gemm` — a per-expert **grouped** MXFP8 GEMM with a
`torch._scaled_grouped_mm`-style interface (2D-A / 3D-B + cumulative `offs`) — that
**routes onto the SM100 blockscaled kernels quack already ships** (dense batched-`L`
for uniform groups, varlen-M for ragged), plus one small, gated kernel addition
(`sfa_tile_aligned`) that lets the varlen-M path consume natural-layout scales.

Motivation: MoE needs a grouped MXFP8 matmul over a (often ragged) batch of experts.
`torch._scaled_grouped_mm` covers this on the PyTorch side; this gives quack a native
equivalent. On B200 it is **faster than `torch._scaled_grouped_mm` on both uniform
(~1.2–1.25×) and ragged 128-aligned (~1.06–1.09×) shapes** (numbers below), and is
correct across heavy skew and empty experts.

## API

```python
from quack.mxfp8_grouped_gemm import mxfp8_grouped_gemm, MXFP8GroupedGemm

# plain call, torch._scaled_grouped_mm-style
out = mxfp8_grouped_gemm(a, b, offs, sfa, sfb)

# sync-free fast path for equal groups (fixed-capacity MoE): route derived from
# shapes, offs never read on the host -> no device->host sync
out = mxfp8_grouped_gemm(a, b, offs, sfa, sfb, uniform=True)

# sync-free fast path for ragged 128-aligned groups: offs consumed only on device
out = mxfp8_grouped_gemm(a, b, offs, sfa, sfb, varlen=True)

# prepared instance (pre-packs the fixed B-scale + reuses the cached compile)
gemm = MXFP8GroupedGemm(b, sfb)        # b/sfb = fixed expert weights
out = gemm(a, offs, sfa)               # per step (offs may change per call)
out = gemm(a, offs, sfa, out=buf)      # reuse an output buffer
```

### Contract (mirrors `torch._scaled_grouped_mm`, 2D-A / 3D-B + `offs`)

| arg    | shape             | dtype             | notes                                                       |
| ------ | ----------------- | ----------------- | ---------------------------------------------------------- |
| `a`    | `(total_m, K)`    | `float8_e4m3fn`   | K-contiguous                                                |
| `b`    | `(E, K, N)`       | `float8_e4m3fn`   | K-contiguous (`b.transpose(-2, -1).is_contiguous()`)        |
| `offs` | `(E,)`            | `int32`           | **cumulative** per-group end rows; `offs[-1] == total_m`    |
| `sfa`  | `(total_m, K//32)`| `float8_e8m0fnu`  | raw per-block (1×32) scales, K-contiguous                   |
| `sfb`  | `(E, N, K//32)`   | `float8_e8m0fnu`  | raw per-block scales, K-contiguous                          |
| `out`  | `(total_m, N)`    | `bfloat16`        | optional, contiguous                                        |

Returns bf16 `(total_m, N)`.

## Routing

`offs` is inspected once (a single host sync), then dispatched to one of three paths
— all backed by existing kernels:

| case                                | route                                                         |
| ----------------------------------- | ------------------------------------------------------------ |
| uniform groups, all `g % 128 == 0`  | reshape to batched-`L` → dense `mxfp8_gemm_out`              |
| ragged, all boundaries `% 128 == 0` | varlen-M, **natural-layout SFA** (`sfa_tile_aligned`)         |
| ragged, non-128 boundaries          | pad each group up to a 128 multiple → batched-`L` dense       |

The varlen route packs SFA in **natural (unpadded)** layout
(`pack_scale_2d_to_blocked_contig`, exactly like torch's `to_blocked`) and the kernel
offsets per expert by `cu_seqlens[b] // 128` — no per-call dQaccum scatter (see below).

### Kernel change: `sfa_tile_aligned` (varlen-M)

`offset_batch_SFA` previously offset SFA by `cu_seqlens[b] // 128 + b` (dQaccum-padded);
the `+ b` slack exists so per-expert seqlens can be **arbitrary** (each rounds up to a
whole 128-tile). For **128-aligned** boundaries that slack is unnecessary, so a new
compile-time `sfa_tile_aligned` flag uses the natural offset `cu_seqlens[b] // 128` and
the caller passes SFA unpadded. Plumbed `GemmSm100 → offset_batch_SFA` via
`compile_blockscaled_gemm_tvm_ffi`; **default `False` preserves the existing dQaccum path,
and sm90/sm120 are untouched.** This removes the per-call scale-rearrange tax — the only
thing that kept ragged below torch — without touching the GEMM math (bit-identical; see
Correctness).

### Sync-free uniform fast path (`uniform=True`)

The per-call `offs`→host sync needed to route on the host is a full stream
synchronize: it gates the kernel launch on a host decision and injects a ~100 µs
launch bubble the GPU can't hide, which alone drops the plain call below torch. For
**equal groups** (fixed-capacity MoE) the route is *shape-determined* (`g = total_m
// E`), so `uniform=True` skips reading `offs` entirely — no sync, no bubble — and
runs the dense batched-`L` path directly. It is a bit-identical shortcut of the
default routed call.

### `MXFP8GroupedGemm` (prepared instance)

A callable that bakes the fixed B operand: the constructor pre-packs the B-scale and
the call reuses the cached compiled kernel, so each call does only the A-scale pack +
the kernel. Holding the packed B-scale as instance state (vs re-packing per call)
keeps it `>=` torch even at small group sizes, where the plain `uniform=True`
function's per-call B-pack would otherwise dominate a tiny kernel. Per-call work is
on the passed tensors, so it composes with CUDA-graph replay (call once on the
capture tensors, then update `a` / `sfa` / `out` in place between replays).

## Correctness

`tests/test_mxfp8_grouped_gemm.py`:

1. **Parity** — all 3 routes × `{eager, prepared}` × `{(256,256), (512,512), (6144,4096)}`,
   checked against a per-group **dequant** reference (`atol=rtol=1e-2`).
2. **Bitwise self-consistency** — `torch.equal(eager, prepared)` across all 3 routes,
   since both APIs compile the *same* `GemmSm100` kernel. This is strictly stronger
   than the tolerance check for catching a scale-pack / reshape plumbing regression
   in the prepared path, and it is robust (no dependence on split-K heuristics).
3. **Skew + empty experts** — heavy load imbalance and size-0 groups (empty experts,
   ubiquitous in MoE), across the varlen-M and padded routes; both APIs vs the dequant
   reference and bitwise `eager == prepared`.
4. **Uniform fast path** — `uniform=True` (function) and `MXFP8GroupedGemm(..., uniform=True)`
   are each bit-identical to the default offs-routed call.
5. **Varlen fast path** — `varlen=True` (function + class) matches the dequant reference and
   the offs-routed call; the function and class varlen paths are bit-identical.
6. **Kernel `sfa_tile_aligned` differential** (`tests/test_gemm_sm100_blockscaled.py`) — on
   128-aligned uniform / ragged / empty-expert / heavy-skew seqlens, the natural-SFA path is
   **bit-identical** to the dQaccum path and matches the dequant reference.

## Performance (B200 / SM100, `nvidia-cutlass-dsl` 4.5.2)

Kernel-only, **uniform** groups, both scales pre-packed (apples-to-apples), CUDA-event
timed, min-of-3 medians. The `torch._scaled_grouped_mm` baseline is validated correct
(within `1e-2` of a fp32 dequant reference) on every shape.

| E  | g (tok/expert) | K    | N    | quack kernel | torch._scaled_grouped_mm | speedup   |
| -- | -------------- | ---- | ---- | ------------ | ------------------------ | --------- |
| 8  | 512            | 4096 | 4096 | 2401 TF/s    | 1623 TF/s                | **1.48×** |
| 8  | 1024           | 4096 | 4096 | 2586 TF/s    | 2316 TF/s                | **1.12×** |
| 8  | 2048           | 4096 | 4096 | 2784 TF/s    | 2267 TF/s                | **1.23×** |
| 8  | 4096           | 4096 | 4096 | 2880 TF/s    | 2431 TF/s                | **1.18×** |
| 8  | 1024           | 6144 | 4096 | 2723 TF/s    | 2089 TF/s                | **1.30×** |
| 8  | 2048           | 6144 | 4096 | 2847 TF/s    | 2283 TF/s                | **1.25×** |
| 8  | 1024           | 7168 | 2048 | 2530 TF/s    | 2137 TF/s                | **1.18×** |
| 8  | 2048           | 7168 | 2048 | 2815 TF/s    | 2109 TF/s                | **1.33×** |
| 8  | 1024           | 2048 | 7168 | 2451 TF/s    | 2198 TF/s                | **1.12×** |
| 8  | 2048           | 2048 | 7168 | 2628 TF/s    | 2437 TF/s                | **1.08×** |
| 16 | 1024           | 4096 | 4096 | 2659 TF/s    | 2673 TF/s                | **0.99×** |
| 16 | 512            | 6144 | 4096 | 2551 TF/s    | 2343 TF/s                | **1.09×** |

**Geomean speedup: 1.19×** (range 0.99–1.48×; quack faster on 11/12, ~parity on the
largest E16 case).

**Varlen (ragged) route, end-to-end (K6144/N4096), vs torch ragged** (baseline validated
correct). The natural-SFA path makes ragged SFA prep just a `pack` (what torch pays for
`to_blocked`), removing the dQaccum rearrange tax → ragged now **beats torch**:

| ragged distribution | SFA prep | vs torch |
| ------------------- | -------- | -------- |
| balanced            | dQaccum (old)                    | 0.99× |
| balanced            | **natural (`sfa_tile_aligned`)** | **1.06×** |
| heavy-skew          | dQaccum (old)                    | 0.96× |
| heavy-skew          | **natural (`sfa_tile_aligned`)** | **1.09×** |

(Arbitrary non-128 seqlens still use the dQaccum path / the padded dense fallback.)

**End-to-end API perf (uniform).** The default plain call pays a per-call `offs`→host
sync — a full stream synchronize that gates the kernel launch and injects a ~100 µs
bubble — which caps it below torch. The sync-free paths recover the kernel win
(all relative to `torch._scaled_grouped_mm` = 1.0):

| E×g (K/N=4096, *=K6144) | plain (routed) | `uniform=True` | `MXFP8GroupedGemm` (uniform) |
| --- | --- | --- | --- |
| 8×512   | 0.50× | 0.77× | **1.16×** |
| 8×1024  | 0.56× | 1.01× | **1.23×** |
| 8×2048* | 0.81× | 1.08× | **1.25×** |
| 16×1024 | 0.71× | 1.02× | **1.25×** |

`uniform=True` removes the sync (≥ torch for g ≥ 1024); the prepared instance also
pre-packs the B-scale, so it stays ≥ torch including small g. These end-to-end numbers
are noisier than the kernel-only table (~20% run-to-run, no clock pinning) and vary with
hardware / driver / cutlass-dsl version — treat as indicative.

## Bitwise note (correctness, not a guarantee)

On the uniform shapes we compared directly with `torch.equal` (K = 512–6144, several
per-group sizes), the output is **bit-identical** to `torch._scaled_grouped_mm` — even
though quack is faster. Both lower to the same tcgen05 blockscaled MMA; with enough M
to fill the SMs **neither uses split-K**, so K is accumulated in the same sequential
fp32 order with a single bf16 epilogue round → identical bits. The speedup is
pipelining/scheduling, which does not change the accumulation *order*.

This is **not asserted** in the tests on purpose: it is fragile by nature — split-K
(e.g. small-M / large-K shapes) tree-reduces in a different order, and any tile /
cluster / kernel-version change breaks it. So the cross-kernel test stays at `1e-2`
tolerance, and only the `eager == prepared` invariant (same kernel) is pinned bitwise.

## Implementation notes

- New files: `quack/mxfp8_grouped_gemm.py` + `tests/test_mxfp8_grouped_gemm.py`.
- Small **gated** kernel change: `quack/varlen_utils.py` (`offset_batch_SFA` +
  `sfa_tile_aligned`), `quack/gemm_sm100.py` (config attr + call site),
  `quack/blockscaled_gemm_utils.py` (`compile_blockscaled_gemm_tvm_ffi` flag), and a
  differential test in `tests/test_gemm_sm100_blockscaled.py`. Default off; sm90/sm120
  untouched.
- Reuses `mxfp8_gemm_out`, `_compile_cached`, `_default_tiler_cluster`,
  `compile_blockscaled_gemm_tvm_ffi`, `pack_scale_2d_to_blocked_contig`,
  `scale_view_for_kernel`.
- The dense route passes **raw** e8m0 scales (the interface packs internally); the
  varlen route passes **natural pre-packed** scales directly.
- The varlen kernel is `lru_cache`'d on `(n, k, e, tiler, cluster, sfa_tile_aligned)` —
  `cute.sym_int` abstracts `total_m`, so one compile serves all group configs of that shape.

## Limitations / future work

- Arbitrary **non-128** per-expert seqlens still use the dQaccum path / padded dense
  fallback; the natural-SFA fast path requires 128-aligned boundaries (caller-asserted
  via `varlen=True`, or detected by the default router).
- The default plain call still pays one `offs`→host sync to *route*; use `uniform=True` /
  `varlen=True` (or the `MXFP8GroupedGemm` instance) to avoid it when the regime is known.
- `mxfp8_gemm_out` exposes only `mma_tiler_mn` / `cluster_shape_mn`; finer epilogue /
  staging knobs could add a few % on some shapes.
- Requires `nvidia-cutlass-dsl >= 4.5.2` (uses `OperandMajorMode`; the 4.5.x scale
  layout, `(l, rm, rk, 512)`).
