### PR TITLE
Avoid pre-electing bulk G2S copies

### DIFF
--- a/quack/copy_utils.py
+++ b/quack/copy_utils.py
@@ -957,21 +957,19 @@ def cpasync_bulk_get_copy_fn(
     def copy_bulk(src_idx, dst_idx, tma_bar_ptr: cute.Pointer, **new_kwargs):
         assert dst_is_smem and not src_is_smem, "cp.async.bulk G2S expects GMEM -> SMEM"
         atom = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), src.element_type)
-        with cute.arch.elect_one():
-            cute.copy(
-                atom,
-                src[None, src_idx],
-                dst[None, dst_idx],
-                mbar_ptr=tma_bar_ptr,
-                **new_kwargs,
-                **kwargs,
-            )
+        cute.copy(
+            atom,
+            src[None, src_idx],
+            dst[None, dst_idx],
+            mbar_ptr=tma_bar_ptr,
+            **new_kwargs,
+            **kwargs,
+        )
 
     def copy_bulk_single_stage(tma_bar_ptr: cute.Pointer, **new_kwargs):
         assert dst_is_smem and not src_is_smem, "cp.async.bulk G2S expects GMEM -> SMEM"
         atom = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), src.element_type)
-        with cute.arch.elect_one():
-            cute.copy(atom, src, dst, mbar_ptr=tma_bar_ptr, **new_kwargs, **kwargs)
+        cute.copy(atom, src, dst, mbar_ptr=tma_bar_ptr, **new_kwargs, **kwargs)
 
     return copy_bulk if const_expr(not single_stage) else copy_bulk_single_stage
 


### PR DESCRIPTION
Follow-up to https://github.com/Dao-AILab/flash-attention/issues/2677(Finding 2) and https://github.com/Dao-AILab/flash-attention/pull/2689.

## Summary

`cute.copy` now emits the required single-lane election internally for async bulk copy atoms that lower through the `cute.copy` path. This PR removes the redundant outer `cute.arch.elect_one()` around Quack's G2S `cute.copy(CopyBulkG2SOp)` helper in `cpasync_bulk_get_copy_fn`.

Keeping both elections nests `elect_one()` around the bulk G2S copy. That can produce functionality issues once the CUTLASS DSL lowering also emits the election. Direct async bulk instructions that bypass `cute.copy`, such as the inline-PTX `cp.reduce.async.bulk` S2G path, still need their explicit election and are intentionally left unchanged here.

## SM90 Backward Finding

We hit failing FlashAttention SM90 backward varlen kernel loads LSE/dPsum through
Quack's `cpasync_bulk_get_copy_fn(gmem, smem)`. With the old Quack wrapper, that path pre-elects before calling `cute.copy(CopyBulkG2SOp)`. On a CUTLASS DSL build where `cute.copy` already emits the bulk-copy election, this creates nested election around the G2S TMA copy and reproduces the reported Hopper
failure as `cudaErrorIllegalInstruction (error code: 715)` during backward.

Removing the Quack-side wrapper lets the compiler-owned election issue the
async bulk copy from the expected context and fixes the SM90 backward case.

## Validation

Focused FlashAttention test:

```bash
flash-attention/tests/cute/test_flash_attn.py::test_flash_attn_varlen_output[True-True-True-True-random-1024-1023-192-False-True-0-0.0-False-False-False-mha-dtype0]
```

Environment:

- GPU: H200 / `sm_90a`
- FlashAttention: `6f644f9eb89c0572887986187cb0efca285a50f5`
- FlashInfer: `2099bac460994d2e6532935f1ad760a79a153f52`
- CUTLASS DSL package: `nvidia-cutlass-dsl=4.6.0a0+20260626210442.fb699d4`

Results:

- Unpatched reported Quack SHA `0735c7d47572bff49b334d5edf35731dffbd2465`:
  hit `cudaErrorIllegalInstruction (error code: 715)`.
- This PR / fix commit `af6bc485c1abbf56686dd25cf21d8adc5703370a`: same
  focused SM90 backward case passed with `1 passed in 36.22s`.

## Dependency Note

This change should be merged with a CUTLASS DSL release that emits the required
election inside `cute.copy` for async bulk copy atoms. If Quack is used with an
older DSL build where `cute.copy` does not emit that election, these G2S
bulk-copy paths still require an explicit `elect_one()`.
