### PR TITLE
[DSL] Update to cutlass-dsl==4.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quack-kernels"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0.dev0",
+    "nvidia-cutlass-dsl==4.6.0",
     "torch",
     "apache-tvm-ffi>=0.1.6,<0.2",
     "torch-c-dlpack-ext",
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0.dev0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0"]
 heuristics = ["nvidia-matmul-heuristics"]
 jax = ["jax", "jax-tvm-ffi"]
 bench = ["pandas"]


### PR DESCRIPTION
Follow-up to #151 — the code is already 4.6-compatible, this moves the pin
off the pre-release now that 4.6.0 stable is on PyPI (released 2026-07-02).

The `==4.6.0.dev0` pin also breaks downstream resolution: uv avoids
pre-releases in transitive dependencies and backtracks to quack-kernels
0.5.0, which still uses the removed `cute.core.ThrMma` API — so installs
via packages like `mamba-ssm` started failing today with
`AttributeError: module 'cutlass.cute.core' has no attribute 'ThrMma'`.