### PR TITLE
[GEMM] Full blockscaled MXFP4/6/8 QMMA and MXFP4/NVFP4 OMMA support for SM100 GEMM

### DIFF
--- a/AI/blockscaled_api.md
+++ b/AI/blockscaled_api.md
@@ -77,7 +77,6 @@ constraints anchor the rationale where noted.
   activations or accept dim1-requant error (the standard MX tradeoff).
 - **NVFP4 outputs with a computed global amax** (needs a delayed or two-pass amax;
   section 7 requires an explicitly provided per-tensor scale instead).
-- **An e5m2 `to_mx` encoder** (`from_parts` is the e5m2 construction path).
 
 ## 3. `BlockScaledFormat` and `BlockScaledOperand` (`quack/blockscaled/operand.py`)
 
@@ -110,8 +109,8 @@ class BlockScaledFormat:
   GEMM can execute a given (A, B, D) dtype combination is asserted per-architecture
   inside the `gemm_smXXX` classes (SM100 accepts any fp8/fp6/fp4 mix under
   kind::mxf8f6f4 - see section 6).
-- E5M2: descriptor + `from_parts` work (the kernel admits e5m2); `quantize` raises
-  because `to_mx` has no e5m2 encoder - `from_parts` is the e5m2 construction path.
+- E5M2: `quantize` encodes via `to_mx(..., elem_dtype=torch.float8_e5m2)`
+  (fp8_max 57344, max_pow2 15); `from_parts` also works for pre-quantized data.
 - `mxfp4_byte` and unversioned byte-container MXFP6 checkpoints retain their logical
   shape and dequantization after load. They are host-side compatibility formats only;
   `BlockScaledOperand.to_packed()` preserves their codes/scales exactly for GEMM use.
@@ -443,7 +442,7 @@ but that is the D5 trap again and breaks on the first same-rank layout.
   (e8m0 keeps the floor rule). bf16 and int-group formats RAISE - floating-
   point relative precision is scale-invariant and group scales are upstream-
   structural (GPTQ/AWQ groups, folded norms), so `from_parts` is the
-  construction path (the e5m2 precedent).
+  construction path.
 
 ### 9.4 Scale layouts (per-operand)
 

--- a/AI/blockscaled_api.md
+++ b/AI/blockscaled_api.md
@@ -30,18 +30,22 @@ constraints anchor the rationale where noted.
 | D1 | **The container is a non-differentiable plain object** - a frozen dataclass, not a `torch.Tensor` subclass, so it structurally cannot enter autograd. Training on quantized operands is out of scope by design: a forward-quantized operand is scaled along the wrong axis for both backward GEMMs (dgrad contracts N, wgrad contracts M; scales block along K), and the square-weight case (K==N) fails *silently*. Any training story is hp master weights + per-GEMM requantization, layered above this container. |
 | D2 | **`shape`/`dtype` report the logical hp view** (unpacked shape, `orig_dtype`, default bf16) as honest computed properties. Storage truth lives in `qdata`/`scale`. The container is unpacked at the top of each public entry point (where `_unpack_operand` sits); **nothing below that line ever sees it** - custom ops, autotuner, `jit_cache`, TVM-FFI all see flat plain tensors. |
 | D3 | **Transpose = qdata stride-swap view; scale untouched.** The blocked `(rm, rk, 32, 4, 4)` scale atom is not view-transposable; scale is defined as "always blocked along K in either orientation". Preserves the load-bearing `weight.T` / `qw.mT` idiom. qdata<->scale shape coupling is validated at gemm dispatch time (`validate_blockscaled_sf`), NOT at construction - varlen padded scale buffers must stay constructible. |
-| D4 | **Format = frozen dataclass descriptor** (`BlockScaledFormat`), not an enum: storage dtype, elem bits, elems-per-container, scale dtype, sf_vec_size, k-alignment are *data per format*. New formats are data, not code. Registry + singletons; legacy string names (`"mxfp8"`) coerce. |
+| D4 | **Format = frozen dataclass descriptor** (`BlockScaledFormat`), not an enum: storage dtype, elem bits, packing, scale dtype, sf_vec_size, k-alignment are *data per format*. New formats are data, not code. Registry + singletons; legacy string names (`"mxfp8"`) coerce. |
 | D5 | **Format crosses the custom-op boundary explicitly** as a scalar `bs_format: str` op-schema arg. Formats are never derived from tensor dtypes (no `SF_DTYPE_TO_VEC_SIZE` table, no fp4 `A.dtype` logical-K special case, no `gemm_blockscaled_ref` sf-vec ternary); `_sf_decode` is format-driven - this kills the "uint8 scale view decoded as e8m0 => NVFP4 silently runs as vec-32 MXFP8" trap. There is NO dtype->format inference site anywhere (the tuple path's `_legacy_format_from_dtypes`, the last one, was deleted with tuple support - D10). |
-| D6 | **MXFP6 qdata = byte-per-element `uint8`** (identity K shape map): matches the PTX `kind::mxf8f6f4` 8-bit SMEM container, CUDA `__nv_fp6_storage_t`, cuBLASLt `CUDA_R_6F_*`; torchao does the same. Documented consequence: byte-per-element MXFP6 has fp8's bandwidth - its value is accuracy headroom over MXFP4, not speed. A packed-6-bit gmem format (CUTLASS 16U6 TMA) would change only descriptor data. |
+| D6 | **MXFP6 qdata = packed 6-bit storage carried in `uint8` bytes**: a little-endian 6-bit stream, element i at bits [6i, 6i+6) - the CUTLASS SubbyteReference layout (`pack_uint6`/`unpack_uint6` in quantize.py). Packed gmem is what the TMA-unpack path consumes (section 6) and keeps fp6's bandwidth advantage over fp8. torch has no fp6 dtype, so the packed stream crosses the FFI boundary as raw `torch.uint8` of shape `(..., 3K/4)` - see section 5 and the boundary notes in section 6. |
 | D7 | **Loud failure, explicit surface.** No aten interception: torch ops reject the non-tensor container with a plain `TypeError`; the supported surface is the explicit methods (`mT`/`T`/`transpose` restricted to last-two-dims, `to(device)` - dtype conversion raises pointing at `dequantize()`, `clone`, `dequantize`). **No dequantize fallback** in a kernels library. Targeted `TypeError` guards at non-blockscaled entry points (`gemm_dact`, `gemm_symmetric`, `gemm_rms`, `gemm_norm_act`) for message quality. |
 | D8 | **`per_tensor_scale` is a field** (NVFP4 only). `gemm` folds `pts_A * pts_B` into alpha at the unwrap site via the existing *tensor-alpha* path (no `.item()` sync; nvfp4-with-pts compiles the tensor-alpha kernel variant). |
 | D9 | **torch.compile support via pytree registration** plus a normal inlineable construction helper for in-graph quantize. It must not use `allow_in_graph`: that makes Dynamo treat the helper as an opaque op, whose non-Tensor `BlockScaledOperand` return is illegal under `fullgraph=True`. `_sf_encode` (e8m0->uint8 view across the op boundary, an Inductor `decompose_auto_functionalized` workaround) sits at the unwrap site. |
 | D10 | **Containers are the only blockscaled operand form**: `(data, scale_factor)` tuples/lists are rejected at the unwrap site with a `TypeError` pointing at `BlockScaledOperand.from_parts`. Every blockscaled operand is therefore construction-validated before it reaches a GEMM. `blockscaled_quantize` / `blockscaled_quantize_dim0` keep their raw `(q, sf)` returns - they are quantizers, not operand constructors (changing the return silently corrupts `qa, sfa = ...` call sites); wrap via `from_parts`, or use `BlockScaledOperand.quantize` directly. The TVM-FFI direct path (`compile_blockscaled_gemm_tvm_ffi`) is plain-tensors-only forever. |
-| D11 | **A and B carry independent formats end-to-end** (`bs_format_a` / `bs_format_b` through every layer, including the op schemas). Pair *legality* is hardware fact, owned by `mma_kind_for_pair` in `operand.py` (PTX: `mxf4nvf4` and `mxf4` need matching element types; `mxf8f6f4` mixes fp8/fp6/fp4 freely but stores every element as an **8-bit container** - so packed-fp4x2 operands cannot join mixed pairs; the byte-container `mxfp4_byte` registry entry is what a mixed pair consumes). Pair *implementation* is enforced **per-architecture**: each `gemm_smXXX` kernel class owns the asserts for the (A, B, SF, D) dtype combinations it supports (`GemmSm100.is_valid_dtypes_and_scale_factor_vec_size`, asserted in its blockscaled setup path; different SM versions support different mx dtypes). SM100's matrix admits **mixed fp8 pairs (e4m3 x e5m2, both orders)**: the DSL's `MmaMXF8F6F4Op` takes independent a/b dtypes, and instruction-K is kind-derived (mxf4/mxf4nvf4 => 64 elements, mxf8f6f4 => 32), not element-width-derived. Pairs involving fp4/fp6 sit outside SM100's matrix; section 6 describes the registry and plumbing groundwork for them and the intended smem-expansion mechanism. `validate_blockscaled_sf` checks per-operand dtypes and cross-checks logical K (`A.shape[-1]*epc_a == B.shape[-1]*epc_b` - packings may differ). |
+| D11 | **A and B carry independent formats end-to-end** (`bs_format_a` / `bs_format_b` through every layer, including the op schemas). Pair *legality* is hardware fact, owned by `mma_kind_for_pair` in `operand.py`, which returns `"mxf8f6f4"` for every non-nvfp4, non-both-mxfp4 pair (PTX: `mxf4nvf4` and `mxf4` need matching element types; `mxf8f6f4` mixes fp8/fp6/fp4 freely, with sub-byte operands TMA-unpacked from packed gmem into 8-bit SMEM containers). Pair *implementation* is enforced **per-architecture**: each `gemm_smXXX` kernel class owns the asserts for the (A, B, SF, D) dtype combinations it supports (`GemmSm100.is_valid_dtypes_and_scale_factor_vec_size`, asserted in its blockscaled setup path; different SM versions support different mx dtypes). SM100's matrix admits **mixed fp8 pairs (e4m3 x e5m2, both orders)**: the DSL's `MmaMXF8F6F4Op` takes independent a/b dtypes, and instruction-K is kind-derived (mxf4/mxf4nvf4 => 64 elements, mxf8f6f4 => 32), not element-width-derived. **Mixed pairs involving fp4/fp6 run via the TMA-unpack path** (section 6): packed gmem + `internal_type=Uint8` + byte-domain SMEM; the `a/b_mma_dtype` split through both compile paths carries the packed-fp6 boundary dtype. `validate_blockscaled_sf` checks per-operand dtypes and cross-checks logical K via the formats' `logical_k` mapping - packings may differ. |
 | D12 | **Blockscaled output D is a first-class API**: `out_dtype: torch.dtype \| BlockScaledFormat \| str` on `gemm`/`gemm_add`/`gemm_act(+postact_dtype)`; the op-schema plumbing is `SFD` (mutated) + `bs_format_d`, completing the (a, b, d) format triple. See section 7. |
 
 ### Rejected alternatives
 
+- **Raw `(data, scale_factor)` tuple operands**: the original convention; kept
+  briefly behind a `DeprecationWarning`, then removed (D10). Ambiguous detection,
+  no fp6, silently dropped NVFP4 per-tensor scales, and required a dtype->format
+  inference site (section 1).
 - **torchao `MXTensor` dependency**: its 2-D lazily swizzled scales do not fit quack's
   permanently-blocked scale atom or varlen padded buffers.
 - **Enum-based format**: recreates the switch-on-format duplication one level up; the
@@ -53,6 +57,11 @@ constraints anchor the rationale where noted.
   frozen dataclass. The container's field set and constructors are exactly what a
   tensor-subclass wrapper would hold, so module citizenship can layer on top later
   without breaking this API.
+- **Byte-container gmem formats for sub-byte elements** (one uint8 byte per fp4/fp6
+  element): rejected because TMA unpack consumes packed gmem directly (section 6), so
+  byte containers would only double (fp4) or inflate by 4/3 (fp6) the gmem traffic
+  and duplicate registry entries; the packed formats serve homogeneous and mixed
+  pairs alike.
 
 ### Out of scope
 
@@ -75,11 +84,10 @@ constraints anchor the rationale where noted.
 ```python
 @dataclass(frozen=True)
 class BlockScaledFormat:
-    name: str                    # "mxfp8_e4m3" | "mxfp8_e5m2" | "mxfp4" | "mxfp4_byte" | "nvfp4" | "mxfp6_e2m3" | "mxfp6_e3m2"
-    qdata_dtype: torch.dtype     # e4m3 | e5m2 | float4_e2m1fn_x2 | uint8 (byte-container fp4/fp6)
-    elem_bits: int               # 8 | 4 | 6
-    elems_per_container: int     # 1 | 2 (fp4x2)
+    name: str                    # "mxfp8_e4m3" | "mxfp8_e5m2" | "mxfp4" | "nvfp4" | "mxfp6_e2m3" | "mxfp6_e3m2"
+    qdata_dtype: torch.dtype     # e4m3 | e5m2 | float4_e2m1fn_x2 | uint8 (packed fp6)
     cutlass_dtype_name: str      # CuTe-DSL MMA element type (may differ from storage: fp6)
+    elem_bits: int               # 8 | 4 | 6
     scale_dtype: torch.dtype     # float8_e8m0fnu | float8_e4m3fn
     sf_vec_size: int             # 32 | 16 (also the min logical-K divisibility)
     has_per_tensor_scale: bool   # nvfp4 only
@@ -87,14 +95,17 @@ class BlockScaledFormat:
 
 - Hashable/picklable -> usable as dynamo guard ctx and kernel-cache key material; only
   `name` crosses the op schema.
-- `logical_k(packed_k)` / `packed_k(logical_k)`; `to_cutlass_dtype()` (lazy cutlass
-  import: `Float8E4M3FN`, `Float8E5M2`, `Float4E2M1FN`, `Float6E2M3FN`, `Float6E3M2FN`);
-  `from_name`, `from_cutlass_dtypes`.
-- Kernel support is NOT a registry property: fp6 descriptors are registered and
-  constructible (checkpoints, round-trips), and whether a GEMM can execute a given
-  (A, B, D) dtype combination is asserted per-architecture inside the `gemm_smXXX`
-  classes (SM100's matrix admits fp8 pairs, including mixed e4m3 x e5m2, and
-  homogeneous fp4; fp6 and mixed sub-byte pairs sit outside it - see section 6).
+- `logical_k(storage_k)` / `storage_k(logical_k)` map between the logical element
+  extent and the storage extent, derived from `elem_bits` (fp4: 2 elements per byte,
+  fp6: 4 elements per 3 bytes - an integer elems-per-container field cannot express
+  that ratio); `is_packed` marks sub-byte packed storage. `to_cutlass_dtype()` (lazy
+  cutlass import: `Float8E4M3FN`, `Float8E5M2`, `Float4E2M1FN`, `Float6E2M3FN`,
+  `Float6E3M2FN`); `from_name`, `from_cutlass_dtypes`.
+- Kernel support is NOT a registry property: descriptors are registered and
+  constructible (checkpoints, round-trips) independently of any kernel, and whether a
+  GEMM can execute a given (A, B, D) dtype combination is asserted per-architecture
+  inside the `gemm_smXXX` classes (SM100 accepts any fp8/fp6/fp4 mix under
+  kind::mxf8f6f4 - see section 6).
 - E5M2: descriptor + `from_parts` work (the kernel admits e5m2); `quantize` raises
   because `to_mx` has no e5m2 encoder - `from_parts` is the e5m2 construction path.
 
@@ -110,14 +121,14 @@ class BlockScaledOperand:
 ```
 
 - **Logical metadata as computed properties**: `shape` (unpacked; packed dim = the
-  unit-stride dim of qdata - fp4 formats are K-major by kernel requirement, so
-  unit-stride == packed == K), `dtype = orig_dtype` (hp provenance; storage truth is
-  `qdata.dtype`), `device`, `ndim`.
+  unit-stride dim of qdata - packed sub-byte formats are K-major by kernel
+  requirement, so unit-stride == packed == K), `dtype = orig_dtype` (hp provenance;
+  storage truth is `qdata.dtype`), `device`, `ndim`.
 - **Quantized axis** `quant_dim in {-1, -2}`: which logical dim the scale vector runs
   along - the direct analogue of CUTLASS's `UMMA::Major` SF-atom parameter. Storage
   alone cannot express it - a square fp8 canonical operand and its `.mT` view are
-  byte-identical. fp4 packing pins it to the packed dim (conflicting requests raise);
-  byte formats default to -1 (quantize's convention); transpose views flip it;
+  byte-identical. Sub-byte packing pins it to the packed dim (conflicting requests
+  raise); byte formats default to -1 (quantize's convention); transpose views flip it;
   `quantize(dim=-2)` and `from_parts(quant_dim=-2)` build the other direction
   directly. Carried through pytree/pickle; used by `dequantize()`. **The interface
   enforces per operand slot that the quantized axis is the contraction axis** (A: -1,
@@ -139,8 +150,9 @@ class BlockScaledOperand:
   view (re-viewed to the format dtype - canonicalization); pts only when
   `fmt.has_per_tensor_scale`. **No qdata<->scale shape coupling** (varlen buffers).
 - Constructors: `from_parts(qdata, scale, format, *, per_tensor_scale=None,
-  orig_dtype=bf16)` and `quantize(x_hp, format, *, per_tensor_scale=None)`, both via an
-  ordinary helper that Dynamo inlines through under `torch.compile`.
+  orig_dtype=bf16, quant_dim=-1)` and `quantize(x_hp, format, *, dim=-1,
+  per_tensor_scale=None)`, both via an ordinary helper that Dynamo inlines through
+  under `torch.compile`.
   Explicit `dequantize()`; never implicit. It requires the canonical dense scale
   shape: padded varlen buffers need `cu_seqlens` offsets the container does not carry,
   so dequantization rejects them rather than silently applying padding as real scales.
@@ -186,81 +198,91 @@ element-class + recipe gates in `mma_kind_for_pair`) are already in place.
 - Rejection guards (`TypeError`) at `gemm_dact`, `gemm_symmetric`, `gemm_rms`,
   `gemm_norm_act`.
 
-## 5. Kernel-path plumbing (`gemm.py`, `gemm_act.py`, `gemm_tvm_ffi_utils.py`)
+## 5. Kernel-path plumbing (`gemm.py`, `gemm_epilogue.py`, `gemm_tvm_ffi_utils.py`)
 
 - `quack.gemm.gemm` and `quack.gemm_act.gemm_act` take `bs_format_a`/`bs_format_b`,
   **both required** when SFA is passed - the kernel-level API carries formats
   explicitly, same as the custom ops.
 - `validate_blockscaled_sf(A, B, SFA, SFB, ..., fmt_a=, fmt_b=)`: per-operand vec
-  size / scale dtype / qdata dtype from the descriptors; logical K =
-  `shape[-1] * elems_per_container` per operand with an A<->B cross-check (no fp4
-  dtype special case; fp6-correct by construction); validates layout and
-  consistency ONLY - dtype-combination support is enforced per-architecture by the
-  kernel classes. **`gemm_act.py` is a full second blockscaled dispatch path** (its
-  own `validate_blockscaled_sf` call and `_compile_gemm_act` cache keys) and gets
-  identical treatment.
-- `_compile_gemm` / `_compile_gemm_act` cache keys: `(sf_dtype, sf_vec_size,
+  size / scale dtype / qdata dtype from the descriptors; logical K via each format's
+  `logical_k(storage_k)` mapping with an A<->B cross-check (no fp4 dtype special
+  case; fp6-correct by construction); validates layout and consistency ONLY -
+  dtype-combination support is enforced per-architecture by the kernel classes.
+  Activation and gated GEMMs use the shared `EpiMod` path in `gemm_epilogue.py`,
+  which performs the same validation before building a plan through `gemm_host.py`.
+- `_compile_gemm` / `_compile_gemm_epi` cache keys: `(sf_dtype, sf_vec_size,
   a_mma_dtype, b_mma_dtype)`, all derived from `fmt` at the caller. Both compile
   paths are `@jit_cache`-keyed on their full argument tuples INCLUDING the MMA
-  dtypes, so same-storage formats that differ only in element type (fp6
-  e2m3/e3m2, byte-fp4 vs fp8) key distinctly - no collision when the per-arch
-  gate admits them. The AB cute dtype comes from `torch2cute_dtype_map[A.dtype]`
-  (correct for all admitted formats). For byte-container sub-byte operands,
-  `GemmSm100` separates the MMA dtype from the copy dtype: `a/b_mma_dtype`
-  (threaded through both compile paths) drives the MMA builder and dtype-validity
-  checks, while SMEM layouts/TMA/sizes run on the storage (container) types. Note
-  that `div_for_dtype` with width 6 is non-integral, so a width-6 storage format
-  needs byte-extent handling at the `_compile_gemm`/fake-tensor level.
+  dtypes, so the two packed-fp6 encodings key distinctly despite sharing uint8
+  storage. The AB cute boundary dtype comes from
+  `torch2cute_dtype_map[A.dtype]`; for packed fp6 that is `Uint8`, while
+  `a/b_mma_dtype` drives the MMA builder and dtype-validity checks. The fake-tensor
+  spec uses a byte-extent K symbol for fp6 because `div_for_dtype` with width 6 is
+  non-integral (96 bytes = 128 logical elements).
 - `_blockscaled_format_of` is a shim over `BlockScaledFormat.from_cutlass_dtypes`.
 - `compile_blockscaled_gemm_tvm_ffi`: asserts plain tensors; docstring states the policy.
 
 ## 6. Sub-byte operands: mixed fp4/fp6/fp8
 
-SM100's tcgen05 `kind::mxf8f6f4` stores every operand element in an 8-bit SMEM
-container regardless of gmem width, and its instruction-K is kind-derived
-(mxf4/mxf4nvf4 => 64 elements, mxf8f6f4 => 32). Two design pieces support sub-byte
-elements under this kind:
+Any A/B pair of {mxfp8_e4m3, mxfp8_e5m2, mxfp4, mxfp6_e2m3, mxfp6_e3m2} runs on
+SM100 under tcgen05 `kind::mxf8f6f4` - including fp6 x fp4, where both operands
+unpack. Both-fp4 runs the single denser `kind::mxf4nvf4` atom, parameterized by the
+format's scale config (vec 32 e8m0 = mxfp4 - PTX spells that instantiation
+`kind::mxf4` - vec 16 = nvfp4, mirroring CUTLASS C++'s `SM100_MMA_MXF4_SS<..., VS>`);
+nvfp4 pairs only with itself (the scale config is instruction-wide).
 
-- **Registry**: byte-container formats `mxfp4_byte` / `mxfp6_e2m3` / `mxfp6_e3m2`
-  (uint8 storage per D6) with quantizers (the `_to_mx_floatx_unpacked` family) and
-  format-keyed dequantization.
-- **Kernel plumbing**: the mma-dtype/copy-dtype split - `a/b_mma_dtype` threaded
-  through `_compile_gemm`/`_compile_gemm_act` into `GemmSm100` (MMA builder +
-  validity on MMA types; SMEM layouts/TMA/sizes on storage types).
+**The TMA-unpack recipe (mirrors CUTLASS C++ `SmemAllocType=uint8_t`):** per unpack
+operand - a packed sub-byte gmem operand in any pair other than both-packed-fp4:
 
-Which pairs execute is each architecture's dtype matrix (D11); fp6 and fp4/fp6-mixed
-pairs sit outside SM100's matrix.
+- **gmem keeps the true sub-byte element type** (`Float4E2M1FN` / `Float6E*FN`,
+  packed). Passing `internal_type=cutlass.Uint8` to `make_tiled_tma_atom_A/B`
+  sets `use_unpack` (`cute/nvgpu/helpers.py:153-175`) and selects the
+  `TmaDataFormat.U4_UNPACK_U8` / `U6_UNPACK_U8` tensormap
+  (= `CU_TENSOR_MAP_DATA_TYPE_16U4/16U6_ALIGN16B`). Recasting gmem to Uint8
+  kills `use_unpack` (that is the sm103 example's *packed*-smem mxf4 path, a
+  different convention).
+- **Everything SMEM-side is byte-domain (Uint8)**: `make_smem_layout_a/b`
+  dtype, `MemRange` storage, stage budgeting. TMA expands each 16 packed
+  elements into a 16-byte smem footprint (8B fp4 / 12B fp6 packed chunk + gap),
+  i.e. one byte of footprint per element; no software indexes below 16B.
+- **The Uint8-typed smem tensor feeds `make_fragment_A/B` directly.** The DSL
+  never checks the fragment dtype against the MMA dtype and builds the smem
+  descriptor from width x stride products, so the byte layout yields the correct
+  LBO/SBO (16-byte units). An f4-typed `make_smem_layout_a(..., Float4E2M1FN)`
+  layout is WRONG here - that is the SW64 packed-mxf4 convention with a halved K
+  stride. The sub-byte identity reaches the instruction only via the tiled_mma's
+  `a/b_mma_dtype` (instruction-descriptor format bits).
+- **mbarrier tx counts packed bytes** (elements x 4 or 6 bits - the gaps are
+  not written), matching CUTLASS `sizeof_bits<ElementA> x cosize(SmemLayoutA)`.
+  quack's existing `size_in_bytes(a_dtype, a_smem_layout)` line does this
+  automatically once the layout is byte-domain and `a_dtype` stays sub-byte.
+- **Constraints** (CUDA driver, cuTensorMapEncodeTiled): unpack operands are
+  K-major with logical K % 128 (globalDim[0] rule; also = the 96B fp6 / 64B fp4
+  inner-extent rules), base address 32B-aligned, byte strides % 32, boxDim[0]
+  exactly 128 elements (satisfied by the SW128 byte-domain atom). Enforced:
+  arg-spec k divisibility 128 (fp4-mixed), fp6 K%128 assert in
+  `validate_blockscaled_sf`, `GemmSm100.can_implement` K%128 + per-operand
+  K-major.
 
-**TMA unpack is the intended mechanism for sub-byte SMEM expansion**, so gmem can
-stay packed:
+**Kernel structure (`gemm_sm100.py`):** per-operand `a/b_unpack` flags +
+`a/b_smem_dtype` (Uint8 when unpack) derived next to the dtype resolution;
+byte-domain smem layouts/storage/stage-budget; `internal_type=Uint8` on the A/B
+TMA atoms; the dtype gate accepts fp8/fp4/fp6 MMA dtypes in any mix (fp6 copy dtype
+may be Uint8 - see the FFI boundary below); the 16B-alignment helper uses a
+128-element granule for width 6 (16*8//6 is fractional).
 
-- `TmaDataFormat` IntEnum in the `cute_nvgpu` dialect has `U4_UNPACK_U8 = 12` and
-  `U6_UNPACK_U8 = 13`; the TMA atom op (`cute_nvgpu.atom.make_non_exec_tiled_tma_load`)
-  takes an optional `tma_format` attribute.
-- The sanctioned Python hook is `internal_type=cutlass.Uint8` on
-  `make_tiled_tma_atom_A/B` (`cute/nvgpu/helpers.py:153-175`): with a gmem tensor
-  typed sub-byte (packed fp4/fp6) and an 8-bit internal type, `use_unpack=True`
-  selects the expanding tensormap - packed gmem, byte containers in SMEM.
-- Precedent: `examples/python/CuTeDSL/blackwell/mixed_input_gemm/*` feeds packed
-  narrow operands exactly this way (then upconverts via `nvgpu.cvt_fpext`, whose
-  docstring confirms the DSL's f6 register convention is i8 with 2-bit MSB padding);
-  `sm103_dense_blockscaled_gemm_persistent.py` shows the byte-domain SMEM layout
-  pattern (`make_smem_layout_atom(K_SW128, Uint8)`, `MemRange[Uint8]`,
-  `adapt_layout_for_tma_*`).
-
-Sketch, per unpack operand (a sub-byte MMA dtype under kind mxf8f6f4): (1) packed
-gmem (the existing `mxfp4` storage; packed-6-bit gmem for fp6, 16 codes / 12 B,
-16 B-aligned rows); (2) a TMA atom with `internal_type=Uint8`; (3) SMEM
-layout/storage/load-byte counts in the byte domain (Uint8); (4) an MMA fragment over
-a hand-built layout in the MMA element's addressing domain - for fp4: outer strides
-x2 with the swizzle base shifted one bit (`cute.recast_layout` at
-`cute/core.py:4229` is the related helper; the shape must stay at logical element
-count, so hand-scale rather than recast); for fp6 (6-bit units cannot express byte
-spacing) the byte-domain layout with an f6-typed pointer - the i8-padding register
-convention suggests the MLIR addresses f6 SMEM by bytes. Plain byte storage without
-the hand-built layout leaves the fragment/descriptor width math inconsistent, and a
-naive recast keeps unscaled layouts. With TMA unpack carrying the GEMM path, the
-byte-container gmem formats serve checkpoints/interop only (quantizers stay).
+**fp6 FFI boundary:** torch has no fp6 dtype (and no `float6_x4`-style packed
+dtype to ride the way fp4 rides `float4_e2m1fn_x2`), so packed-fp6 qdata crosses
+tvm-ffi as raw `torch.uint8` of shape `(..., 3K/4)` - a little-endian 6-bit
+stream, element i at bits [6i, 6i+6), the CUTLASS SubbyteReference layout
+(bit-identical to the DSL's own fp6 fill kernel). The arg spec gives the byte
+extent an independent sym (divisibility 96 = 128 elements; the 4/3 relation
+between shared syms is not expressible - logical-K consistency is checked
+host-side), and `GemmSm100.__call__` reinterprets it via `_reinterpret_packed_fp6`
+(recast_ptr to `Float6E*FN` + logical layout: K extent x4/3, K stride stays 1,
+outer byte strides x4/3 - exact since rows are whole 96-byte groups).
+`a/b_mma_dtype` (threaded through both compile paths) is what marks the operand as
+packed fp6 at the boundary.
 
 ## 7. Blockscaled outputs: SF-generation epilogue
 
@@ -315,6 +337,10 @@ shape or smoke checks alone.
 - Compile: container as fullgraph input (attribute reads + the e8m0/Inductor
   regression); in-graph `quantize` + gemm fullgraph; an in-graph `from_parts`
   compile test with raw (q, sf) graph inputs.
+- Mixed pairs: representative fp8/fp6/fp4 A/B combinations are validated against
+  the dequantized-operand reference at the same tolerance as the fp8-pair baseline,
+  including fp6 x fp4 where both operands unpack; the packed 6-bit stream is checked
+  bit-exact against the DSL's fp6 fill kernel.
 - Numerics references: `gemm_blockscaled_ref` dequant-matmul, plus bit-exact
   `torch._scaled_mm` comparison via `scale_blocked_for_cublas`.
 

--- a/AI/blockscaled_api.md
+++ b/AI/blockscaled_api.md
@@ -229,7 +229,12 @@ SM100 under tcgen05 `kind::mxf8f6f4` - including fp6 x fp4, where both operands
 unpack. Both-fp4 runs the single denser `kind::mxf4nvf4` atom, parameterized by the
 format's scale config (vec 32 e8m0 = mxfp4 - PTX spells that instantiation
 `kind::mxf4` - vec 16 = nvfp4, mirroring CUTLASS C++'s `SM100_MMA_MXF4_SS<..., VS>`);
-nvfp4 pairs only with itself (the scale config is instruction-wide).
+nvfp4 pairs only with itself (the scale config is instruction-wide). Concretely,
+quack subclasses the DSL's `MmaMXF4NVF4Op` to un-pin its hardcoded vec 16 and
+always constructs it for both-fp4 (`quack/sm100_utils.py:
+make_blockscaled_trivial_tiled_mma`) - safe because both DSL fp4 op classes build
+the identical MLIR atom type (no kind attribute; the backend derives the PTX
+spelling from the vec size).
 
 **The TMA-unpack recipe (mirrors CUTLASS C++ `SmemAllocType=uint8_t`):** per unpack
 operand - a packed sub-byte gmem operand in any pair other than both-packed-fp4:

--- a/AI/blockscaled_api.md
+++ b/AI/blockscaled_api.md
@@ -30,14 +30,14 @@ constraints anchor the rationale where noted.
 | D1 | **The container is a non-differentiable plain object** - a frozen dataclass, not a `torch.Tensor` subclass, so it structurally cannot enter autograd. Training on quantized operands is out of scope by design: a forward-quantized operand is scaled along the wrong axis for both backward GEMMs (dgrad contracts N, wgrad contracts M; scales block along K), and the square-weight case (K==N) fails *silently*. Any training story is hp master weights + per-GEMM requantization, layered above this container. |
 | D2 | **`shape`/`dtype` report the logical hp view** (unpacked shape, `orig_dtype`, default bf16) as honest computed properties. Storage truth lives in `qdata`/`scale`. The container is unpacked at the top of each public entry point (where `_unpack_operand` sits); **nothing below that line ever sees it** - custom ops, autotuner, `jit_cache`, TVM-FFI all see flat plain tensors. |
 | D3 | **Transpose = qdata stride-swap view; scale untouched.** The blocked `(rm, rk, 32, 4, 4)` scale atom is not view-transposable; scale is defined as "always blocked along K in either orientation". Preserves the load-bearing `weight.T` / `qw.mT` idiom. qdata<->scale shape coupling is validated at gemm dispatch time (`validate_blockscaled_sf`), NOT at construction - varlen padded scale buffers must stay constructible. |
-| D4 | **Format = frozen dataclass descriptor** (`BlockScaledFormat`), not an enum: storage dtype, elem bits, packing, scale dtype, sf_vec_size, k-alignment are *data per format*. New formats are data, not code. Registry + singletons; legacy string names (`"mxfp8"`) coerce. |
+| D4 | **Format = frozen dataclass descriptor** (`BlockScaledFormat`), not an enum: storage dtype, elem bits, packing, scale dtype, sf_vec_size, k-alignment are *data per format*. New formats are data, not code. Registry + singletons; legacy string names (`"mxfp8"`) coerce. The original positional `elems_per_container` field remains in place for source/pickle compatibility; `storage_layout` versions layouts that it cannot express (packed fp6). |
 | D5 | **Format crosses the custom-op boundary explicitly** as a scalar `bs_format: str` op-schema arg. Formats are never derived from tensor dtypes (no `SF_DTYPE_TO_VEC_SIZE` table, no fp4 `A.dtype` logical-K special case, no `gemm_blockscaled_ref` sf-vec ternary); `_sf_decode` is format-driven - this kills the "uint8 scale view decoded as e8m0 => NVFP4 silently runs as vec-32 MXFP8" trap. There is NO dtype->format inference site anywhere (the tuple path's `_legacy_format_from_dtypes`, the last one, was deleted with tuple support - D10). |
-| D6 | **MXFP6 qdata = packed 6-bit storage carried in `uint8` bytes**: a little-endian 6-bit stream, element i at bits [6i, 6i+6) - the CUTLASS SubbyteReference layout (`pack_uint6`/`unpack_uint6` in quantize.py). Packed gmem is what the TMA-unpack path consumes (section 6) and keeps fp6's bandwidth advantage over fp8. torch has no fp6 dtype, so the packed stream crosses the FFI boundary as raw `torch.uint8` of shape `(..., 3K/4)` - see section 5 and the boundary notes in section 6. |
+| D6 | **MXFP6 storage names are unambiguous and backward compatible.** Origin/main names `mxfp6_e2m3` / `mxfp6_e3m2` remain one-code-per-`uint8` byte containers, including their quantizer behavior and serialized descriptors. Kernel-ready `mxfp6_e2m3_packed` / `mxfp6_e3m2_packed` use `storage_layout="packed_lsb_v1"`: a little-endian 6-bit stream with element i at bits [6i, 6i+6), the CUTLASS SubbyteReference layout (`pack_uint6`/`unpack_uint6`). Packed gmem is what TMA unpack consumes (section 6), crossing FFI as raw `torch.uint8` of shape `(..., 3K/4)`. `to_packed()` migrates byte operands bit-exactly and canonicalizes descriptors emitted under the short-lived packed/unversioned naming. |
 | D7 | **Loud failure, explicit surface.** No aten interception: torch ops reject the non-tensor container with a plain `TypeError`; the supported surface is the explicit methods (`mT`/`T`/`transpose` restricted to last-two-dims, `to(device)` - dtype conversion raises pointing at `dequantize()`, `clone`, `dequantize`). **No dequantize fallback** in a kernels library. Targeted `TypeError` guards at non-blockscaled entry points (`gemm_dact`, `gemm_symmetric`, `gemm_rms`, `gemm_norm_act`) for message quality. |
 | D8 | **`per_tensor_scale` is a field** (NVFP4 only). `gemm` folds `pts_A * pts_B` into alpha at the unwrap site via the existing *tensor-alpha* path (no `.item()` sync; nvfp4-with-pts compiles the tensor-alpha kernel variant). |
-| D9 | **torch.compile support via pytree registration** plus a normal inlineable construction helper for in-graph quantize. It must not use `allow_in_graph`: that makes Dynamo treat the helper as an opaque op, whose non-Tensor `BlockScaledOperand` return is illegal under `fullgraph=True`. `_sf_encode` (e8m0->uint8 view across the op boundary, an Inductor `decompose_auto_functionalized` workaround) sits at the unwrap site. |
+| D9 | **torch.compile support via pytree registration** plus a normal inlineable construction helper for in-graph quantize. Pytree context is a versioned, JSON-safe encoding of every descriptor field, `orig_dtype`, and `quant_dim`, so custom/legacy formats survive `treespec_dumps`/`treespec_loads`; origin/main's old `(format_name, dtype, quant_dim)` context remains readable. It must not use `allow_in_graph`: that makes Dynamo treat the helper as an opaque op, whose non-Tensor `BlockScaledOperand` return is illegal under `fullgraph=True`. `_sf_encode` (e8m0->uint8 view across the op boundary, an Inductor `decompose_auto_functionalized` workaround) sits at the unwrap site. |
 | D10 | **Containers are the only blockscaled operand form**: `(data, scale_factor)` tuples/lists are rejected at the unwrap site with a `TypeError` pointing at `BlockScaledOperand.from_parts`. Every blockscaled operand is therefore construction-validated before it reaches a GEMM. `blockscaled_quantize` / `blockscaled_quantize_dim0` keep their raw `(q, sf)` returns - they are quantizers, not operand constructors (changing the return silently corrupts `qa, sfa = ...` call sites); wrap via `from_parts`, or use `BlockScaledOperand.quantize` directly. The TVM-FFI direct path (`compile_blockscaled_gemm_tvm_ffi`) is plain-tensors-only forever. |
-| D11 | **A and B carry independent formats end-to-end** (`bs_format_a` / `bs_format_b` through every layer, including the op schemas). Pair *legality* is hardware fact, owned by `mma_kind_for_pair` in `operand.py`, which returns `"mxf8f6f4"` for every non-nvfp4, non-both-mxfp4 pair (PTX: `mxf4nvf4` and `mxf4` need matching element types; `mxf8f6f4` mixes fp8/fp6/fp4 freely, with sub-byte operands TMA-unpacked from packed gmem into 8-bit SMEM containers). Pair *implementation* is enforced **per-architecture**: each `gemm_smXXX` kernel class owns the asserts for the (A, B, SF, D) dtype combinations it supports (`GemmSm100.is_valid_dtypes_and_scale_factor_vec_size`, asserted in its blockscaled setup path; different SM versions support different mx dtypes). SM100's matrix admits **mixed fp8 pairs (e4m3 x e5m2, both orders)**: the DSL's `MmaMXF8F6F4Op` takes independent a/b dtypes, and instruction-K is kind-derived (mxf4/mxf4nvf4 => 64 elements, mxf8f6f4 => 32), not element-width-derived. **Mixed pairs involving fp4/fp6 run via the TMA-unpack path** (section 6): packed gmem + `internal_type=Uint8` + byte-domain SMEM; the `a/b_mma_dtype` split through both compile paths carries the packed-fp6 boundary dtype. `validate_blockscaled_sf` checks per-operand dtypes and cross-checks logical K via the formats' `logical_k` mapping - packings may differ. |
+| D11 | **A and B carry independent formats end-to-end** (`bs_format_a` / `bs_format_b` through every layer, including the op schemas). Pair *legality* is hardware fact, owned by `mma_kind_for_pair` in `operand.py`, which rejects byte-container compatibility formats and returns `"mxf8f6f4"` for every kernel-ready non-nvfp4, non-both-mxfp4 pair (PTX: `mxf4nvf4` and `mxf4` need matching element types; `mxf8f6f4` mixes fp8/fp6/fp4 freely, with sub-byte operands TMA-unpacked from packed gmem into 8-bit SMEM containers). Pair *implementation* is enforced **per-architecture**: each `gemm_smXXX` kernel class owns the asserts for the (A, B, SF, D) dtype combinations it supports (`GemmSm100.is_valid_dtypes_and_scale_factor_vec_size`, asserted in its blockscaled setup path; different SM versions support different mx dtypes). SM100's matrix admits **mixed fp8 pairs (e4m3 x e5m2, both orders)**: the DSL's `MmaMXF8F6F4Op` takes independent a/b dtypes, and instruction-K is kind-derived (mxf4/mxf4nvf4 => 64 elements, mxf8f6f4 => 32), not element-width-derived. **Mixed pairs involving fp4/fp6 run via the TMA-unpack path** (section 6): packed gmem + `internal_type=Uint8` + byte-domain SMEM; the `a/b_mma_dtype` split through both compile paths carries the packed-fp6 boundary dtype. `validate_blockscaled_sf` checks per-operand dtypes and cross-checks logical K via the formats' `logical_k` mapping - packings may differ. |
 | D12 | **Blockscaled output D is a first-class API**: `out_dtype: torch.dtype \| BlockScaledFormat \| str` on `gemm`/`gemm_add`/`gemm_act(+postact_dtype)`; the op-schema plumbing is `SFD` (mutated) + `bs_format_d`, completing the (a, b, d) format triple. See section 7. |
 
 ### Rejected alternatives
@@ -57,11 +57,11 @@ constraints anchor the rationale where noted.
   frozen dataclass. The container's field set and constructors are exactly what a
   tensor-subclass wrapper would hold, so module citizenship can layer on top later
   without breaking this API.
-- **Byte-container gmem formats for sub-byte elements** (one uint8 byte per fp4/fp6
+- **Byte-container gmem formats for new GEMMs** (one uint8 byte per fp4/fp6
   element): rejected because TMA unpack consumes packed gmem directly (section 6), so
-  byte containers would only double (fp4) or inflate by 4/3 (fp6) the gmem traffic
-  and duplicate registry entries; the packed formats serve homogeneous and mixed
-  pairs alike.
+  byte containers would only double (fp4) or inflate by 4/3 (fp6) the gmem traffic.
+  The origin/main descriptors remain registered for checkpoint compatibility and host-side
+  conversion, but GEMM rejects them and points callers to `to_packed()`.
 
 ### Out of scope
 
@@ -84,23 +84,27 @@ constraints anchor the rationale where noted.
 ```python
 @dataclass(frozen=True)
 class BlockScaledFormat:
-    name: str                    # "mxfp8_e4m3" | "mxfp8_e5m2" | "mxfp4" | "nvfp4" | "mxfp6_e2m3" | "mxfp6_e3m2"
-    qdata_dtype: torch.dtype     # e4m3 | e5m2 | float4_e2m1fn_x2 | uint8 (packed fp6)
+    name: str                    # includes unversioned byte and explicit *_packed fp6
+    qdata_dtype: torch.dtype     # e4m3 | e5m2 | float4_e2m1fn_x2 | uint8
     cutlass_dtype_name: str      # CuTe-DSL MMA element type (may differ from storage: fp6)
     elem_bits: int               # 8 | 4 | 6
+    elems_per_container: int     # legacy positional contract; 2 for fp4x2, else 1
     scale_dtype: torch.dtype     # float8_e8m0fnu | float8_e4m3fn
     sf_vec_size: int             # 32 | 16 (also the min logical-K divisibility)
     has_per_tensor_scale: bool   # nvfp4 only
+    storage_layout: str | None   # "packed_lsb_v1" for *_packed fp6; None is legacy
 ```
 
 - Hashable/picklable -> usable as dynamo guard ctx and kernel-cache key material; only
   `name` crosses the op schema.
 - `logical_k(storage_k)` / `storage_k(logical_k)` map between the logical element
-  extent and the storage extent, derived from `elem_bits` (fp4: 2 elements per byte,
-  fp6: 4 elements per 3 bytes - an integer elems-per-container field cannot express
-  that ratio); `is_packed` marks sub-byte packed storage. `to_cutlass_dtype()` (lazy
+  extent and the storage extent. Container layouts use `elems_per_container`; the
+  versioned packed-fp6 layout uses the 4-elements-per-3-bytes bit ratio that an integer
+  field cannot express. `is_packed` and `is_byte_container` distinguish those paths.
+  `to_cutlass_dtype()` (lazy
   cutlass import: `Float8E4M3FN`, `Float8E5M2`, `Float4E2M1FN`, `Float6E2M3FN`,
-  `Float6E3M2FN`); `from_name`, `from_cutlass_dtypes`.
+  `Float6E3M2FN`); `from_name`, `from_cutlass_dtypes`. Dtype-triple lookup filters
+  byte containers and therefore resolves fp6 to the explicit packed descriptor.
 - Kernel support is NOT a registry property: descriptors are registered and
   constructible (checkpoints, round-trips) independently of any kernel, and whether a
   GEMM can execute a given (A, B, D) dtype combination is asserted per-architecture
@@ -108,6 +112,12 @@ class BlockScaledFormat:
   kind::mxf8f6f4 - see section 6).
 - E5M2: descriptor + `from_parts` work (the kernel admits e5m2); `quantize` raises
   because `to_mx` has no e5m2 encoder - `from_parts` is the e5m2 construction path.
+- `mxfp4_byte` and unversioned byte-container MXFP6 checkpoints retain their logical
+  shape and dequantization after load. They are host-side compatibility formats only;
+  `BlockScaledOperand.to_packed()` preserves their codes/scales exactly for GEMM use.
+- Pickle migration distinguishes schemas structurally: origin/main states contain
+  `elems_per_container` and keep byte semantics, while the short-lived feature state
+  omits both packing fields and migrates fractional FP6 to the explicit `*_packed` name.
 
 ```python
 @dataclass(frozen=True, eq=False)        # plain container, not a Tensor
@@ -220,11 +230,14 @@ element-class + recipe gates in `mma_kind_for_pair`) are already in place.
   spec uses a byte-extent K symbol for fp6 because `div_for_dtype` with width 6 is
   non-integral (96 bytes = 128 logical elements).
 - `_blockscaled_format_of` is a shim over `BlockScaledFormat.from_cutlass_dtypes`.
+  Its legacy direct-compiler generator still rejects packed FP6 because that path
+  has no separate uint8 storage dtype / FP6 MMA dtype; unified and varlen APIs do.
 - `compile_blockscaled_gemm_tvm_ffi`: asserts plain tensors; docstring states the policy.
 
 ## 6. Sub-byte operands: mixed fp4/fp6/fp8
 
-Any A/B pair of {mxfp8_e4m3, mxfp8_e5m2, mxfp4, mxfp6_e2m3, mxfp6_e3m2} runs on
+Any A/B pair of {mxfp8_e4m3, mxfp8_e5m2, mxfp4, mxfp6_e2m3_packed,
+mxfp6_e3m2_packed} runs on
 SM100 under tcgen05 `kind::mxf8f6f4` - including fp6 x fp4, where both operands
 unpack. Both-fp4 runs the single denser `kind::mxf4nvf4` atom, parameterized by the
 format's scale config (vec 32 e8m0 = mxfp4 - PTX spells that instantiation
@@ -267,7 +280,8 @@ operand - a packed sub-byte gmem operand in any pair other than both-packed-fp4:
   exactly 128 elements (satisfied by the SW128 byte-domain atom). Enforced:
   arg-spec k divisibility 128 (fp4-mixed), fp6 K%128 assert in
   `validate_blockscaled_sf`, `GemmSm100.can_implement` K%128 + per-operand
-  K-major.
+  K-major, and 32B fake-argument/per-launch alignment checks (the latter also
+  protects cached plans whose keys do not include data pointers).
 
 **Kernel structure (`gemm_sm100.py`):** per-operand `a/b_unpack` flags +
 `a/b_smem_dtype` (Uint8 when unpack) derived next to the dtype resolution;
@@ -330,8 +344,8 @@ shape or smoke checks alone.
   varlen-padded scale construction; `clone`/`.to(device)` (dtype-`to` raises pointing
   at dequantize); `.mT`/`.T`/`transpose` round-trips with the SAME scale object; loud
   TypeError from torch ops; repr; deepcopy; save/`load(weights_only=True)`; pytree
-  round-trip (orientation flag included); rejection guards at the non-blockscaled
-  entry points.
+  round-trip (orientation flag included), including JSON TreeSpec serialization for
+  custom and legacy formats; rejection guards at the non-blockscaled entry points.
 - Interface (`tests/test_gemm_blockscaled_interface.py`): the dtype matrix runs on
   containers (the only operand form); a negative test pins the tuple/list
   `TypeError` (removal regression); regression tests encoding the failure modes the
@@ -387,7 +401,7 @@ flat enumerations of the same `(bm, bk, scale dtype)` points.
 
 | recipe | bm | bk | scale dtype | elements |
 |---|---|---|---|---|
-| mxfp8 / mxfp4 / mxfp6 | 1 | 32 | e8m0 | fp8/4/6 |
+| mxfp8 / mxfp4 / mxfp6_*_packed | 1 | 32 | e8m0 | fp8/4/6 |
 | nvfp4 | 1 | 16 | e4m3 (+pts) | fp4 |
 | DeepSeek 1D (acts) | 1 | 128 | fp32 | e4m3 |
 | DeepSeek 2D (weights) | 128 | 128 | fp32 | e4m3 |

--- a/AI/probe_fp6_pitch.py
+++ b/AI/probe_fp6_pitch.py
@@ -1,0 +1,48 @@
+# Probe: fp6 TMA-unpack numerics vs row pitch.
+# _reinterpret_packed_fp6 scales non-K byte strides by *4//3 (floor). Exactness
+# in the element domain requires pitch % 3 == 0; this probe checks whether
+# 32B-aligned-but-not-%3 pitches still produce correct results (hypothesis: the
+# DSL rounds sub-byte strides back up to TMA's 16B granularity, recovering the
+# exact pitch for any 32B-aligned value).
+import torch
+
+from quack.gemm_interface import gemm, gemm_blockscaled_ref
+from quack.blockscaled.operand import BlockScaledOperand
+
+torch.manual_seed(0)
+m = n = 128
+k = 512  # storage rows: 3*512/4 = 384 bytes
+
+
+def relayout(op, offset_bytes, row_pad_bytes):
+    rows, storage_k = op.qdata.shape
+    row_stride = storage_k + row_pad_bytes
+    raw = torch.full(
+        (offset_bytes + rows * row_stride,),
+        0xA5,  # poison the padding: floor-stride bugs would read into it
+        dtype=torch.uint8,
+        device=op.qdata.device,
+    )
+    qdata = raw[offset_bytes:].as_strided((rows, storage_k), (row_stride, 1))
+    qdata.view(torch.uint8).copy_(op.qdata.view(torch.uint8))
+    return BlockScaledOperand.from_parts(qdata, op.scale, op.format, orig_dtype=op.orig_dtype)
+
+
+x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+A = BlockScaledOperand.quantize(x, "mxfp8_e4m3")
+W0 = BlockScaledOperand.quantize(w, "mxfp6_e2m3_packed")
+
+print(f"{'pad':>5} {'pitch':>6} {'%3':>3} {'%32':>4}  rel_err")
+for pad in [0, 32, 64, 96, 160, 3744]:
+    pitch = 384 + pad
+    W = relayout(W0, 32, pad)
+    try:
+        out = gemm(A, W.mT, tuned=False)
+        ref = gemm_blockscaled_ref(A, W.mT)
+        rel = (out.float() - ref.float()).abs().max().item() / ref.float().abs().max().item()
+        status = f"{rel:.2e}" + ("  <-- WRONG" if rel > 5e-3 else "")
+    except Exception as e:
+        status = f"raised: {type(e).__name__}: {str(e)[:90]}"
+    print(f"{pad:>5} {pitch:>6} {pitch % 3:>3} {pitch % 32:>4}  {status}")
+torch.cuda.synchronize()

--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -235,16 +235,7 @@ def _quantize_dense_operand(l, mn, k, mn_major, fmt):
     from quack.blockscaled.operand import BlockScaledOperand
 
     x = (torch.randn(l, mn, k, device="cuda", dtype=torch.bfloat16) * k**-0.5).contiguous()
-    if fmt.name == "mxfp8_e5m2":
-        # No in-repo e5m2 quantizer: re-encode e4m3 codes as e5m2 (rounds some
-        # mantissas, but self-consistent - the reference dequantizes the e5m2
-        # bits). Same trick as the mixed-input interface tests.
-        t4 = BlockScaledOperand.quantize(x, "mxfp8_e4m3")
-        op = BlockScaledOperand.from_parts(
-            t4.qdata.float().to(torch.float8_e5m2), t4.scale, fmt, orig_dtype=x.dtype
-        )
-    else:
-        op = BlockScaledOperand.quantize(x, fmt)
+    op = BlockScaledOperand.quantize(x, fmt)
     ref_mkl = op.dequantize(torch.float32).permute(1, 2, 0).contiguous()
     q = op.qdata  # (l, mn, k_storage) contiguous, K innermost
     if mn_major:

--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -151,7 +151,8 @@ def parse_arguments() -> argparse.Namespace:
         help="A/B input dtype. Default: BFloat16 for dense, auto-detected for "
         "blockscaled (MXFP8 if sf=E8M0/vec=32, NVFP4 if sf=E4M3FN/vec=16). "
         "Dense: BFloat16/Float16/Float32. "
-        "Blockscaled: Float8E4M3FN/Float8E5M2/Float4E2M1FN.",
+        "Blockscaled: Float8E4M3FN/Float8E5M2/Float4E2M1FN/"
+        "Float6E2M3FN/Float6E3M2FN.",
     )
     parser.add_argument(
         "--sf_dtype",
@@ -173,10 +174,10 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         default=None,
         help="Blockscaled format for A (BlockScaledFormat registry name: mxfp8_e4m3/"
-        "mxfp8_e5m2/mxfp4/nvfp4/mxfp6_e2m3/mxfp6_e3m2). Setting this enables the "
-        "blockscaled path. Default: the format resolved from --ab_dtype/--sf_dtype/"
-        "--sf_vec_size. A and B may carry different formats (nvfp4 pairs only "
-        "with itself).",
+        "mxfp8_e5m2/mxfp4/nvfp4/mxfp6_e2m3_packed/mxfp6_e3m2_packed). "
+        "Setting this enables the blockscaled path. Default: the format resolved from "
+        "--ab_dtype/--sf_dtype/--sf_vec_size. A and B may carry different formats "
+        "(nvfp4 pairs only with itself).",
     )
     parser.add_argument(
         "--bs_format_b",
@@ -201,8 +202,8 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         default=None,
         choices=["k", "m"],
-        help="A operand major mode. Blockscaled: MXFP8 supports k/m, "
-        "MXFP4/NVFP4 must be k. Dense: varlen_k forces m, others default "
+        help="A operand major mode. Blockscaled: 8-bit formats support k/m; "
+        "packed fp4/fp6 formats require k. Dense: varlen_k forces m, others default "
         "to k if omitted.",
     )
     parser.add_argument(
@@ -210,8 +211,8 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         default=None,
         choices=["k", "n"],
-        help="B operand major mode. Blockscaled: MXFP8 supports k/n, "
-        "MXFP4/NVFP4 must be k. Dense: varlen_k forces n, others default "
+        help="B operand major mode. Blockscaled: 8-bit formats support k/n; "
+        "packed fp4/fp6 formats require k. Dense: varlen_k forces n, others default "
         "to k if omitted.",
     )
 
@@ -277,7 +278,7 @@ def _run_blockscaled(args):
     if args.varlen_k or args.gather_A or args.pingpong:
         raise NotImplementedError(
             "blockscaled + varlen_k/gather/pingpong is not wired up yet. "
-            "Only --varlen_m is currently supported for blockscaled (MXFP8 only)."
+            "Only same-format --varlen_m is currently supported for blockscaled."
         )
 
     m, n, k, l = args.mnkl
@@ -375,9 +376,10 @@ def _run_blockscaled(args):
     )
     if args.varlen_m:
         # varlen_m: l is num_experts, m is per-expert m, total_m = m * l.
-        # Supports MXFP8 / MXFP4 / NVFP4 (fp4 operands must be K-major).
+        # Supports every kernel-ready same-format operand pair. Packed fp4/fp6
+        # operands must be K-major.
         # A must stay k-major in varlen_m (the per-expert padded SF offset
-        # targets the M axis); B can be k- or n-major (MXFP8 only).
+        # targets the M axis); B can be k- or n-major for 8-bit formats.
         if fmt_a.name != fmt_b.name:
             raise NotImplementedError(
                 f"blockscaled varlen_m benchmarking supports a single format for A and B; "
@@ -400,7 +402,7 @@ def _run_blockscaled(args):
         mSFA, mSFB = a_sc_contig, b_sc_contig  # (1, padded_rm, rk, 32, 4, 4), (l, rn, rk, 32, 4, 4)
         mD = torch.empty(total_m, n, dtype=torch_dtype_for_cutlass(d_dtype), device="cuda")
         # Unified dispatch takes a (l, n, k) B view (zero-copy permute of the
-        # (n, k, l) kernel-layout tensor); A/D stay 2D (total_m, k[/2]) / (total_m, n).
+        # (n, k_storage, l) kernel-layout tensor); A/D stay 2D.
         B = mB.permute(2, 0, 1)
 
         def fn():

--- a/benchmarks/benchmark_gemm.py
+++ b/benchmarks/benchmark_gemm.py
@@ -9,8 +9,9 @@ from quack.gemm_interface import SplitKMode
 
 """
 GEMM benchmark using quack.gemm.gemm() for both the dense path and the SM100
-blockscaled path (MXFP8 / MXFP4 / NVFP4), including blockscaled varlen_m.
-Blockscaled is selected by passing --sf_dtype and/or --sf_vec_size; everything
+blockscaled path (mx/nv fp8/fp6/fp4, mixed A/B formats), including blockscaled
+varlen_m. Blockscaled is selected by passing --sf_dtype, --sf_vec_size and/or
+per-operand --bs_format_a/--bs_format_b registry names; everything
 runs through the same unified quack.gemm.gemm() dispatch (with SFA/SFB), so
 the tile/cluster flags apply identically and the timings include the real
 dispatch overhead users pay.
@@ -31,6 +32,10 @@ Usage (blockscaled MXFP4):
 Usage (blockscaled NVFP4):
     python benchmarks/benchmark_gemm.py --mnkl 4096,4096,4096,1 \
         --ab_dtype Float4E2M1FN --sf_dtype Float8E4M3FN --sf_vec_size 16
+
+Usage (blockscaled with mixed A/B formats):
+    python benchmarks/benchmark_gemm.py --mnkl 4096,4096,4096,1 \
+        --bs_format_a mxfp4 --bs_format_b mxfp8_e4m3
 """
 
 
@@ -137,7 +142,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--use_tma_gather", action="store_true", help="Use TMA gather4 for A")
     parser.add_argument("--max_swizzle_size", type=int, default=8, help="Max swizzle size")
     parser.add_argument("--skip_ref_check", action="store_true", help="Skip reference checking")
-    # Dtype flags. Blockscaled path is selected automatically when --sf_dtype is passed.
+    # Dtype flags. Blockscaled path is selected automatically when any of
+    # --sf_dtype/--sf_vec_size/--bs_format_a/--bs_format_b is passed.
     parser.add_argument(
         "--ab_dtype",
         type=str,
@@ -161,6 +167,22 @@ def parse_arguments() -> argparse.Namespace:
         default=None,
         help="Blockscaled scale vector size (32 for MX, 16 for NVFP4). "
         "Setting this enables the blockscaled path.",
+    )
+    parser.add_argument(
+        "--bs_format_a",
+        type=str,
+        default=None,
+        help="Blockscaled format for A (BlockScaledFormat registry name: mxfp8_e4m3/"
+        "mxfp8_e5m2/mxfp4/nvfp4/mxfp6_e2m3/mxfp6_e3m2). Setting this enables the "
+        "blockscaled path. Default: the format resolved from --ab_dtype/--sf_dtype/"
+        "--sf_vec_size. A and B may carry different formats (nvfp4 pairs only "
+        "with itself).",
+    )
+    parser.add_argument(
+        "--bs_format_b",
+        type=str,
+        default=None,
+        help="Blockscaled format for B; see --bs_format_a.",
     )
     parser.add_argument(
         "--d_dtype",
@@ -201,21 +223,49 @@ def parse_arguments() -> argparse.Namespace:
     return args
 
 
+def _quantize_dense_operand(l, mn, k, mn_major, fmt):
+    """Quantize a random (l, mn, k) bf16 tensor with ``fmt`` and return
+    (ref_mkl, q, scale_contig):
+      ref_mkl: (mn, k, l) fp32 dequantized reference
+      q:       (l, mn, k_storage) quantized operand in the format's storage
+               dtype, K- or MN-major on the trailing two dims
+      scale_contig: (l, rm, rk, 32, 4, 4) blocked scale factors
+    """
+    from quack.blockscaled.operand import BlockScaledOperand
+
+    x = (torch.randn(l, mn, k, device="cuda", dtype=torch.bfloat16) * k**-0.5).contiguous()
+    if fmt.name == "mxfp8_e5m2":
+        # No in-repo e5m2 quantizer: re-encode e4m3 codes as e5m2 (rounds some
+        # mantissas, but self-consistent - the reference dequantizes the e5m2
+        # bits). Same trick as the mixed-input interface tests.
+        t4 = BlockScaledOperand.quantize(x, "mxfp8_e4m3")
+        op = BlockScaledOperand.from_parts(
+            t4.qdata.float().to(torch.float8_e5m2), t4.scale, fmt, orig_dtype=x.dtype
+        )
+    else:
+        op = BlockScaledOperand.quantize(x, fmt)
+    ref_mkl = op.dequantize(torch.float32).permute(1, 2, 0).contiguous()
+    q = op.qdata  # (l, mn, k_storage) contiguous, K innermost
+    if mn_major:
+        # 8-bit formats only (sub-byte operands are rejected as MN-major
+        # upstream): rebuild the same codes with mn innermost.
+        q = q.transpose(1, 2).contiguous().permute(0, 2, 1)
+    return ref_mkl, q, op.scale
+
+
 def _run_blockscaled(args):
-    """Blockscaled (MXFP8 / MXFP4 / NVFP4) path.
+    """Blockscaled (mx/nv fp8/fp6/fp4) path; A and B may carry different formats.
 
     Both dense and varlen_m run through the unified quack.gemm.gemm() dispatch
     (SFA/SFB tensors, dynamic-shape compile cache).
     """
     import cutlass
     from quack.blockscaled.utils import (
-        blockscaled_gemm_reference,
-        create_blockscaled_operand_quantized,
         create_blockscaled_varlen_m_operands,
         scale_blocked_for_cublas,
         torch_dtype_for_cutlass,
     )
-    from quack.cute_dsl_utils import get_device_capacity
+    from quack.cute_dsl_utils import get_device_capacity, torch2cute_dtype_map
     from quack.gemm_default_epi import GemmDefaultSm100
 
     sm_major = get_device_capacity(torch.device("cuda"))[0]
@@ -240,47 +290,68 @@ def _run_blockscaled(args):
         raise NotImplementedError(
             "blockscaled derives tile K from the MMA instruction; pass --tile_shape_mnk M,N"
         )
-    # Default sf_vec_size: 32 (MX). Auto-pick sf_dtype / ab_dtype from (sf_vec_size, ab_dtype).
-    sf_vec_size = args.sf_vec_size if args.sf_vec_size is not None else 32
-    if args.sf_dtype is None:
-        if sf_vec_size == 32:
-            sf_dtype = cutlass.Float8E8M0FNU  # MXFP8 / MXFP4
-        elif sf_vec_size == 16:
-            sf_dtype = cutlass.Float8E4M3FN  # NVFP4
-        else:
-            raise ValueError(
-                f"Cannot auto-pick sf_dtype for sf_vec_size={sf_vec_size}. Pass --sf_dtype."
-            )
-    else:
-        sf_dtype = cutlass.dtype(args.sf_dtype)
     d_dtype = cutlass.dtype(args.d_dtype)
-    # Auto-pick ab_dtype if user didn't set it.
-    if args.ab_dtype is None:
-        if sf_dtype == cutlass.Float8E8M0FNU and sf_vec_size == 32:
-            ab_dtype = cutlass.Float8E4M3FN  # MXFP8 default (user can override -> MXFP4)
-        elif sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 16:
-            ab_dtype = cutlass.Float4E2M1FN  # NVFP4
-        else:
-            raise ValueError(
-                f"Cannot auto-detect --ab_dtype for sf_dtype={sf_dtype}, sf_vec_size={sf_vec_size}. "
-                f"Pass --ab_dtype explicitly."
-            )
-    else:
-        ab_dtype = cutlass.dtype(args.ab_dtype)
+    from quack.blockscaled.operand import BlockScaledFormat
 
-    # MXFP4/NVFP4 require K-major for both operands. Only MXFP8 supports m/n-major.
+    def _format_from_dtype_triple():
+        """Resolve the (--ab_dtype, --sf_dtype, --sf_vec_size) triple to a format
+        descriptor - the fallback for operands without an explicit --bs_format_a/b."""
+        # Default sf_vec_size: 32 (MX). Auto-pick sf_dtype / ab_dtype from (sf_vec_size, ab_dtype).
+        sf_vec_size = args.sf_vec_size if args.sf_vec_size is not None else 32
+        if args.sf_dtype is None:
+            if sf_vec_size == 32:
+                sf_dtype = cutlass.Float8E8M0FNU  # MXFP8 / MXFP4
+            elif sf_vec_size == 16:
+                sf_dtype = cutlass.Float8E4M3FN  # NVFP4
+            else:
+                raise ValueError(
+                    f"Cannot auto-pick sf_dtype for sf_vec_size={sf_vec_size}. Pass --sf_dtype."
+                )
+        else:
+            sf_dtype = cutlass.dtype(args.sf_dtype)
+        # Auto-pick ab_dtype if user didn't set it.
+        if args.ab_dtype is None:
+            if sf_dtype == cutlass.Float8E8M0FNU and sf_vec_size == 32:
+                ab_dtype = cutlass.Float8E4M3FN  # MXFP8 default (user can override -> MXFP4)
+            elif sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 16:
+                ab_dtype = cutlass.Float4E2M1FN  # NVFP4
+            else:
+                raise ValueError(
+                    f"Cannot auto-detect --ab_dtype for sf_dtype={sf_dtype}, "
+                    f"sf_vec_size={sf_vec_size}. Pass --ab_dtype explicitly."
+                )
+        else:
+            ab_dtype = cutlass.dtype(args.ab_dtype)
+        return BlockScaledFormat.from_cutlass_dtypes(ab_dtype, sf_dtype, sf_vec_size)
+
+    # Per-operand formats: explicit --bs_format_a/--bs_format_b win; each unset
+    # side falls back to the dtype-triple format, so existing single-format
+    # invocations behave identically.
+    fallback = None
+    if args.bs_format_a is None or args.bs_format_b is None:
+        fallback = _format_from_dtype_triple()
+    fmt_a = BlockScaledFormat.from_name(args.bs_format_a) if args.bs_format_a else fallback
+    fmt_b = BlockScaledFormat.from_name(args.bs_format_b) if args.bs_format_b else fallback
+
     a_major = args.a_major if args.a_major is not None else "k"
     b_major = args.b_major if args.b_major is not None else "k"
-    is_fp4 = ab_dtype == cutlass.Float4E2M1FN
-    if is_fp4 and (a_major != "k" or b_major != "k"):
+    # Sub-byte (fp4/fp6) operands must be K-major; 8-bit formats support m/n-major.
+    for name, fmt, major in (("A", fmt_a, a_major), ("B", fmt_b, b_major)):
+        if fmt.elem_bits < 8 and major != "k":
+            raise ValueError(f"{fmt.name} requires a K-major {name} operand; got major={major!r}")
+    # Any pair with a sub-byte operand other than both-fp4 runs kind::mxf8f6f4
+    # with TMA-unpacked packed storage: the ALIGN16B unpack tensormap granule
+    # requires the contiguous K extent to be a multiple of 128 elements.
+    both_fp4 = fmt_a.elem_bits == 4 and fmt_b.elem_bits == 4
+    if (fmt_a.elem_bits < 8 or fmt_b.elem_bits < 8) and not both_fp4 and k % 128 != 0:
         raise ValueError(
-            f"MXFP4/NVFP4 require K-major for both A and B; got a_major={a_major}, b_major={b_major}"
+            f"{fmt_a.name} x {fmt_b.name} has a TMA-unpacked sub-byte operand and "
+            f"requires K divisible by 128 (unpack tensormap granule); got K={k}"
         )
-    if not GemmDefaultSm100.can_implement_blockscaled(
-        ab_dtype,
-        ab_dtype,
-        sf_dtype,
-        sf_vec_size,
+    if not GemmDefaultSm100.can_implement(
+        fmt_a,
+        fmt_b,
+        cutlass.Float32,
         d_dtype,
         mma_tiler_mnk,
         cluster_shape_mn,
@@ -293,20 +364,25 @@ def _run_blockscaled(args):
         "n",
     ):
         raise TypeError(
-            f"Unsupported blockscaled config: ab={ab_dtype}, sf={sf_dtype}, vec={sf_vec_size}, "
+            f"Unsupported blockscaled config: A={fmt_a.name}, B={fmt_b.name}, "
             f"d={d_dtype}, tiler={mma_tiler_mnk}, cluster={cluster_shape_mn}, "
             f"a_major={a_major}, b_major={b_major}"
         )
 
-    assert k % sf_vec_size == 0, f"k ({k}) must be divisible by sf_vec_size ({sf_vec_size})"
-    from quack.blockscaled.operand import BlockScaledFormat
-
-    bs_format = BlockScaledFormat.from_cutlass_dtypes(ab_dtype, sf_dtype, sf_vec_size).name
+    assert k % fmt_a.sf_vec_size == 0 and k % fmt_b.sf_vec_size == 0, (
+        f"k ({k}) must be divisible by the scale vec sizes "
+        f"({fmt_a.sf_vec_size} / {fmt_b.sf_vec_size})"
+    )
     if args.varlen_m:
         # varlen_m: l is num_experts, m is per-expert m, total_m = m * l.
         # Supports MXFP8 / MXFP4 / NVFP4 (fp4 operands must be K-major).
         # A must stay k-major in varlen_m (the per-expert padded SF offset
         # targets the M axis); B can be k- or n-major (MXFP8 only).
+        if fmt_a.name != fmt_b.name:
+            raise NotImplementedError(
+                f"blockscaled varlen_m benchmarking supports a single format for A and B; "
+                f"got {fmt_a.name} x {fmt_b.name}"
+            )
         assert a_major == "k", f"varlen_m currently requires a_major=k; got a={a_major}"
         total_m = m * l
         a_ref_dq, b_ref_dq, mA, mB, a_sc_contig, b_sc_contig, cu_seqlens_m = (
@@ -315,9 +391,9 @@ def _run_blockscaled(args):
                 m,
                 n,
                 k,
-                sf_vec_size,
-                ab_dtype,
-                sf_dtype,
+                fmt_a.sf_vec_size,
+                fmt_a.to_cutlass_dtype(),
+                torch2cute_dtype_map[fmt_a.scale_dtype],
                 b_major=b_major,
             )
         )
@@ -344,37 +420,15 @@ def _run_blockscaled(args):
                 cu_seqlens_m=cu_seqlens_m,
                 SFA=mSFA,
                 SFB=mSFB,
-                bs_format_a=bs_format,
-                bs_format_b=bs_format,
+                bs_format_a=fmt_a.name,
+                bs_format_b=fmt_b.name,
             )
     else:
-        a_ref, mA, a_sc_contig = create_blockscaled_operand_quantized(
-            l,
-            m,
-            k,
-            a_major == "m",
-            sf_vec_size,
-            ab_dtype,
-            sf_dtype,
-        )
-        b_ref, mB, b_sc_contig = create_blockscaled_operand_quantized(
-            l,
-            n,
-            k,
-            b_major == "n",
-            sf_vec_size,
-            ab_dtype,
-            sf_dtype,
-        )
-        # (l, rm, rk, 32, 4, 4) blocked scales, consumed by the unified dispatch as-is.
-        mSFA = a_sc_contig
-        mSFB = b_sc_contig
-        sfa_ref = torch.ones_like(a_ref)
-        sfb_ref = torch.ones_like(b_ref)
-        # Unified dispatch takes (l, m, k) / (l, n, k) views (zero-copy permutes
-        # of the (m, k, l) / (n, k, l) kernel-layout tensors) and (l, m, n) D.
-        A = mA.permute(2, 0, 1)
-        B = mB.permute(2, 0, 1)
+        # Each operand is quantized with its own format; the unified dispatch
+        # takes the (l, m, k_storage) / (l, n, k_storage) qdata tensors and
+        # (l, rm, rk, 32, 4, 4) blocked scales as-is, plus (l, m, n) D.
+        a_ref, A, mSFA = _quantize_dense_operand(l, m, k, a_major == "m", fmt_a)
+        b_ref, B, mSFB = _quantize_dense_operand(l, n, k, b_major == "n", fmt_b)
         mD = torch.empty(l, m, n, dtype=torch_dtype_for_cutlass(d_dtype), device="cuda").permute(
             1, 2, 0
         )
@@ -395,8 +449,8 @@ def _run_blockscaled(args):
                 max_swizzle_size=args.max_swizzle_size,
                 SFA=mSFA,
                 SFB=mSFB,
-                bs_format_a=bs_format,
-                bs_format_b=bs_format,
+                bs_format_a=fmt_a.name,
+                bs_format_b=fmt_b.name,
             )
 
     if not args.skip_ref_check:
@@ -410,16 +464,15 @@ def _run_blockscaled(args):
             )
             torch.testing.assert_close(mD.float(), ref, atol=tol, rtol=1e-3)
         else:
-            ref = blockscaled_gemm_reference(a_ref, b_ref, sfa_ref, sfb_ref)
+            # a_ref / b_ref are each dequantized with their own format.
+            ref = torch.einsum("mkl,nkl->mnl", a_ref, b_ref)
             torch.testing.assert_close(mD.float(), ref, atol=tol, rtol=1e-3)
         print("Ref check PASSED")
 
     print("Running SM100 Blockscaled GEMM with:")
     print(f"mnkl: {args.mnkl}")
     print(f"tile_shape_mnk: {mma_tiler_mnk}, cluster_shape_mnk: {cluster_shape_mnk}")
-    print(
-        f"ab_dtype: {ab_dtype}, sf_dtype: {sf_dtype}, sf_vec_size: {sf_vec_size}, d_dtype: {args.d_dtype}"
-    )
+    print(f"format A: {fmt_a.name}, format B: {fmt_b.name}, d_dtype: {args.d_dtype}")
     print(f"a_major: {a_major}, b_major: {b_major}")
 
     flops = 2 * m * n * k * l
@@ -442,17 +495,23 @@ def _run_blockscaled(args):
             f"(skipping cuBLAS: F.scaled_mm needs a_major=k, b_major=k; got a={a_major}, b={b_major})"
         )
         return
+    if fmt_a.name != fmt_b.name or fmt_a.elem_bits == 6:
+        # F.scaled_mm takes one scaling recipe per fp8/fp4 operand dtype; mixed
+        # A/B formats and packed fp6 have no comparable single-call path.
+        print(f"(skipping cuBLAS: F.scaled_mm has no {fmt_a.name} x {fmt_b.name} path)")
+        return
     from torch.nn.functional import scaled_mm, ScalingType, SwizzleType
 
+    sf_vec_size = fmt_a.sf_vec_size
     scaling_recipe_map = {32: ScalingType.BlockWise1x32, 16: ScalingType.BlockWise1x16}
     if sf_vec_size not in scaling_recipe_map:
         print(f"(skipping cuBLAS: unsupported sf_vec_size={sf_vec_size})")
         return
     recipe = scaling_recipe_map[sf_vec_size]
-    a_cub = mA[:, :, 0].contiguous()
-    b_cub = mB[:, :, 0].contiguous()
-    a_sc_cub = scale_blocked_for_cublas(a_sc_contig, m, k // sf_vec_size, 0)
-    b_sc_cub = scale_blocked_for_cublas(b_sc_contig, n, k // sf_vec_size, 0)
+    a_cub = A[0].contiguous()
+    b_cub = B[0].contiguous()
+    a_sc_cub = scale_blocked_for_cublas(mSFA, m, k // sf_vec_size, 0)
+    b_sc_cub = scale_blocked_for_cublas(mSFB, n, k // sf_vec_size, 0)
     out_dtype_t = _torch_dtype(args.d_dtype) if args.d_dtype != "Float32" else torch.bfloat16
 
     def fn_cublas():
@@ -483,7 +542,12 @@ def _run_blockscaled(args):
 
 
 def run(args):
-    if args.sf_dtype is not None or args.sf_vec_size is not None:
+    if (
+        args.sf_dtype is not None
+        or args.sf_vec_size is not None
+        or args.bs_format_a is not None
+        or args.bs_format_b is not None
+    ):
         return _run_blockscaled(args)
     m, n, k, l = args.mnkl
     tile_M, tile_N = args.tile_shape_mnk[:2]

--- a/quack/blockscaled/__init__.py
+++ b/quack/blockscaled/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026, Tri Dao.
-"""Blockscaled (MXFP8 / MXFP4 / NVFP4) GEMM support.
+"""Blockscaled (MXFP8 / MXFP4 / MXFP6 / NVFP4) GEMM support.
 
 - :mod:`quack.blockscaled.quantize` — pure-PyTorch quantizers (ported from
   torchao) with torch.compile'd fast paths.
@@ -14,8 +14,13 @@ rejected with a TypeError). Design doc: ``AI/blockscaled_api.md``.
 from quack.blockscaled.operand import (  # noqa: F401
     BLOCKSCALED_FORMAT_REGISTRY,
     MXFP4,
+    MXFP4_BYTE,
     MXFP6_E2M3,
+    MXFP6_E2M3_BYTE,
+    MXFP6_E2M3_PACKED,
     MXFP6_E3M2,
+    MXFP6_E3M2_BYTE,
+    MXFP6_E3M2_PACKED,
     MXFP8_E4M3,
     MXFP8_E5M2,
     NVFP4,
@@ -31,7 +36,21 @@ from quack.blockscaled.quantize import (  # noqa: F401
     to_mx_dim0,
     to_mx_dim0_compiled,
     to_mxfp4,
+    to_mxfp4_byte,
+    to_mxfp4_byte_compiled,
     to_mxfp4_compiled,
+    to_mxfp6_e2m3,
+    to_mxfp6_e2m3_byte,
+    to_mxfp6_e2m3_byte_compiled,
+    to_mxfp6_e2m3_compiled,
+    to_mxfp6_e2m3_packed,
+    to_mxfp6_e2m3_packed_compiled,
+    to_mxfp6_e3m2,
+    to_mxfp6_e3m2_byte,
+    to_mxfp6_e3m2_byte_compiled,
+    to_mxfp6_e3m2_compiled,
+    to_mxfp6_e3m2_packed,
+    to_mxfp6_e3m2_packed_compiled,
     to_nvfp4,
     to_nvfp4_compiled,
 )

--- a/quack/blockscaled/__init__.py
+++ b/quack/blockscaled/__init__.py
@@ -14,7 +14,6 @@ rejected with a TypeError). Design doc: ``AI/blockscaled_api.md``.
 from quack.blockscaled.operand import (  # noqa: F401
     BLOCKSCALED_FORMAT_REGISTRY,
     MXFP4,
-    MXFP4_BYTE,
     MXFP6_E2M3,
     MXFP6_E3M2,
     MXFP8_E4M3,

--- a/quack/blockscaled/operand.py
+++ b/quack/blockscaled/operand.py
@@ -20,10 +20,10 @@ Design doc: AI/blockscaled_api.md. In short:
 - ``quant_dim`` records which logical dim the scale vector runs along (-1 or
   -2) - the analogue of CUTLASS's ``UMMA::Major`` on its SF atoms. Storage alone
   cannot express it: a square fp8 canonical operand and its ``.mT`` view are
-  byte-identical. fp4 packing pins it to the packed (unit-stride) dim; byte
-  formats default to the last dim (quantize's convention); transpose flips it.
-  Consumed as a GEMM operand, the quantized axis must be the contraction axis
-  (the interface enforces this per operand slot).
+  byte-identical. Packed formats (fp4, fp6) pin it to the packed (unit-stride)
+  dim; 8-bit formats default to the last dim (quantize's convention); transpose
+  flips it. Consumed as a GEMM operand, the quantized axis must be the
+  contraction axis (the interface enforces this per operand slot).
 
 This module must stay import-light (torch only at module level): it is imported
 by ``quack.gemm_interface`` at module level and by the kernel-layer modules
@@ -51,7 +51,6 @@ __all__ = [
     "MXFP8_E4M3",
     "MXFP8_E5M2",
     "MXFP4",
-    "MXFP4_BYTE",
     "NVFP4",
     "MXFP6_E2M3",
     "MXFP6_E3M2",
@@ -74,19 +73,58 @@ class BlockScaledFormat:
     # (copy dtype, MMA dtype, convert) triple. See AI/blockscaled_api.md section 9.
     cutlass_dtype_name: Optional[str]
     elem_bits: int
-    elems_per_container: int  # logical elements per qdata element (2 for fp4x2)
     scale_dtype: torch.dtype
     sf_vec_size: int  # logical K elements per scale factor (== min logical-K divisibility)
     has_per_tensor_scale: bool = False
 
     def to_cutlass_dtype(self):
         """The CuTe-DSL element type for the MMA instruction (not the storage/copy
-        dtype: MXFP6 stores uint8 byte containers but computes as Float6*)."""
+        dtype: packed MXFP6 stores raw uint8 bytes but computes as Float6*)."""
         if self.cutlass_dtype_name is None:
             raise ValueError(f"{self.name} has no CuTe-DSL element type")
         import cutlass  # lazy: keep this module importable without the DSL
 
         return getattr(cutlass, self.cutlass_dtype_name)
+
+    # -- logical <-> storage K mapping ----------------------------------------
+    # qdata shapes carry the STORAGE K extent; these derive it from elem_bits
+    # and the torch storage element width instead of an elements-per-container
+    # int (which cannot express fp6's 4-elements-per-3-bytes packing).
+
+    @property
+    def storage_elem_bits(self) -> int:
+        """Bits per qdata storage element (the torch dtype's width)."""
+        return self.qdata_dtype.itemsize * 8
+
+    @property
+    def is_packed(self) -> bool:
+        """True when logical elements share storage elements (fp4x2, packed
+        fp6): the storage K extent then differs from logical K, and the packing
+        pins the quantized axis to the unit-stride dim."""
+        return self.elem_bits < self.storage_elem_bits
+
+    def storage_k(self, logical_k: int) -> int:
+        """Storage K extent of a qdata row holding ``logical_k`` elements
+        (fp8: identity; fp4x2: K/2; packed fp6 in uint8: 3*K/4)."""
+        bits = logical_k * self.elem_bits
+        if bits % self.storage_elem_bits:
+            raise ValueError(
+                f"{self.name}: logical K={logical_k} does not fill whole storage "
+                f"elements ({self.elem_bits}-bit codes in {self.storage_elem_bits}-bit units)"
+            )
+        return bits // self.storage_elem_bits
+
+    def logical_k(self, storage_k: int) -> int:
+        """Logical K extent of a qdata row of ``storage_k`` storage elements.
+        Exact inverse of :meth:`storage_k`: rows hold whole packed groups
+        (fp6: whole 3-byte groups of 4 codes)."""
+        bits = storage_k * self.storage_elem_bits
+        if bits % self.elem_bits:
+            raise ValueError(
+                f"{self.name}: storage K={storage_k} is not whole packed groups "
+                f"({self.storage_elem_bits}-bit units of {self.elem_bits}-bit codes)"
+            )
+        return bits // self.elem_bits
 
     @classmethod
     def from_name(cls, name: str) -> "BlockScaledFormat":
@@ -119,46 +157,39 @@ class BlockScaledFormat:
 
 
 MXFP8_E4M3 = BlockScaledFormat(
-    "mxfp8_e4m3", torch.float8_e4m3fn, "Float8E4M3FN", 8, 1, torch.float8_e8m0fnu, 32
+    "mxfp8_e4m3", torch.float8_e4m3fn, "Float8E4M3FN", 8, torch.float8_e8m0fnu, 32
 )
 MXFP8_E5M2 = BlockScaledFormat(
-    "mxfp8_e5m2", torch.float8_e5m2, "Float8E5M2", 8, 1, torch.float8_e8m0fnu, 32
+    "mxfp8_e5m2", torch.float8_e5m2, "Float8E5M2", 8, torch.float8_e8m0fnu, 32
 )
 MXFP4 = BlockScaledFormat(
-    "mxfp4", torch.float4_e2m1fn_x2, "Float4E2M1FN", 4, 2, torch.float8_e8m0fnu, 32
+    "mxfp4", torch.float4_e2m1fn_x2, "Float4E2M1FN", 4, torch.float8_e8m0fnu, 32
 )
 NVFP4 = BlockScaledFormat(
     "nvfp4",
     torch.float4_e2m1fn_x2,
     "Float4E2M1FN",
     4,
-    2,
     torch.float8_e4m3fn,
     16,
     has_per_tensor_scale=True,
 )
-# MXFP6 qdata is byte-per-element uint8 (one fp6 code in bits [5:0], bits [7:6] zero):
-# PTX kind::mxf8f6f4 addresses every element as an 8-bit container in SMEM, matching
-# CUDA __nv_fp6_storage_t and cuBLASLt CUDA_R_6F_*. Byte-per-element MXFP6 therefore
-# has fp8's bandwidth; its value is accuracy headroom over MXFP4, not speed. Packed
-# 6-bit gmem (CUTLASS 16U6 TMA) is a backlog item that only changes descriptor data.
-# Byte-container fp4: one E2M1 code per uint8. This is fp4 in the form the
-# mixed-capable kind::mxf8f6f4 consumes (the DSL has no TMA sub-byte->container
-# expansion, so byte containers live in gmem too). Use packed `mxfp4` for pure
-# fp4 x fp4 GEMMs (kind::mxf4, half the bandwidth).
-MXFP4_BYTE = BlockScaledFormat(
-    "mxfp4_byte", torch.uint8, "Float4E2M1FN", 4, 1, torch.float8_e8m0fnu, 32
-)
+# MXFP6 qdata is PACKED 6-bit storage in uint8 bytes: each row is the K 6-bit
+# codes as a little-endian bit stream (element i occupies bits [6i, 6i+6)), so
+# 4 codes pack into 3 bytes and the storage K extent is 3*K/4 (torch has no fp6
+# dtype, so the bytes are raw uint8). This is the CUTLASS SubbyteReference
+# layout the CU_TENSOR_MAP_DATA_TYPE_16U6 unpack tensormap consumes: TMA
+# expands packed gmem into 8-bit SMEM containers for tcgen05 kind::mxf8f6f4
+# (fp8's SMEM footprint, but 3/4 of its gmem/L2 bandwidth).
 MXFP6_E2M3 = BlockScaledFormat(
-    "mxfp6_e2m3", torch.uint8, "Float6E2M3FN", 6, 1, torch.float8_e8m0fnu, 32
+    "mxfp6_e2m3", torch.uint8, "Float6E2M3FN", 6, torch.float8_e8m0fnu, 32
 )
 MXFP6_E3M2 = BlockScaledFormat(
-    "mxfp6_e3m2", torch.uint8, "Float6E3M2FN", 6, 1, torch.float8_e8m0fnu, 32
+    "mxfp6_e3m2", torch.uint8, "Float6E3M2FN", 6, torch.float8_e8m0fnu, 32
 )
 
 BLOCKSCALED_FORMAT_REGISTRY = {
-    fmt.name: fmt
-    for fmt in (MXFP8_E4M3, MXFP8_E5M2, MXFP4, MXFP4_BYTE, NVFP4, MXFP6_E2M3, MXFP6_E3M2)
+    fmt.name: fmt for fmt in (MXFP8_E4M3, MXFP8_E5M2, MXFP4, NVFP4, MXFP6_E2M3, MXFP6_E3M2)
 }
 
 # Worked examples of formats the descriptor already expresses but that are NOT
@@ -170,19 +201,19 @@ BLOCKSCALED_FORMAT_REGISTRY = {
 #
 #   # DeepSeek-style 1x128 fp32-scale fp8 (SM90/SM100 blockwise promotion):
 #   BlockScaledFormat("fp8_e4m3_1x128", torch.float8_e4m3fn, "Float8E4M3FN",
-#                     8, 1, torch.float32, 128)
+#                     8, torch.float32, 128)
 #   # kscale: bf16 elements, per-row fp32 scale every 128 of K (one-sided;
 #   # quantize() would raise - scales are upstream-structural, from_parts only):
 #   BlockScaledFormat("bf16_1x128", torch.bfloat16, "BFloat16",
-#                     16, 1, torch.float32, 128)
+#                     16, torch.float32, 128)
 #   # W4A16 int4-g128 (AWQ/GPTQ-style; uint4b8's fixed offset is element
 #   # decode, not a descriptor field; bf16 scales are just data):
 #   BlockScaledFormat("int4_1x128", torch.uint8, "Int4",
-#                     4, 2, torch.bfloat16, 128)
+#                     4, torch.bfloat16, 128)
 #   # A hypothetical e3m4: no CuTe-DSL element type -> host-side only until a
 #   # kernel declares its own (copy dtype, MMA dtype, convert) triple:
 #   BlockScaledFormat("mxfp8_e3m4", torch.uint8, None,
-#                     8, 1, torch.float8_e8m0fnu, 32)
+#                     8, torch.float8_e8m0fnu, 32)
 #
 # NVFP4 weight-only (W4A16) needs NO new row: the same NVFP4 format pairs with
 # a plain bf16 activation tensor and dispatches to an upconvert kernel per
@@ -209,9 +240,13 @@ def mma_kind_for_pair(fmt_a: "BlockScaledFormat", fmt_b: "BlockScaledFormat") ->
     combinations; see GemmSm100.is_valid_dtypes_and_scale_factor_vec_size,
     asserted in its blockscaled setup path).
 
-    PTX rules: ``kind::mxf4nvf4`` (e4m3 scales, vec 16) requires fp4 on both
-    operands; ``kind::mxf4`` covers both-fp4 with e8m0 scales; ``kind::mxf8f6f4``
-    admits any mix of fp8/fp6/fp4 element types (e8m0 scales, vec 32).
+    PTX rules: ``kind::mxf4nvf4`` requires fp4 on both operands and covers both
+    scale configs - scale_vec::2X (vec 32, e8m0 = mxfp4; PTX also spells this
+    instantiation ``kind::mxf4``) and scale_vec::4X (vec 16 = nvfp4). It is ONE
+    MMA atom parameterized by (sf_dtype, sf_vec_size), mirroring CUTLASS C++'s
+    ``SM100_MMA_MXF4_SS<..., VS>``; the scale config is instruction-wide, so
+    the two operands' formats must match. ``kind::mxf8f6f4`` admits any mix of
+    fp8/fp6/fp4 element types (e8m0 scales, vec 32).
 
     The kind rules are encoded in three places that must stay in sync (this
     function cannot be shared: the kernel layer keys on cutlass dtypes and must
@@ -226,16 +261,11 @@ def mma_kind_for_pair(fmt_a: "BlockScaledFormat", fmt_b: "BlockScaledFormat") ->
         raise ValueError(
             f"nvfp4 (e4m3 scales, vec 16) cannot pair with "
             f"{fmt_b.name if fmt_a.name == 'nvfp4' else fmt_a.name}: "
-            f"the mxf4nvf4 MMA kind requires nvfp4 on both operands"
+            f"the mxf4nvf4 MMA kind's scale config is instruction-wide, so it "
+            f"requires nvfp4 on both operands"
         )
     if fmt_a.name == "mxfp4" and fmt_b.name == "mxfp4":
-        return "mxf4"
-    if fmt_a.name == "mxfp4_byte" and fmt_b.name == "mxfp4_byte":
-        raise ValueError(
-            "mxfp4_byte x mxfp4_byte has no MMA kind: use mxfp4 (packed, kind::mxf4) "
-            "for pure fp4 pairs; byte-container fp4 exists for mixed mxf8f6f4 pairs"
-        )
-    # fp8/fp6 byte-width element types mix freely under mxf8f6f4 (all e8m0 / vec 32).
+        return "mxf4nvf4"
     # Gate BOTH axes explicitly rather than falling through: a format whose
     # elements no tcgen05 kind can consume (no DSL type, or a non-fp8/6/4 one),
     # or whose scale RECIPE the SF hardware cannot represent (kind::mxf8f6f4 is
@@ -257,16 +287,10 @@ def mma_kind_for_pair(fmt_a: "BlockScaledFormat", fmt_b: "BlockScaledFormat") ->
                 f"32; software-scaled recipes are a follow-up (AI/blockscaled_api.md "
                 f"section 9)"
             )
-    if fmt_a.elems_per_container > 1 or fmt_b.elems_per_container > 1:
-        packed = fmt_a.name if fmt_a.elems_per_container > 1 else fmt_b.name
-        other = fmt_b.name if fmt_a.elems_per_container > 1 else fmt_a.name
-        raise ValueError(
-            f"{packed} (packed fp4x2 storage) cannot join a mixed pair with {other}: "
-            f"the mixed-capable mxf8f6f4 MMA kind reads sub-byte elements from 8-bit "
-            f"SMEM containers, which packed gmem storage cannot feed; requantize as "
-            f"mxfp4_byte (byte-container fp4) for mixed pairs "
-            f"(AI/blockscaled_api.md section 6)"
-        )
+    # Everything else - fp8 x fp8 and any mix involving a packed sub-byte
+    # operand - runs kind::mxf8f6f4 (all e8m0 scales / vec 32): sub-byte
+    # operands are loaded from packed gmem via TMA unpack into 8-bit smem
+    # containers (the CUTLASS *_unpacksmem_t convention).
     return "mxf8f6f4"
 
 
@@ -302,7 +326,7 @@ def _packed_dim(qdata: torch.Tensor, fmt: BlockScaledFormat) -> int:
     """The qdata dim holding multiple logical elements per storage element.
 
     Convention: the unit-stride dim. Packing is always along the quantization
-    (K) axis, and packed (fp4) formats are required K-major by the kernel, so
+    (K) axis, and packed (fp4/fp6) formats are required K-major by the kernel, so
     unit-stride == packed == K. Scanned from the last dim so fully-contiguous
     qdata resolves to the innermost dim. Size-1 dims report arbitrary strides
     (a (Kp, 1) K-major operand can present stride 1 on BOTH dims), so dims with
@@ -385,12 +409,12 @@ class BlockScaledOperand:
         requested = (
             None if self.quant_dim is None else _normalize_quant_dim(self.quant_dim, self.ndim)
         )
-        if fmt.elems_per_container > 1:
-            # fp4 packing pins the quantized axis to the packed (unit-stride) dim.
+        if fmt.is_packed:
+            # fp4/fp6 packing pins the quantized axis to the packed (unit-stride) dim.
             derived = -1 if _packed_dim(self.qdata, fmt) == self.qdata.ndim - 1 else -2
             if requested is not None and requested != derived:
                 raise ValueError(
-                    f"quant_dim={self.quant_dim} conflicts with the fp4 packed dim "
+                    f"quant_dim={self.quant_dim} conflicts with the {fmt.name} packed dim "
                     f"(packing runs along the quantized axis, here dim {derived})"
                 )
             object.__setattr__(self, "quant_dim", derived)
@@ -401,13 +425,14 @@ class BlockScaledOperand:
 
     @property
     def shape(self) -> Tuple[int, ...]:
-        """Logical (unpacked) shape; fp4x2 doubles the packed dim, which
-        ``quant_dim`` already tracks."""
-        epc = self.format.elems_per_container
-        if epc == 1:
+        """Logical (unpacked) shape; the packed dim (fp4x2: K/2, packed fp6:
+        3*K/4 bytes) maps back to logical K, which ``quant_dim`` already
+        tracks."""
+        fmt = self.format
+        if not fmt.is_packed:
             return tuple(self.qdata.shape)
         k_dim = self._mn_k_dims()[1]
-        return tuple(s * epc if d == k_dim else s for d, s in enumerate(self.qdata.shape))
+        return tuple(fmt.logical_k(s) if d == k_dim else s for d, s in enumerate(self.qdata.shape))
 
     @property
     def ndim(self) -> int:
@@ -538,8 +563,11 @@ class BlockScaledOperand:
             pts = pts_out.to(torch.float32) if per_tensor_scale is not None else None
         else:
             q, sc = fn(x_flat, fmt.sf_vec_size)
-        if fmt.elems_per_container > 1:  # quantizers emit packed uint8 codes for fp4
-            q = q.view(torch.uint8).view(fmt.qdata_dtype)
+        # Quantizers emit packed storage: fp4 as uint8 nibble pairs (re-viewed
+        # to the fp4x2 storage dtype), fp6 as the packed uint8 bit stream
+        # (already the storage dtype), fp8 as the storage dtype directly.
+        if q.dtype != fmt.qdata_dtype:
+            q = q.view(fmt.qdata_dtype)
         q = q.reshape(*x.shape[:-1], -1)
         sf = pack_scale_2d_to_blocked_contig(sc.view(l, mn, k // fmt.sf_vec_size))
         if not batched:

--- a/quack/blockscaled/operand.py
+++ b/quack/blockscaled/operand.py
@@ -51,9 +51,14 @@ __all__ = [
     "MXFP8_E4M3",
     "MXFP8_E5M2",
     "MXFP4",
+    "MXFP4_BYTE",
     "NVFP4",
     "MXFP6_E2M3",
     "MXFP6_E3M2",
+    "MXFP6_E2M3_PACKED",
+    "MXFP6_E3M2_PACKED",
+    "MXFP6_E2M3_BYTE",
+    "MXFP6_E3M2_BYTE",
 ]
 
 
@@ -73,9 +78,115 @@ class BlockScaledFormat:
     # (copy dtype, MMA dtype, convert) triple. See AI/blockscaled_api.md section 9.
     cutlass_dtype_name: Optional[str]
     elem_bits: int
+    # Keep this field in its original positional slot. Besides preserving the
+    # public constructor/pickle contract, it describes legacy container storage
+    # exactly (fp4x2: 2, byte-container fp4/fp6: 1). Fractional dense packing is
+    # selected explicitly by storage_layout below.
+    elems_per_container: int
     scale_dtype: torch.dtype
     sf_vec_size: int  # logical K elements per scale factor (== min logical-K divisibility)
     has_per_tensor_scale: bool = False
+    # None is intentionally the legacy default: old pickles do not carry this
+    # field and must retain elems_per_container semantics. packed_lsb_v1 is a
+    # dense little-endian bit stream (currently canonical packed fp6).
+    storage_layout: Optional[str] = None
+
+    def __setstate__(self, state):
+        """Load both current and pre-storage-layout dataclass pickles.
+
+        ``origin/main`` pickles contain ``elems_per_container`` and therefore
+        retain container semantics when ``storage_layout`` is absent. The
+        short-lived packed-FP6 feature schema contains neither field; derive
+        its packing and rename unversioned FP6 to the explicit packed name.
+        Materialize every field on the instance so generated dataclass helpers
+        such as hash/repr/replace remain safe after load.
+        """
+        if not isinstance(state, dict):
+            raise TypeError(f"invalid BlockScaledFormat pickle state: {type(state)}")
+        values = dict(state)
+        missing_epc = "elems_per_container" not in values
+        missing_layout = "storage_layout" not in values
+        if missing_epc:
+            storage_bits = values["qdata_dtype"].itemsize * 8
+            elem_bits = values["elem_bits"]
+            if values.get("storage_layout") == "packed_lsb_v1" or (
+                missing_layout and storage_bits % elem_bits
+            ):
+                values["elems_per_container"] = 1
+                values.setdefault("storage_layout", "packed_lsb_v1")
+            elif storage_bits % elem_bits == 0:
+                values["elems_per_container"] = storage_bits // elem_bits
+            else:
+                raise ValueError(
+                    "cannot infer elems_per_container from serialized format state"
+                )
+        values.setdefault("has_per_tensor_scale", False)
+        values.setdefault("storage_layout", None)
+        if values["storage_layout"] == "packed_lsb_v1":
+            values["name"] = {
+                "mxfp6_e2m3": "mxfp6_e2m3_packed",
+                "mxfp6_e3m2": "mxfp6_e3m2_packed",
+            }.get(values["name"], values["name"])
+        for name in (
+            "name",
+            "qdata_dtype",
+            "cutlass_dtype_name",
+            "elem_bits",
+            "elems_per_container",
+            "scale_dtype",
+            "sf_vec_size",
+            "has_per_tensor_scale",
+            "storage_layout",
+        ):
+            if name not in values:
+                raise ValueError(f"BlockScaledFormat pickle is missing {name!r}")
+            object.__setattr__(self, name, values[name])
+        self.__post_init__()
+
+    def __post_init__(self):
+        if not isinstance(self.name, str) or not self.name:
+            raise TypeError("format name must be a non-empty str")
+        if not isinstance(self.qdata_dtype, torch.dtype):
+            raise TypeError(f"qdata_dtype must be a torch.dtype, got {self.qdata_dtype!r}")
+        if self.cutlass_dtype_name is not None and not isinstance(self.cutlass_dtype_name, str):
+            raise TypeError("cutlass_dtype_name must be a str or None")
+        if (
+            not isinstance(self.elem_bits, int)
+            or isinstance(self.elem_bits, bool)
+            or self.elem_bits <= 0
+        ):
+            raise TypeError(f"elem_bits must be a positive int, got {self.elem_bits!r}")
+        if (
+            not isinstance(self.elems_per_container, int)
+            or isinstance(self.elems_per_container, bool)
+            or self.elems_per_container <= 0
+        ):
+            raise TypeError(
+                "elems_per_container must be a positive int, got "
+                f"{self.elems_per_container!r}"
+            )
+        if not isinstance(self.scale_dtype, torch.dtype):
+            raise TypeError(f"scale_dtype must be a torch.dtype, got {self.scale_dtype!r}")
+        if (
+            not isinstance(self.sf_vec_size, int)
+            or isinstance(self.sf_vec_size, bool)
+            or self.sf_vec_size <= 0
+        ):
+            raise TypeError(f"sf_vec_size must be a positive int, got {self.sf_vec_size!r}")
+        if not isinstance(self.has_per_tensor_scale, bool):
+            raise TypeError("has_per_tensor_scale must be bool")
+        if self.storage_layout not in (None, "container_v1", "packed_lsb_v1"):
+            raise ValueError(
+                "storage_layout must be None, 'container_v1', or 'packed_lsb_v1', "
+                f"got {self.storage_layout!r}"
+            )
+        if self.storage_layout != "packed_lsb_v1":
+            used_bits = self.elem_bits * self.elems_per_container
+            if used_bits > self.storage_elem_bits:
+                raise ValueError(
+                    f"{self.name}: {self.elems_per_container} x {self.elem_bits}-bit values "
+                    f"do not fit in a {self.storage_elem_bits}-bit storage element"
+                )
 
     def to_cutlass_dtype(self):
         """The CuTe-DSL element type for the MMA instruction (not the storage/copy
@@ -87,9 +198,9 @@ class BlockScaledFormat:
         return getattr(cutlass, self.cutlass_dtype_name)
 
     # -- logical <-> storage K mapping ----------------------------------------
-    # qdata shapes carry the STORAGE K extent; these derive it from elem_bits
-    # and the torch storage element width instead of an elements-per-container
-    # int (which cannot express fp6's 4-elements-per-3-bytes packing).
+    # qdata shapes carry the STORAGE K extent. Legacy/container layouts use the
+    # original integer elems_per_container contract; versioned dense bitstreams
+    # derive the fractional ratio from elem_bits and the storage element width.
 
     @property
     def storage_elem_bits(self) -> int:
@@ -98,33 +209,46 @@ class BlockScaledFormat:
 
     @property
     def is_packed(self) -> bool:
-        """True when logical elements share storage elements (fp4x2, packed
-        fp6): the storage K extent then differs from logical K, and the packing
-        pins the quantized axis to the unit-stride dim."""
-        return self.elem_bits < self.storage_elem_bits
+        """True when the storage K extent differs from logical K."""
+        layout = getattr(self, "storage_layout", None)
+        return layout == "packed_lsb_v1" or self.elems_per_container > 1
+
+    @property
+    def is_byte_container(self) -> bool:
+        """True for deprecated one-code-per-storage-element sub-byte formats."""
+        return not self.is_packed and self.elem_bits < self.storage_elem_bits
 
     def storage_k(self, logical_k: int) -> int:
         """Storage K extent of a qdata row holding ``logical_k`` elements
         (fp8: identity; fp4x2: K/2; packed fp6 in uint8: 3*K/4)."""
-        bits = logical_k * self.elem_bits
-        if bits % self.storage_elem_bits:
+        if getattr(self, "storage_layout", None) == "packed_lsb_v1":
+            bits = logical_k * self.elem_bits
+            if bits % self.storage_elem_bits:
+                raise ValueError(
+                    f"{self.name}: logical K={logical_k} does not fill whole storage "
+                    f"elements ({self.elem_bits}-bit codes in {self.storage_elem_bits}-bit units)"
+                )
+            return bits // self.storage_elem_bits
+        if logical_k % self.elems_per_container:
             raise ValueError(
-                f"{self.name}: logical K={logical_k} does not fill whole storage "
-                f"elements ({self.elem_bits}-bit codes in {self.storage_elem_bits}-bit units)"
+                f"{self.name}: logical K={logical_k} is not divisible by "
+                f"elems_per_container={self.elems_per_container}"
             )
-        return bits // self.storage_elem_bits
+        return logical_k // self.elems_per_container
 
     def logical_k(self, storage_k: int) -> int:
         """Logical K extent of a qdata row of ``storage_k`` storage elements.
         Exact inverse of :meth:`storage_k`: rows hold whole packed groups
         (fp6: whole 3-byte groups of 4 codes)."""
-        bits = storage_k * self.storage_elem_bits
-        if bits % self.elem_bits:
-            raise ValueError(
-                f"{self.name}: storage K={storage_k} is not whole packed groups "
-                f"({self.storage_elem_bits}-bit units of {self.elem_bits}-bit codes)"
-            )
-        return bits // self.elem_bits
+        if getattr(self, "storage_layout", None) == "packed_lsb_v1":
+            bits = storage_k * self.storage_elem_bits
+            if bits % self.elem_bits:
+                raise ValueError(
+                    f"{self.name}: storage K={storage_k} is not whole packed groups "
+                    f"({self.storage_elem_bits}-bit units of {self.elem_bits}-bit codes)"
+                )
+            return bits // self.elem_bits
+        return storage_k * self.elems_per_container
 
     @classmethod
     def from_name(cls, name: str) -> "BlockScaledFormat":
@@ -146,6 +270,7 @@ class BlockScaledFormat:
         for fmt in BLOCKSCALED_FORMAT_REGISTRY.values():
             if (
                 fmt.cutlass_dtype_name is not None  # DSL-typeless formats can't match
+                and not fmt.is_byte_container  # dtype triples select kernel-ready storage
                 and fmt.to_cutlass_dtype() == ab_dtype
                 and torch2cute_dtype_map[fmt.scale_dtype] == sf_dtype
                 and fmt.sf_vec_size == sf_vec_size
@@ -157,39 +282,93 @@ class BlockScaledFormat:
 
 
 MXFP8_E4M3 = BlockScaledFormat(
-    "mxfp8_e4m3", torch.float8_e4m3fn, "Float8E4M3FN", 8, torch.float8_e8m0fnu, 32
+    "mxfp8_e4m3", torch.float8_e4m3fn, "Float8E4M3FN", 8, 1, torch.float8_e8m0fnu, 32
 )
 MXFP8_E5M2 = BlockScaledFormat(
-    "mxfp8_e5m2", torch.float8_e5m2, "Float8E5M2", 8, torch.float8_e8m0fnu, 32
+    "mxfp8_e5m2", torch.float8_e5m2, "Float8E5M2", 8, 1, torch.float8_e8m0fnu, 32
 )
 MXFP4 = BlockScaledFormat(
-    "mxfp4", torch.float4_e2m1fn_x2, "Float4E2M1FN", 4, torch.float8_e8m0fnu, 32
+    "mxfp4", torch.float4_e2m1fn_x2, "Float4E2M1FN", 4, 2, torch.float8_e8m0fnu, 32
 )
 NVFP4 = BlockScaledFormat(
     "nvfp4",
     torch.float4_e2m1fn_x2,
     "Float4E2M1FN",
     4,
+    2,
     torch.float8_e4m3fn,
     16,
     has_per_tensor_scale=True,
 )
-# MXFP6 qdata is PACKED 6-bit storage in uint8 bytes: each row is the K 6-bit
+# Origin/main's unversioned MXFP6 formats store one 6-bit code per uint8. Keep
+# those names and descriptors byte-for-byte compatible with existing callers,
+# checkpoints, and quantizer outputs. They are host-side compatibility formats:
+# SM100 GEMM consumes the explicitly versioned packed formats below.
+MXFP6_E2M3 = BlockScaledFormat(
+    "mxfp6_e2m3", torch.uint8, "Float6E2M3FN", 6, 1, torch.float8_e8m0fnu, 32
+)
+MXFP6_E3M2 = BlockScaledFormat(
+    "mxfp6_e3m2", torch.uint8, "Float6E3M2FN", 6, 1, torch.float8_e8m0fnu, 32
+)
+
+# Packed MXFP6 qdata is 6-bit storage in uint8 bytes: each row is the K 6-bit
 # codes as a little-endian bit stream (element i occupies bits [6i, 6i+6)), so
 # 4 codes pack into 3 bytes and the storage K extent is 3*K/4 (torch has no fp6
 # dtype, so the bytes are raw uint8). This is the CUTLASS SubbyteReference
 # layout the CU_TENSOR_MAP_DATA_TYPE_16U6 unpack tensormap consumes: TMA
 # expands packed gmem into 8-bit SMEM containers for tcgen05 kind::mxf8f6f4
 # (fp8's SMEM footprint, but 3/4 of its gmem/L2 bandwidth).
-MXFP6_E2M3 = BlockScaledFormat(
-    "mxfp6_e2m3", torch.uint8, "Float6E2M3FN", 6, torch.float8_e8m0fnu, 32
+MXFP6_E2M3_PACKED = BlockScaledFormat(
+    "mxfp6_e2m3_packed",
+    torch.uint8,
+    "Float6E2M3FN",
+    6,
+    1,
+    torch.float8_e8m0fnu,
+    32,
+    storage_layout="packed_lsb_v1",
 )
-MXFP6_E3M2 = BlockScaledFormat(
-    "mxfp6_e3m2", torch.uint8, "Float6E3M2FN", 6, torch.float8_e8m0fnu, 32
+MXFP6_E3M2_PACKED = BlockScaledFormat(
+    "mxfp6_e3m2_packed",
+    torch.uint8,
+    "Float6E3M2FN",
+    6,
+    1,
+    torch.float8_e8m0fnu,
+    32,
+    storage_layout="packed_lsb_v1",
 )
 
+# Deprecated host-side compatibility formats. They remain quantizable,
+# dequantizable, and serializable, but mma_kind_for_pair rejects them: SM100's
+# mixed path consumes densely packed gmem via TMA unpack, not byte containers.
+MXFP4_BYTE = BlockScaledFormat(
+    "mxfp4_byte",
+    torch.uint8,
+    "Float4E2M1FN",
+    4,
+    1,
+    torch.float8_e8m0fnu,
+    32,
+)
+# Names added while packed FP6 was under development remain import aliases,
+# but the public descriptor names are the origin/main unversioned names.
+MXFP6_E2M3_BYTE = MXFP6_E2M3
+MXFP6_E3M2_BYTE = MXFP6_E3M2
+
 BLOCKSCALED_FORMAT_REGISTRY = {
-    fmt.name: fmt for fmt in (MXFP8_E4M3, MXFP8_E5M2, MXFP4, NVFP4, MXFP6_E2M3, MXFP6_E3M2)
+    fmt.name: fmt
+    for fmt in (
+        MXFP8_E4M3,
+        MXFP8_E5M2,
+        MXFP4,
+        NVFP4,
+        MXFP6_E2M3,
+        MXFP6_E3M2,
+        MXFP6_E2M3_PACKED,
+        MXFP6_E3M2_PACKED,
+        MXFP4_BYTE,
+    )
 }
 
 # Worked examples of formats the descriptor already expresses but that are NOT
@@ -201,19 +380,19 @@ BLOCKSCALED_FORMAT_REGISTRY = {
 #
 #   # DeepSeek-style 1x128 fp32-scale fp8 (SM90/SM100 blockwise promotion):
 #   BlockScaledFormat("fp8_e4m3_1x128", torch.float8_e4m3fn, "Float8E4M3FN",
-#                     8, torch.float32, 128)
+#                     8, 1, torch.float32, 128)
 #   # kscale: bf16 elements, per-row fp32 scale every 128 of K (one-sided;
 #   # quantize() would raise - scales are upstream-structural, from_parts only):
 #   BlockScaledFormat("bf16_1x128", torch.bfloat16, "BFloat16",
-#                     16, torch.float32, 128)
+#                     16, 1, torch.float32, 128)
 #   # W4A16 int4-g128 (AWQ/GPTQ-style; uint4b8's fixed offset is element
 #   # decode, not a descriptor field; bf16 scales are just data):
 #   BlockScaledFormat("int4_1x128", torch.uint8, "Int4",
-#                     4, torch.bfloat16, 128)
+#                     4, 2, torch.bfloat16, 128)
 #   # A hypothetical e3m4: no CuTe-DSL element type -> host-side only until a
 #   # kernel declares its own (copy dtype, MMA dtype, convert) triple:
 #   BlockScaledFormat("mxfp8_e3m4", torch.uint8, None,
-#                     8, torch.float8_e8m0fnu, 32)
+#                     8, 1, torch.float8_e8m0fnu, 32)
 #
 # NVFP4 weight-only (W4A16) needs NO new row: the same NVFP4 format pairs with
 # a plain bf16 activation tensor and dispatches to an upconvert kernel per
@@ -223,8 +402,15 @@ BLOCKSCALED_FORMAT_REGISTRY = {
 
 # Legacy short names used by blockscaled_quantize / BLOCKSCALED_FORMATS (the
 # inverse is derived - this dict is the single source of the aliasing).
-_LEGACY_FORMAT_NAMES = {"mxfp8": "mxfp8_e4m3"}
-_CANONICAL_TO_LEGACY = {v: k for k, v in _LEGACY_FORMAT_NAMES.items()}
+_LEGACY_FORMAT_NAMES = {
+    "mxfp8": "mxfp8_e4m3",
+    "mxfp6_e2m3_byte": "mxfp6_e2m3",
+    "mxfp6_e3m2_byte": "mxfp6_e3m2",
+}
+# Only mxfp8 has a preferred legacy generator name. The ``*_byte`` spellings
+# above are lookup-only aliases and must not replace origin/main's stable
+# unversioned keys in BLOCKSCALED_FORMATS.
+_CANONICAL_TO_LEGACY = {"mxfp8_e4m3": "mxfp8"}
 
 
 def legacy_format_name(fmt: "BlockScaledFormat") -> str:
@@ -255,6 +441,12 @@ def mma_kind_for_pair(fmt_a: "BlockScaledFormat", fmt_b: "BlockScaledFormat") ->
     subset in ``GemmSm100.is_valid_dtypes_and_scale_factor_vec_size`` (MMA
     dtypes). ``test_mma_kind_mirrors_kernel_inst_k`` pins the first mirror.
     """
+    for fmt in (fmt_a, fmt_b):
+        if fmt.is_byte_container:
+            raise ValueError(
+                f"{fmt.name} uses deprecated byte-per-element sub-byte storage and is "
+                "host-side compatibility only; call operand.to_packed() before GEMM"
+            )
     if fmt_a.name == "nvfp4" or fmt_b.name == "nvfp4":
         if fmt_a.name == fmt_b.name:
             return "mxf4nvf4"
@@ -307,6 +499,18 @@ def _mma_element_class(fmt: "BlockScaledFormat") -> Optional[str]:
 
 def _coerce_format(format) -> BlockScaledFormat:
     if isinstance(format, BlockScaledFormat):
+        interim_targets = {
+            ("mxfp6_e2m3", "packed_lsb_v1"): MXFP6_E2M3_PACKED,
+            ("mxfp6_e3m2", "packed_lsb_v1"): MXFP6_E3M2_PACKED,
+        }
+        target = interim_targets.get((format.name, getattr(format, "storage_layout", None)))
+        if target is not None:
+            if replace(format, name=target.name) != target:
+                raise ValueError(
+                    f"ambiguous interim packed FP6 descriptor {format.name}: fields do not "
+                    f"match {target.name}"
+                )
+            return target
         return format
     if isinstance(format, str):
         return BlockScaledFormat.from_name(format)
@@ -538,7 +742,14 @@ class BlockScaledOperand:
         if _normalize_quant_dim(dim, x.ndim) == -2:
             xt = x.transpose(-1, -2).contiguous()
             return cls.quantize(xt, fmt, per_tensor_scale=per_tensor_scale).mT
-        quantizer = QUANTIZERS.get(fmt.name)
+        quantizer_name = fmt.name
+        if fmt.is_byte_container:
+            quantizer_name = {
+                "Float4E2M1FN": "mxfp4_byte",
+                "Float6E2M3FN": "mxfp6_e2m3",
+                "Float6E3M2FN": "mxfp6_e3m2",
+            }.get(fmt.cutlass_dtype_name, fmt.name)
+        quantizer = QUANTIZERS.get(quantizer_name)
         if quantizer is None:
             # Every registered format except mxfp8_e5m2 has a quantizer; to_mx has
             # no e5m2 encoder, so from_parts is the e5m2 construction path.
@@ -563,9 +774,9 @@ class BlockScaledOperand:
             pts = pts_out.to(torch.float32) if per_tensor_scale is not None else None
         else:
             q, sc = fn(x_flat, fmt.sf_vec_size)
-        # Quantizers emit packed storage: fp4 as uint8 nibble pairs (re-viewed
-        # to the fp4x2 storage dtype), fp6 as the packed uint8 bit stream
-        # (already the storage dtype), fp8 as the storage dtype directly.
+        # Quantizers emit the descriptor's storage: fp4 as uint8 nibble pairs
+        # (re-viewed to fp4x2), unversioned fp6 as byte codes, packed fp6 as a
+        # uint8 bit stream, and fp8 directly in its storage dtype.
         if q.dtype != fmt.qdata_dtype:
             q = q.view(fmt.qdata_dtype)
         q = q.reshape(*x.shape[:-1], -1)
@@ -573,6 +784,84 @@ class BlockScaledOperand:
         if not batched:
             sf = sf.squeeze(0)
         return _construct(q, sf, fmt, pts, x.dtype, -1)
+
+    def to_packed(self) -> "BlockScaledOperand":
+        """Migrate a deprecated byte-container operand to canonical packed storage.
+
+        The element codes and scale factors are preserved bit-exactly; no
+        dequantize/requantize round trip is involved. Canonical packed operands
+        are returned unchanged.
+        """
+        fmt = self.format
+
+        def check_recipe(target):
+            source_recipe = (
+                fmt.cutlass_dtype_name,
+                fmt.elem_bits,
+                fmt.scale_dtype,
+                fmt.sf_vec_size,
+                fmt.has_per_tensor_scale,
+            )
+            target_recipe = (
+                target.cutlass_dtype_name,
+                target.elem_bits,
+                target.scale_dtype,
+                target.sf_vec_size,
+                target.has_per_tensor_scale,
+            )
+            if source_recipe != target_recipe:
+                raise ValueError(
+                    f"cannot repack {fmt.name} as {target.name}: its element/scale recipe "
+                    "does not match the canonical packed format"
+                )
+
+        if not fmt.is_byte_container:
+            # Packed FP6 briefly shipped with the unversioned byte-format name.
+            # Relabel those descriptors so schema-boundary name resolution does
+            # not reinterpret their 3K/4 storage as one-byte-per-code storage.
+            interim_targets = {
+                ("mxfp6_e2m3", "packed_lsb_v1"): MXFP6_E2M3_PACKED,
+                ("mxfp6_e3m2", "packed_lsb_v1"): MXFP6_E3M2_PACKED,
+            }
+            target = interim_targets.get((fmt.name, getattr(fmt, "storage_layout", None)))
+            if target is not None:
+                check_recipe(target)
+                return _construct(
+                    self.qdata,
+                    self.scale,
+                    target,
+                    self.per_tensor_scale,
+                    self.orig_dtype,
+                    self.quant_dim,
+                )
+            return self
+        from quack.blockscaled.quantize import _pack_uint4, pack_uint6
+
+        targets = {
+            "Float4E2M1FN": MXFP4,
+            "Float6E2M3FN": MXFP6_E2M3_PACKED,
+            "Float6E3M2FN": MXFP6_E3M2_PACKED,
+        }
+        target = targets.get(fmt.cutlass_dtype_name)
+        if target is None:
+            raise NotImplementedError(f"no canonical packed format for {fmt.name}")
+        check_recipe(target)
+        mn_dim, k_dim = self._mn_k_dims()
+        qdata = self.qdata if k_dim == self.ndim - 1 else self.qdata.transpose(mn_dim, k_dim)
+        if target is MXFP4:
+            qdata = _pack_uint4(qdata).view(target.qdata_dtype)
+        else:
+            qdata = pack_uint6(qdata)
+        if k_dim != self.ndim - 1:
+            qdata = qdata.transpose(mn_dim, k_dim)
+        return _construct(
+            qdata,
+            self.scale,
+            target,
+            self.per_tensor_scale,
+            self.orig_dtype,
+            self.quant_dim,
+        )
 
     def dequantize(self, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """Explicit dequantization to a plain high-precision tensor.
@@ -662,18 +951,103 @@ def _construct(qdata, scale, fmt, per_tensor_scale, orig_dtype, quant_dim):
 
 # pytree registration: lets the container cross torch.compile / functional-transform
 # boundaries as a structure of tensor leaves (same mechanics as the legacy tuple).
+_PYTREE_CONTEXT_VERSION = 1
+
+
+def _dtype_to_context(dtype: torch.dtype) -> str:
+    name = str(dtype)
+    if not name.startswith("torch."):
+        raise TypeError(f"cannot serialize torch dtype {dtype!r}")
+    return name.removeprefix("torch.")
+
+
+def _dtype_from_context(name) -> torch.dtype:
+    # Old three-tuple contexts carried the dtype object directly.
+    if isinstance(name, torch.dtype):
+        return name
+    if not isinstance(name, str):
+        raise TypeError(f"invalid serialized torch dtype {name!r}")
+    dtype = getattr(torch, name.removeprefix("torch."), None)
+    if not isinstance(dtype, torch.dtype):
+        raise ValueError(f"unknown serialized torch dtype {name!r}")
+    return dtype
+
+
+def _format_to_context(fmt: BlockScaledFormat) -> dict:
+    """Encode every descriptor field using JSON scalar values only."""
+    return {
+        "name": fmt.name,
+        "qdata_dtype": _dtype_to_context(fmt.qdata_dtype),
+        "cutlass_dtype_name": fmt.cutlass_dtype_name,
+        "elem_bits": fmt.elem_bits,
+        "elems_per_container": fmt.elems_per_container,
+        "scale_dtype": _dtype_to_context(fmt.scale_dtype),
+        "sf_vec_size": fmt.sf_vec_size,
+        "has_per_tensor_scale": fmt.has_per_tensor_scale,
+        "storage_layout": getattr(fmt, "storage_layout", None),
+    }
+
+
+def _format_from_context(context: dict) -> BlockScaledFormat:
+    if not isinstance(context, dict):
+        raise TypeError(f"invalid serialized BlockScaledFormat context {context!r}")
+    fmt = BlockScaledFormat(
+        name=context["name"],
+        qdata_dtype=_dtype_from_context(context["qdata_dtype"]),
+        cutlass_dtype_name=context["cutlass_dtype_name"],
+        elem_bits=context["elem_bits"],
+        elems_per_container=context["elems_per_container"],
+        scale_dtype=_dtype_from_context(context["scale_dtype"]),
+        sf_vec_size=context["sf_vec_size"],
+        has_per_tensor_scale=context["has_per_tensor_scale"],
+        storage_layout=context.get("storage_layout"),
+    )
+    registered = BLOCKSCALED_FORMAT_REGISTRY.get(fmt.name)
+    return registered if registered == fmt else fmt
+
+
 def _flatten(op: BlockScaledOperand):
     children = (op.qdata, op.scale, op.per_tensor_scale)
-    ctx = (op.format.name, op.orig_dtype, op.quant_dim)
+    ctx = {
+        "version": _PYTREE_CONTEXT_VERSION,
+        "format": _format_to_context(op.format),
+        "orig_dtype": _dtype_to_context(op.orig_dtype),
+        "quant_dim": op.quant_dim,
+    }
     return children, ctx
 
 
 def _unflatten(children, ctx):
     qdata, scale, pts = children
-    name, orig_dtype, quant_dim = ctx
-    return BlockScaledOperand(
-        qdata, scale, BlockScaledFormat.from_name(name), pts, orig_dtype, quant_dim
-    )
+    if isinstance(ctx, dict):
+        version = ctx.get("version")
+        if version != _PYTREE_CONTEXT_VERSION:
+            raise ValueError(f"unsupported BlockScaledOperand pytree context version {version!r}")
+        fmt = _format_from_context(ctx["format"])
+        orig_dtype = _dtype_from_context(ctx["orig_dtype"])
+        quant_dim = ctx["quant_dim"]
+    else:
+        # Origin/main emitted (format_name, torch.dtype, quant_dim). Also accept
+        # the descriptor-valued three-tuple used briefly during packed-FP6
+        # development so in-memory TreeSpecs remain reconstructible.
+        if not isinstance(ctx, (tuple, list)) or len(ctx) != 3:
+            raise TypeError(f"invalid legacy BlockScaledOperand pytree context {ctx!r}")
+        fmt_or_name, orig_dtype, quant_dim = ctx
+        fmt = (
+            fmt_or_name
+            if isinstance(fmt_or_name, BlockScaledFormat)
+            else BlockScaledFormat.from_name(fmt_or_name)
+        )
+        orig_dtype = _dtype_from_context(orig_dtype)
+    return BlockScaledOperand(qdata, scale, fmt, pts, orig_dtype, quant_dim)
+
+
+def _dump_pytree_context(ctx):
+    return ctx
+
+
+def _load_pytree_context(ctx):
+    return ctx
 
 
 _pytree.register_pytree_node(
@@ -681,6 +1055,8 @@ _pytree.register_pytree_node(
     _flatten,
     _unflatten,
     serialized_type_name="quack.blockscaled.operand.BlockScaledOperand",
+    to_dumpable_context=_dump_pytree_context,
+    from_dumpable_context=_load_pytree_context,
 )
 
 # weights_only torch.load of pickled containers needs the classes allowlisted.

--- a/quack/blockscaled/operand.py
+++ b/quack/blockscaled/operand.py
@@ -751,8 +751,8 @@ class BlockScaledOperand:
             }.get(fmt.cutlass_dtype_name, fmt.name)
         quantizer = QUANTIZERS.get(quantizer_name)
         if quantizer is None:
-            # Every registered format except mxfp8_e5m2 has a quantizer; to_mx has
-            # no e5m2 encoder, so from_parts is the e5m2 construction path.
+            # Every registered format has a quantizer; this is the path for
+            # custom (unregistered) descriptors.
             raise NotImplementedError(
                 f"no in-repo quantizer for {fmt.name}; construct pre-quantized data via from_parts"
             )

--- a/quack/blockscaled/quantize.py
+++ b/quack/blockscaled/quantize.py
@@ -20,6 +20,8 @@ import torch
 
 F8E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
 F8E4M3_MAX_POW2 = 8
+F8E5M2_MAX = torch.finfo(torch.float8_e5m2).max  # 57344.0
+F8E5M2_MAX_POW2 = 15
 E8M0_EXPONENT_BIAS = 127
 E8M0_EXPONENT_NAN_VAL = 255
 F32_EXP_BIAS = 127
@@ -40,26 +42,40 @@ def _n_ones(n: int) -> int:
     return (1 << n) - 1
 
 
-def to_mx(data_hp: torch.Tensor, block_size: int = 32, scaling_mode: str = "rceil"):
-    """MXFP8-e4m3 quantization.
+def to_mx(
+    data_hp: torch.Tensor,
+    block_size: int = 32,
+    scaling_mode: str = "rceil",
+    elem_dtype: torch.dtype = torch.float8_e4m3fn,
+):
+    """MXFP8 quantization (e4m3 or e5m2 target).
 
     Args:
         data_hp: (..., K) bf16 or fp32 tensor, contiguous, K % block_size == 0.
         scaling_mode:
-            "rceil" (default): scale = 2^ceil(log2(max_abs / 448)), the OCP MX
-                hardware-conversion rule — the smallest power of two such that
-                the block max never saturates e4m3. NVIDIA's MXFP8 pretraining
-                recipe (arXiv:2506.08027) requires this for bf16 loss parity.
-            "floor": scale = 2^(floor(log2(max_abs)) - 8), torchao's MX default;
-                clips block maxima in (448, 512)·2^e. Kept for torchao parity.
+            "rceil" (default): scale = 2^ceil(log2(max_abs / fp8_max)), the OCP
+                MX hardware-conversion rule — the smallest power of two such
+                that the block max never saturates the target fp8 type.
+                NVIDIA's MXFP8 pretraining recipe (arXiv:2506.08027) requires
+                this for bf16 loss parity.
+            "floor": scale = 2^(floor(log2(max_abs)) - max_pow2), torchao's MX
+                default; clips block maxima in (fp8_max, 2^(max_pow2+1))·2^e.
+                Kept for torchao parity.
+        elem_dtype: float8_e4m3fn (default) or float8_e5m2 (fp8_max 448 / 57344).
     Returns:
-        qdata: (..., K) float8_e4m3fn
+        qdata: (..., K) elem_dtype
         scale: (..., K // block_size) float8_e8m0fnu
     """
     assert data_hp.dtype in (torch.bfloat16, torch.float32)
     assert data_hp.shape[-1] % block_size == 0
     assert data_hp.is_contiguous()
     assert scaling_mode in ("rceil", "floor")
+    assert elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    fp8_max, fp8_max_pow2 = (
+        (F8E4M3_MAX, F8E4M3_MAX_POW2)
+        if elem_dtype == torch.float8_e4m3fn
+        else (F8E5M2_MAX, F8E5M2_MAX_POW2)
+    )
 
     orig_shape = data_hp.shape
     data_hp = data_hp.reshape(*orig_shape[:-1], orig_shape[-1] // block_size, block_size)
@@ -69,9 +85,9 @@ def to_mx(data_hp: torch.Tensor, block_size: int = 32, scaling_mode: str = "rcei
     max_abs = max_abs.to(torch.float32)
 
     if scaling_mode == "rceil":
-        scale_e8m0_biased = _compute_e8m0_scale_rceil(max_abs, F8E4M3_MAX)
+        scale_e8m0_biased = _compute_e8m0_scale_rceil(max_abs, fp8_max)
     else:
-        scale_e8m0_biased = _compute_e8m0_scale_floor(max_abs, F8E4M3_MAX_POW2)
+        scale_e8m0_biased = _compute_e8m0_scale_floor(max_abs, fp8_max_pow2)
 
     # reconstruct fp32 scale from biased exponent
     scale_fp32 = (torch.bitwise_left_shift(scale_e8m0_biased.to(torch.int32), MBITS_F32)).view(
@@ -83,11 +99,17 @@ def to_mx(data_hp: torch.Tensor, block_size: int = 32, scaling_mode: str = "rcei
     data_lp = data_hp / scale_fp32
     # eager fp8 cast is unsaturated; clamp explicitly
     if not torch._dynamo.is_compiling():
-        data_lp = torch.clamp(data_lp, min=-F8E4M3_MAX, max=F8E4M3_MAX)
+        data_lp = torch.clamp(data_lp, min=-fp8_max, max=fp8_max)
 
-    qdata = data_lp.to(torch.float8_e4m3fn).reshape(orig_shape)
+    qdata = data_lp.to(elem_dtype).reshape(orig_shape)
     scale = scale_e8m0_biased.view(torch.float8_e8m0fnu).squeeze(-1)
     return qdata, scale
+
+
+def to_mx_e5m2(data_hp: torch.Tensor, block_size: int = 32, scaling_mode: str = "rceil"):
+    """MXFP8-e5m2 quantization: :func:`to_mx` with the e5m2 target (fp8_max
+    57344), positional-signature-compatible with the QUANTIZERS registry."""
+    return to_mx(data_hp, block_size, scaling_mode, elem_dtype=torch.float8_e5m2)
 
 
 def to_mx_dim0(data_hp: torch.Tensor, block_size: int = 32, scaling_mode: str = "rceil"):
@@ -434,14 +456,14 @@ def to_nvfp4(x: torch.Tensor, block_size: int = 16, per_tensor_scale=None):
 _COMPILE_KW = dict(dynamic=False, recompile_limit=64)
 
 to_mx_compiled = torch.compile(to_mx, **_COMPILE_KW)
+to_mx_e5m2_compiled = torch.compile(to_mx_e5m2, **_COMPILE_KW)
 to_mx_dim0_compiled = torch.compile(to_mx_dim0, **_COMPILE_KW)
 to_mxfp4_compiled = torch.compile(to_mxfp4, **_COMPILE_KW)
 to_nvfp4_compiled = torch.compile(to_nvfp4, **_COMPILE_KW)
 
 # In-repo quantizers by canonical format name: (eager fn, torch.compile'd fn).
 # Membership is the single source of "which formats can be quantized in-repo";
-# formats without an entry (mxfp8_e5m2) are from_parts-only until an encoder
-# lands.
+# formats without an entry are from_parts-only until an encoder lands.
 to_mxfp6_e2m3_compiled = torch.compile(to_mxfp6_e2m3, dynamic=True)
 to_mxfp6_e3m2_compiled = torch.compile(to_mxfp6_e3m2, dynamic=True)
 to_mxfp6_e2m3_packed_compiled = torch.compile(to_mxfp6_e2m3_packed, dynamic=True)
@@ -452,6 +474,7 @@ to_mxfp6_e3m2_byte_compiled = to_mxfp6_e3m2_compiled
 
 QUANTIZERS = {
     "mxfp8_e4m3": (to_mx, to_mx_compiled),
+    "mxfp8_e5m2": (to_mx_e5m2, to_mx_e5m2_compiled),
     "mxfp4": (to_mxfp4, to_mxfp4_compiled),
     "mxfp4_byte": (to_mxfp4_byte, to_mxfp4_byte_compiled),
     "mxfp6_e2m3": (to_mxfp6_e2m3, to_mxfp6_e2m3_compiled),

--- a/quack/blockscaled/quantize.py
+++ b/quack/blockscaled/quantize.py
@@ -327,22 +327,48 @@ def _to_mx_floatx_unpacked(x: torch.Tensor, block_size: int, ebits: int, mbits: 
     return codes, scale
 
 
+def to_mxfp4_byte(x: torch.Tensor, block_size: int = 32):
+    """Deprecated MXFP4 byte-container compatibility encoder.
+
+    Produces one E2M1 code per uint8. This representation remains useful for
+    old checkpoints and host-side conversion, but blockscaled GEMM requires
+    canonical packed ``mxfp4`` storage.
+    """
+    return _to_mx_floatx_unpacked(x, block_size, EBITS_F4_E2M1, MBITS_F4_E2M1, F4_E2M1_MAX_POW2)
+
+
 def to_mxfp6_e2m3(x: torch.Tensor, block_size: int = 32):
+    """MXFP6-E2M3 quantization using origin/main's byte-container layout."""
+    return _to_mx_floatx_unpacked(x, block_size, 2, 3, F6_E2M3_MAX_POW2)
+
+
+def to_mxfp6_e3m2(x: torch.Tensor, block_size: int = 32):
+    """MXFP6-E3M2 quantization using origin/main's byte-container layout."""
+    return _to_mx_floatx_unpacked(x, block_size, 3, 2, F6_E3M2_MAX_POW2)
+
+
+def to_mxfp6_e2m3_packed(x: torch.Tensor, block_size: int = 32):
     """MXFP6-E2M3 quantization: packed 6-bit codes + E8M0 scales.
 
     Returns (qdata_packed uint8 (..., 3*K//4) - see :func:`pack_uint6` for the
     bit stream layout - and scale float8_e8m0fnu (..., K // block_size)).
     Requires K % 4 == 0 (subsumed by K % block_size == 0 for block_size 32).
     """
-    codes, scale = _to_mx_floatx_unpacked(x, block_size, 2, 3, F6_E2M3_MAX_POW2)
+    codes, scale = to_mxfp6_e2m3(x, block_size)
     return pack_uint6(codes), scale
 
 
-def to_mxfp6_e3m2(x: torch.Tensor, block_size: int = 32):
+def to_mxfp6_e3m2_packed(x: torch.Tensor, block_size: int = 32):
     """MXFP6-E3M2 quantization: packed 6-bit codes + E8M0 scales (see
-    :func:`to_mxfp6_e2m3` for the layout)."""
-    codes, scale = _to_mx_floatx_unpacked(x, block_size, 3, 2, F6_E3M2_MAX_POW2)
+    :func:`to_mxfp6_e2m3_packed` for the layout)."""
+    codes, scale = to_mxfp6_e3m2(x, block_size)
     return pack_uint6(codes), scale
+
+
+# Compatibility aliases introduced during packed-FP6 development. The
+# unversioned functions are the stable origin/main byte-container API.
+to_mxfp6_e2m3_byte = to_mxfp6_e2m3
+to_mxfp6_e3m2_byte = to_mxfp6_e3m2
 
 
 def nvfp4_per_tensor_scale(amax: torch.Tensor) -> torch.Tensor:
@@ -418,12 +444,20 @@ to_nvfp4_compiled = torch.compile(to_nvfp4, **_COMPILE_KW)
 # lands.
 to_mxfp6_e2m3_compiled = torch.compile(to_mxfp6_e2m3, dynamic=True)
 to_mxfp6_e3m2_compiled = torch.compile(to_mxfp6_e3m2, dynamic=True)
+to_mxfp6_e2m3_packed_compiled = torch.compile(to_mxfp6_e2m3_packed, dynamic=True)
+to_mxfp6_e3m2_packed_compiled = torch.compile(to_mxfp6_e3m2_packed, dynamic=True)
+to_mxfp4_byte_compiled = torch.compile(to_mxfp4_byte, dynamic=True)
+to_mxfp6_e2m3_byte_compiled = to_mxfp6_e2m3_compiled
+to_mxfp6_e3m2_byte_compiled = to_mxfp6_e3m2_compiled
 
 QUANTIZERS = {
     "mxfp8_e4m3": (to_mx, to_mx_compiled),
     "mxfp4": (to_mxfp4, to_mxfp4_compiled),
+    "mxfp4_byte": (to_mxfp4_byte, to_mxfp4_byte_compiled),
     "mxfp6_e2m3": (to_mxfp6_e2m3, to_mxfp6_e2m3_compiled),
     "mxfp6_e3m2": (to_mxfp6_e3m2, to_mxfp6_e3m2_compiled),
+    "mxfp6_e2m3_packed": (to_mxfp6_e2m3_packed, to_mxfp6_e2m3_packed_compiled),
+    "mxfp6_e3m2_packed": (to_mxfp6_e3m2_packed, to_mxfp6_e3m2_packed_compiled),
     "nvfp4": (to_nvfp4, to_nvfp4_compiled),
 }
 
@@ -504,8 +538,14 @@ def floatx_unpacked_to_value(codes: torch.Tensor, ebits: int, mbits: int) -> tor
     return sign * torch.where(exp > 0, normal, subnormal)
 
 
-# unpacked-code (ebits, mbits) per packed-fp6 format name
-_FP6_CODE_BITS = {"mxfp6_e2m3": (2, 3), "mxfp6_e3m2": (3, 2)}
+# Low-bit code shape by CuTe-DSL element type. Storage layout decides whether
+# the uint8 tensor is decoded directly (legacy byte container) or unpacked
+# first (packed_lsb_v1); the format name alone is deliberately insufficient.
+_FLOATX_CODE_BITS = {
+    "Float4E2M1FN": (2, 1),
+    "Float6E2M3FN": (2, 3),
+    "Float6E3M2FN": (3, 2),
+}
 
 
 def dequant_operand(x: torch.Tensor, fmt=None) -> torch.Tensor:
@@ -522,12 +562,17 @@ def dequant_operand(x: torch.Tensor, fmt=None) -> torch.Tensor:
         hi = _fp4_unpacked_to_value((u8 >> 4) & 0x0F)
         return torch.stack([lo, hi], dim=-1).reshape(*x.shape[:-1], x.shape[-1] * 2)
     if x.dtype == torch.uint8:
-        if fmt is None or fmt.name not in _FP6_CODE_BITS:
+        bits = None if fmt is None else _FLOATX_CODE_BITS.get(fmt.cutlass_dtype_name)
+        if bits is None:
             raise ValueError(
-                "uint8 operand bytes are ambiguous; pass the packed-fp6 "
-                "BlockScaledFormat (mxfp6_e2m3 / mxfp6_e3m2)"
+                "uint8 operand bytes are ambiguous; pass a supported byte-container "
+                "or packed-fp6 BlockScaledFormat"
             )
-        return floatx_unpacked_to_value(unpack_uint6(x), *_FP6_CODE_BITS[fmt.name])
+        if getattr(fmt, "storage_layout", None) == "packed_lsb_v1":
+            if fmt.elem_bits != 6:
+                raise ValueError(f"packed_lsb_v1 dequantization is unsupported for {fmt.name}")
+            x = unpack_uint6(x)
+        return floatx_unpacked_to_value(x, *bits)
     return x.float()
 
 

--- a/quack/blockscaled/quantize.py
+++ b/quack/blockscaled/quantize.py
@@ -191,6 +191,42 @@ def _pack_uint4(uint8_data: torch.Tensor) -> torch.Tensor:
     return (uint8_data[::2] | uint8_data[1::2] << 4).view(*shape[:-1], shape[-1] // 2)
 
 
+def pack_uint6(codes: torch.Tensor) -> torch.Tensor:
+    """Pack 6-bit codes (one per uint8, low 6 bits) into a little-endian bit
+    stream along the last dim: element i occupies bits [6*i, 6*i + 6) of its
+    row, so 4 codes pack into 3 bytes as
+
+        b0 = c0 | (c1 << 6);  b1 = (c1 >> 2) | (c2 << 4);  b2 = (c2 >> 4) | (c3 << 2)
+
+    (..., K) uint8 -> (..., 3*K//4) uint8. This is the CUTLASS SubbyteReference
+    bit order - the gmem layout the CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B unpack
+    tensormap consumes (verified bit-exact against the DSL's fp6 fill kernel).
+    """
+    assert codes.dtype == torch.uint8
+    k = codes.shape[-1]
+    assert k % 4 == 0, f"K ({k}) must be divisible by 4 to pack 6-bit codes"
+    c = codes.reshape(*codes.shape[:-1], k // 4, 4)
+    c0, c1, c2, c3 = c[..., 0], c[..., 1], c[..., 2], c[..., 3]
+    # uint8 shifts truncate mod 256, keeping exactly the in-byte bits.
+    packed = torch.stack([c0 | (c1 << 6), (c1 >> 2) | (c2 << 4), (c2 >> 4) | (c3 << 2)], dim=-1)
+    return packed.reshape(*codes.shape[:-1], 3 * (k // 4))
+
+
+def unpack_uint6(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`pack_uint6`: (..., 3*K//4) uint8 bit stream ->
+    (..., K) uint8 codes in the low 6 bits."""
+    assert packed.dtype == torch.uint8
+    kb = packed.shape[-1]
+    assert kb % 3 == 0, f"packed extent ({kb}) must be whole 3-byte groups"
+    b = packed.reshape(*packed.shape[:-1], kb // 3, 3)
+    b0, b1, b2 = b[..., 0], b[..., 1], b[..., 2]
+    codes = torch.stack(
+        [b0 & 0x3F, (b0 >> 6) | ((b1 & 0x0F) << 2), (b1 >> 4) | ((b2 & 0x03) << 4), b2 >> 2],
+        dim=-1,
+    )
+    return codes.reshape(*packed.shape[:-1], kb // 3 * 4)
+
+
 def _compute_e8m0_scale_floor(max_abs: torch.Tensor, target_max_pow2: int) -> torch.Tensor:
     """Return biased E8M0 scale (uint8) for FLOOR-mode MX quantization."""
     max_abs_int32 = max_abs.view(torch.int32)
@@ -263,8 +299,9 @@ F6_E3M2_MAX_POW2 = 4
 
 
 def _to_mx_floatx_unpacked(x: torch.Tensor, block_size: int, ebits: int, mbits: int, max_pow2: int):
-    """E8M0-scaled quantization to UNPACKED floatx codes (one code per uint8 -
-    the byte-container storage kind::mxf8f6f4 consumes), FLOOR scaling.
+    """E8M0-scaled quantization to UNPACKED floatx codes (one code per uint8,
+    in the low bits), FLOOR scaling. The code<->value logic is shared; storage
+    packing (e.g. :func:`pack_uint6` for fp6) is a separate step on top.
 
     Returns (codes uint8 (..., K), scale float8_e8m0fnu (..., K // block_size)).
     """
@@ -290,20 +327,22 @@ def _to_mx_floatx_unpacked(x: torch.Tensor, block_size: int, ebits: int, mbits: 
     return codes, scale
 
 
-def to_mxfp4_byte(x: torch.Tensor, block_size: int = 32):
-    """MXFP4 with byte-container storage (one E2M1 code per uint8): the form
-    kind::mxf8f6f4 consumes, enabling mixed fp4 x fp8/fp6 pairs."""
-    return _to_mx_floatx_unpacked(x, block_size, EBITS_F4_E2M1, MBITS_F4_E2M1, F4_E2M1_MAX_POW2)
-
-
 def to_mxfp6_e2m3(x: torch.Tensor, block_size: int = 32):
-    """MXFP6-E2M3 quantization (byte-container uint8 codes + E8M0 scales)."""
-    return _to_mx_floatx_unpacked(x, block_size, 2, 3, F6_E2M3_MAX_POW2)
+    """MXFP6-E2M3 quantization: packed 6-bit codes + E8M0 scales.
+
+    Returns (qdata_packed uint8 (..., 3*K//4) - see :func:`pack_uint6` for the
+    bit stream layout - and scale float8_e8m0fnu (..., K // block_size)).
+    Requires K % 4 == 0 (subsumed by K % block_size == 0 for block_size 32).
+    """
+    codes, scale = _to_mx_floatx_unpacked(x, block_size, 2, 3, F6_E2M3_MAX_POW2)
+    return pack_uint6(codes), scale
 
 
 def to_mxfp6_e3m2(x: torch.Tensor, block_size: int = 32):
-    """MXFP6-E3M2 quantization (byte-container uint8 codes + E8M0 scales)."""
-    return _to_mx_floatx_unpacked(x, block_size, 3, 2, F6_E3M2_MAX_POW2)
+    """MXFP6-E3M2 quantization: packed 6-bit codes + E8M0 scales (see
+    :func:`to_mxfp6_e2m3` for the layout)."""
+    codes, scale = _to_mx_floatx_unpacked(x, block_size, 3, 2, F6_E3M2_MAX_POW2)
+    return pack_uint6(codes), scale
 
 
 def nvfp4_per_tensor_scale(amax: torch.Tensor) -> torch.Tensor:
@@ -375,16 +414,14 @@ to_nvfp4_compiled = torch.compile(to_nvfp4, **_COMPILE_KW)
 
 # In-repo quantizers by canonical format name: (eager fn, torch.compile'd fn).
 # Membership is the single source of "which formats can be quantized in-repo";
-# formats without an entry (mxfp8_e5m2, fp6) are from_parts-only until an
-# encoder lands.
-to_mxfp4_byte_compiled = torch.compile(to_mxfp4_byte, dynamic=True)
+# formats without an entry (mxfp8_e5m2) are from_parts-only until an encoder
+# lands.
 to_mxfp6_e2m3_compiled = torch.compile(to_mxfp6_e2m3, dynamic=True)
 to_mxfp6_e3m2_compiled = torch.compile(to_mxfp6_e3m2, dynamic=True)
 
 QUANTIZERS = {
     "mxfp8_e4m3": (to_mx, to_mx_compiled),
     "mxfp4": (to_mxfp4, to_mxfp4_compiled),
-    "mxfp4_byte": (to_mxfp4_byte, to_mxfp4_byte_compiled),
     "mxfp6_e2m3": (to_mxfp6_e2m3, to_mxfp6_e2m3_compiled),
     "mxfp6_e3m2": (to_mxfp6_e3m2, to_mxfp6_e3m2_compiled),
     "nvfp4": (to_nvfp4, to_nvfp4_compiled),
@@ -467,8 +504,8 @@ def floatx_unpacked_to_value(codes: torch.Tensor, ebits: int, mbits: int) -> tor
     return sign * torch.where(exp > 0, normal, subnormal)
 
 
-# unpacked-code (ebits, mbits) per byte-container format name
-_FLOATX_CODE_BITS = {"mxfp4_byte": (2, 1), "mxfp6_e2m3": (2, 3), "mxfp6_e3m2": (3, 2)}
+# unpacked-code (ebits, mbits) per packed-fp6 format name
+_FP6_CODE_BITS = {"mxfp6_e2m3": (2, 3), "mxfp6_e3m2": (3, 2)}
 
 
 def dequant_operand(x: torch.Tensor, fmt=None) -> torch.Tensor:
@@ -476,8 +513,8 @@ def dequant_operand(x: torch.Tensor, fmt=None) -> torch.Tensor:
 
     fp8 tensors convert directly; ``float4_e2m1fn_x2`` tensors unpack two codes
     per byte (low nibble = even K, high nibble = odd K), doubling the last dim.
-    uint8 byte-container codes (fp6, byte-fp4) are ambiguous from the dtype
-    alone - pass the BlockScaledFormat.
+    uint8 packed-fp6 bit streams (3 bytes per 4 codes along the last dim) are
+    ambiguous from the dtype alone - pass the BlockScaledFormat.
     """
     if x.dtype == torch.float4_e2m1fn_x2:
         u8 = x.view(torch.uint8)
@@ -485,12 +522,12 @@ def dequant_operand(x: torch.Tensor, fmt=None) -> torch.Tensor:
         hi = _fp4_unpacked_to_value((u8 >> 4) & 0x0F)
         return torch.stack([lo, hi], dim=-1).reshape(*x.shape[:-1], x.shape[-1] * 2)
     if x.dtype == torch.uint8:
-        if fmt is None or fmt.name not in _FLOATX_CODE_BITS:
+        if fmt is None or fmt.name not in _FP6_CODE_BITS:
             raise ValueError(
-                "uint8 operand codes are ambiguous; pass the byte-container "
-                "BlockScaledFormat (mxfp4_byte / mxfp6_*)"
+                "uint8 operand bytes are ambiguous; pass the packed-fp6 "
+                "BlockScaledFormat (mxfp6_e2m3 / mxfp6_e3m2)"
             )
-        return floatx_unpacked_to_value(x, *_FLOATX_CODE_BITS[fmt.name])
+        return floatx_unpacked_to_value(unpack_uint6(x), *_FP6_CODE_BITS[fmt.name])
     return x.float()
 
 

--- a/quack/blockscaled/utils.py
+++ b/quack/blockscaled/utils.py
@@ -335,9 +335,8 @@ def _blockscaled_format_of(ab_dtype, sf_dtype, sf_vec_size) -> str:
     """Identify which quantizer-backed format the (ab, sf, vec) tuple corresponds to.
 
     Thin shim over :meth:`BlockScaledFormat.from_cutlass_dtypes` returning the legacy short
-    name this module's test/bench generators branch on. Formats without an
-    direct-compiler storage path (e5m2, packed fp6) are rejected. Packed fp6
-    requires the unified API's separate storage and MMA dtype plumbing.
+    name this module's test/bench generators branch on. Packed fp6 is rejected:
+    it requires the unified API's separate storage and MMA dtype plumbing.
     """
     from quack.blockscaled.operand import BlockScaledFormat
 
@@ -345,10 +344,10 @@ def _blockscaled_format_of(ab_dtype, sf_dtype, sf_vec_size) -> str:
         fmt = BlockScaledFormat.from_cutlass_dtypes(ab_dtype, sf_dtype, sf_vec_size)
     except ValueError:
         fmt = None
-    if fmt is None or fmt.name not in {"mxfp8_e4m3", "mxfp4", "nvfp4"}:
+    if fmt is None or fmt.name not in {"mxfp8_e4m3", "mxfp8_e5m2", "mxfp4", "nvfp4"}:
         raise ValueError(
             f"init=quant does not support (ab={ab_dtype}, sf={sf_dtype}, vec={sf_vec_size}). "
-            f"Supported: MXFP8 (e4m3+e8m0+32), MXFP4 (e2m1+e8m0+32), "
+            f"Supported: MXFP8 (e4m3/e5m2+e8m0+32), MXFP4 (e2m1+e8m0+32), "
             f"NVFP4 (e2m1+e4m3+16)."
         )
     return legacy_format_name(fmt)
@@ -375,7 +374,8 @@ def create_blockscaled_operand_quantized(
            `scale_blocked_for_cublas` for cuBLAS.
     """
     fmt = _blockscaled_format_of(ab_dtype, sf_dtype, sf_vec_size)
-    if is_mn_major and fmt != "mxfp8":
+    is_mxfp8 = fmt in ("mxfp8", "mxfp8_e5m2")
+    if is_mn_major and not is_mxfp8:
         raise NotImplementedError(
             f"is_mn_major=True is only supported for MXFP8 (tcgen05 MMA requires "
             f"K-major for MXFP4/NVFP4 operands); got fmt={fmt}"
@@ -387,8 +387,9 @@ def create_blockscaled_operand_quantized(
     x_hp = (torch.randn(l, mn, k, dtype=torch.bfloat16, device="cuda") * std).contiguous()
     x_flat = x_hp.view(l * mn, k)
 
-    if fmt == "mxfp8":
-        q_flat, scale_2d = to_mx_compiled(x_flat, sf_vec_size)  # (l*mn, k), (l*mn, sf_k)
+    if is_mxfp8:
+        to_fp8 = to_mx_compiled if fmt == "mxfp8" else QUANTIZERS["mxfp8_e5m2"][1]
+        q_flat, scale_2d = to_fp8(x_flat, sf_vec_size)  # (l*mn, k), (l*mn, sf_k)
         if is_mn_major:
             # Operand: (mn, k, l) MN-major. Start from (l, mn, k) contig, transpose
             # to (l, k, mn) contig, then permute to (mn, k, l) with strides (1, mn, mn*k).
@@ -460,9 +461,8 @@ def create_blockscaled_varlen_m_operands(
       cu_seqlens_m: (num_experts+1,) int32
 
     Supports all kernel-ready SM100 formats. Packed fp4/fp6 formats require
-    b_major="k". MXFP8 E5M2 is constructed by quantizing as E4M3 and value-casting
-    the codes, matching the dense benchmark path. NVFP4 uses no per-tensor scale
-    here (it would just fold into alpha).
+    b_major="k". NVFP4 uses no per-tensor scale here (it would just fold into
+    alpha).
     """
     assert k % sf_vec_size == 0
     if seqlens_m is None:
@@ -481,11 +481,7 @@ def create_blockscaled_varlen_m_operands(
     def quantize(x2d):
         """(rows, k) bf16 -> packed qdata, 2D scales, and dequantized reference."""
         if fmt.name in ("mxfp8_e4m3", "mxfp8_e5m2"):
-            q, sc = to_mx_compiled(x2d, sf_vec_size)
-            if fmt.name == "mxfp8_e5m2":
-                # There is no in-repo E5M2 encoder. Match the dense benchmark:
-                # quantize to E4M3, then value-cast the stored codes to E5M2.
-                q = q.float().to(torch.float8_e5m2)
+            q, sc = QUANTIZERS[fmt.name][1](x2d, sf_vec_size)
             vals = q.float()
         elif fmt.name in ("mxfp4", "nvfp4"):
             if fmt.name == "mxfp4":

--- a/quack/blockscaled/utils.py
+++ b/quack/blockscaled/utils.py
@@ -145,9 +145,11 @@ def _create_fp4_operand_tensor(
 ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
     if is_mode0_major:
         raise ValueError("Float4E2M1FN blockscaled operands must be K-major")
+    # (mn, k/2, l) K-major view of a contiguous (l, mn, k/2) buffer; allocating
+    # (mn, k/2, l) directly would put stride 1 on L instead of K for l > 1.
     tensor = torch.empty(
-        (mode0, ceil_div(mode1, 2), l), dtype=torch.float4_e2m1fn_x2, device="cuda"
-    )
+        (l, mode0, ceil_div(mode1, 2)), dtype=torch.float4_e2m1fn_x2, device="cuda"
+    ).permute(1, 2, 0)
     tensor.view(torch.uint8).zero_()
     if init == "empty":
         return None, tensor

--- a/quack/blockscaled/utils.py
+++ b/quack/blockscaled/utils.py
@@ -18,6 +18,7 @@ from quack.gemm_default_epi import GemmDefaultSm100
 from quack.gemm_tvm_ffi_utils import div_for_dtype, make_scheduler_args
 from quack.blockscaled.operand import (
     BLOCKSCALED_FORMAT_REGISTRY,
+    BlockScaledFormat,
     BlockScaledOperand,
     legacy_format_name,
 )
@@ -335,7 +336,8 @@ def _blockscaled_format_of(ab_dtype, sf_dtype, sf_vec_size) -> str:
 
     Thin shim over :meth:`BlockScaledFormat.from_cutlass_dtypes` returning the legacy short
     name this module's test/bench generators branch on. Formats without an
-    in-repo quantizer (e5m2, fp6) are rejected - init=quant cannot produce them.
+    direct-compiler storage path (e5m2, packed fp6) are rejected. Packed fp6
+    requires the unified API's separate storage and MMA dtype plumbing.
     """
     from quack.blockscaled.operand import BlockScaledFormat
 
@@ -343,10 +345,11 @@ def _blockscaled_format_of(ab_dtype, sf_dtype, sf_vec_size) -> str:
         fmt = BlockScaledFormat.from_cutlass_dtypes(ab_dtype, sf_dtype, sf_vec_size)
     except ValueError:
         fmt = None
-    if fmt is None or fmt.name not in QUANTIZERS:
+    if fmt is None or fmt.name not in {"mxfp8_e4m3", "mxfp4", "nvfp4"}:
         raise ValueError(
             f"init=quant does not support (ab={ab_dtype}, sf={sf_dtype}, vec={sf_vec_size}). "
-            f"Supported: MXFP8 (e4m3+e8m0+32), MXFP4 (e2m1+e8m0+32), NVFP4 (e2m1+e4m3+16)."
+            f"Supported: MXFP8 (e4m3+e8m0+32), MXFP4 (e2m1+e8m0+32), "
+            f"NVFP4 (e2m1+e4m3+16)."
         )
     return legacy_format_name(fmt)
 
@@ -420,7 +423,6 @@ def create_blockscaled_operand_quantized(
             q_packed.view(l, mn, k // 2).contiguous().permute(1, 2, 0).view(torch.float4_e2m1fn_x2)
         )
         scale_2d = scale_2d.view(l, mn, sf_k)
-
     scale_contig = pack_scale_2d_to_blocked_contig(scale_2d)
     return ref_mkl, q_mkl, scale_contig
 
@@ -450,16 +452,17 @@ def create_blockscaled_varlen_m_operands(
     Returns (a_ref, b_ref, qa, qb, a_sc_contig, b_sc_contig, cu_seqlens_m):
       a_ref: (total_m, k) fp32 dequantized
       b_ref: (num_experts, n, k) fp32 dequantized
-      qa:   (total_m, k) 2D K-major quantized operand (fp8) or (total_m, k/2) (fp4)
-      qb:   (n, k, num_experts) 3D K-major quantized operand (fp8) or (n, k/2, num_experts) (fp4)
+      qa:   (total_m, k_storage) 2D K-major quantized operand
+      qb:   (n, k_storage, num_experts) 3D K-major quantized operand
       a_sc_contig: (1, total_padded_rm, rk, 32, 4, 4) — M-padded SFA (tile-aligned per batch).
         total_padded_rm = ((total_m + num_experts * 128) // 128).
       b_sc_contig: (num_experts, rn, rk, 32, 4, 4) — regular per-expert SFB.
       cu_seqlens_m: (num_experts+1,) int32
 
-    Supports MXFP8 / MXFP4 / NVFP4; fp4 formats require b_major="k" (tcgen05
-    MMA needs K-major fp4 operands). NVFP4 uses no per-tensor scale here (it
-    would just fold into alpha).
+    Supports all kernel-ready SM100 formats. Packed fp4/fp6 formats require
+    b_major="k". MXFP8 E5M2 is constructed by quantizing as E4M3 and value-casting
+    the codes, matching the dense benchmark path. NVFP4 uses no per-tensor scale
+    here (it would just fold into alpha).
     """
     assert k % sf_vec_size == 0
     if seqlens_m is None:
@@ -471,29 +474,38 @@ def create_blockscaled_varlen_m_operands(
     std = randn_std if randn_std is not None else k**-0.5
     sf_k = k // sf_vec_size
 
-    fmt = _blockscaled_format_of(ab_dtype, sf_dtype, sf_vec_size)
-    if fmt != "mxfp8":
-        assert b_major == "k", f"{fmt} requires K-major operands, got b_major={b_major!r}"
+    fmt = BlockScaledFormat.from_cutlass_dtypes(ab_dtype, sf_dtype, sf_vec_size)
+    if fmt.is_packed:
+        assert b_major == "k", f"{fmt.name} requires K-major operands, got {b_major=!r}"
 
     def quantize(x2d):
-        """(rows, k) bf16 -> (q, scale_2d, dequant_ref); q is fp8 (rows, k) or fp4x2 (rows, k/2)."""
-        if fmt == "mxfp8":
+        """(rows, k) bf16 -> packed qdata, 2D scales, and dequantized reference."""
+        if fmt.name in ("mxfp8_e4m3", "mxfp8_e5m2"):
             q, sc = to_mx_compiled(x2d, sf_vec_size)
+            if fmt.name == "mxfp8_e5m2":
+                # There is no in-repo E5M2 encoder. Match the dense benchmark:
+                # quantize to E4M3, then value-cast the stored codes to E5M2.
+                q = q.float().to(torch.float8_e5m2)
             vals = q.float()
-        else:
-            if fmt == "mxfp4":
+        elif fmt.name in ("mxfp4", "nvfp4"):
+            if fmt.name == "mxfp4":
                 q_packed, sc = to_mxfp4_compiled(x2d, sf_vec_size)
-            else:  # nvfp4
+            else:
                 q_packed, sc, _ = to_nvfp4_compiled(x2d, sf_vec_size, None)
             q = q_packed.view(torch.uint8).view(torch.float4_e2m1fn_x2)
-            vals = dequant_operand(q)
+            vals = dequant_operand(q, fmt)
+        elif fmt.name in ("mxfp6_e2m3_packed", "mxfp6_e3m2_packed"):
+            q, sc = QUANTIZERS[fmt.name][1](x2d, sf_vec_size)
+            vals = dequant_operand(q, fmt)
+        else:
+            raise NotImplementedError(f"varlen_m operand generation does not support {fmt.name}")
         ref = vals * sc.float().repeat_interleave(sf_vec_size, dim=-1)
         return q, sc, ref
 
-    # Quantize A: (total_m, k) bf16 -> (total_m, k[/2]) K-major.
+    # Quantize A: (total_m, k) bf16 -> (total_m, k_storage) K-major.
     # A data itself is stored packed (no per-expert padding); only SFA is padded.
     a_hp = (torch.randn(total_m, k, dtype=torch.bfloat16, device="cuda") * std).contiguous()
-    qa, sa_2d, a_ref = quantize(a_hp)  # (total_m, k[/2]), (total_m, sf_k), (total_m, k)
+    qa, sa_2d, a_ref = quantize(a_hp)
 
     # Build padded SFA storage (tile-aligned per-batch). Each expert's m_i rows of
     # scales are written at padded tile offset `cu_seqlens[i] // 128 + i`.
@@ -512,12 +524,12 @@ def create_blockscaled_varlen_m_operands(
         offset += m_i
     a_sc_contig = pack_scale_2d_to_blocked_contig(sa_2d_padded.view(1, total_padded_m, sf_k))
 
-    # Quantize B: (num_experts, n, k) bf16 -> (n, k[/2], num_experts). b_major selects
-    # k-major (stride (kb, 1, n*kb)) or n-major (stride (1, n, n*k), mxfp8 only).
+    # Quantize B: (num_experts, n, k) bf16 -> (n, k_storage, num_experts).
+    # b_major selects k-major or n-major (8-bit formats only).
     assert b_major in ("k", "n"), f"b_major must be 'k' or 'n', got {b_major!r}"
     b_hp = (torch.randn(num_experts, n, k, dtype=torch.bfloat16, device="cuda") * std).contiguous()
     qb_flat, sb_2d, b_ref_flat = quantize(b_hp.view(num_experts * n, k))
-    kb = qb_flat.shape[-1]  # k for fp8, k/2 for packed fp4
+    kb = qb_flat.shape[-1]
     if b_major == "k":
         qb = (
             qb_flat.view(num_experts, n, kb).contiguous().permute(1, 2, 0)

--- a/quack/blockscaled/utils.py
+++ b/quack/blockscaled/utils.py
@@ -555,8 +555,13 @@ def create_blockscaled_varlen_k_operands(
     randn_std: Optional[float] = None,
     seqlens_k: Optional[list] = None,
     sf_pad_byte: int = 0,
+    b_dtype: Optional[Type[cutlass.Numeric]] = None,
 ):
     """Generate bf16 randn + quantize for a varlen_k blockscaled GEMM.
+
+    Pass b_dtype != ab_dtype for mixed-precision mxf8f6f4 (fp8 pairs only:
+    varlen_k needs m-major A / n-major B, and packed sub-byte operands must be
+    K-major).
 
     Per-expert `k_i` is arbitrary (any positive int): neither `sf_vec_size` nor
     `sf_vec_size * 4` (= 128 for MXFP8) alignment is required. A non-multiple-of-32
@@ -584,12 +589,17 @@ def create_blockscaled_varlen_k_operands(
       b_sc_contig: (1, rn, total_padded_rk, 32, 4, 4) K-padded SFB (tile-aligned per batch).
       cu_seqlens_k: (num_experts+1,) int32.
     """
+    fp8_dtypes = (cutlass.Float8E4M3FN, cutlass.Float8E5M2)
+    b_dtype = b_dtype if b_dtype is not None else ab_dtype
     if not (
-        ab_dtype == cutlass.Float8E4M3FN and sf_dtype == cutlass.Float8E8M0FNU and sf_vec_size == 32
+        ab_dtype in fp8_dtypes
+        and b_dtype in fp8_dtypes
+        and sf_dtype == cutlass.Float8E8M0FNU
+        and sf_vec_size == 32
     ):
         raise NotImplementedError(
-            f"varlen_k currently only supports MXFP8 (got ab={ab_dtype}, sf={sf_dtype}, "
-            f"vec={sf_vec_size}). FP4 is k-major-only and not wired up."
+            f"varlen_k currently only supports MXFP8 e4m3/e5m2 (got a={ab_dtype}, b={b_dtype}, "
+            f"sf={sf_dtype}, vec={sf_vec_size}). Packed fp4/fp6 are k-major-only and not wired up."
         )
     if seqlens_k is None:
         seqlens_k = [k_per] * num_experts
@@ -603,7 +613,7 @@ def create_blockscaled_varlen_k_operands(
 
     from quack.blockscaled.quantize import to_mx_compiled
 
-    def quantize(mn, k_i):
+    def quantize(mn, k_i, elem_dtype):
         # The quantizer reshapes K into sf_vec_size chunks, so zero-pad k_i up to a
         # multiple of it; zeros never raise a chunk amax, so the real elements
         # quantize identically. Values are sliced back to k_i; scales keep the
@@ -611,7 +621,7 @@ def create_blockscaled_varlen_k_operands(
         k_q = (k_i + sf_vec_size - 1) // sf_vec_size * sf_vec_size
         hp = torch.zeros(mn, k_q, dtype=torch.bfloat16, device="cuda")
         hp[:, :k_i] = torch.randn(mn, k_i, dtype=torch.bfloat16, device="cuda") * std
-        q, sc = to_mx_compiled(hp, sf_vec_size)
+        q, sc = to_mx_compiled(hp, sf_vec_size, elem_dtype=torch_dtype_for_cutlass(elem_dtype))
         q = q[:, :k_i]
         ref = q.float() * sc.float().repeat_interleave(sf_vec_size, dim=-1)[:, :k_i]
         return q, sc, ref
@@ -619,12 +629,12 @@ def create_blockscaled_varlen_k_operands(
     a_q_list, a_sc_list, a_ref_list = [], [], []
     b_q_list, b_sc_list, b_ref_list = [], [], []
     for k_i in seqlens_k:
-        a_q, a_sc, a_ref = quantize(m, k_i)
+        a_q, a_sc, a_ref = quantize(m, k_i, ab_dtype)
         a_q_list.append(a_q)
         a_sc_list.append(a_sc)
         a_ref_list.append(a_ref)
 
-        b_q, b_sc, b_ref = quantize(n, k_i)
+        b_q, b_sc, b_ref = quantize(n, k_i, b_dtype)
         b_q_list.append(b_q)
         b_sc_list.append(b_sc)
         b_ref_list.append(b_ref)

--- a/quack/gemm.py
+++ b/quack/gemm.py
@@ -83,7 +83,7 @@ def _compile_gemm(
     b_kn=False,
     sf_batched=True,
     a_mma_dtype=None,  # blockscaled: MMA element types when they differ from the
-    b_mma_dtype=None,  # storage dtypes (byte-container sub-byte formats)
+    b_mma_dtype=None,  # storage dtypes (packed fp6 crosses the boundary as bytes)
 ):
     sm_to_cls = {
         8: GemmDefaultSm80,
@@ -107,6 +107,8 @@ def _compile_gemm(
         gather_A=gather_A,
         batched=batched,
         b_kn=b_kn,
+        a_mma_dtype=a_mma_dtype,
+        b_mma_dtype=b_mma_dtype,
     )
     if split_k > 1 and split_k_mode == SplitKMode.SEPARATE:
         # D is the f32 partials workspace; its batch extent is l * split_k, not l,
@@ -672,7 +674,8 @@ def _build_gemm_plan(
     if blockscaled:
         fmt_a, fmt_b = resolve_blockscaled_formats(bs_format_a, bs_format_b)
         # MMA element types come from the descriptors; identical to the storage
-        # dtypes except for byte-container sub-byte formats (fp6, byte-fp4).
+        # dtypes except packed fp6, which crosses the FFI boundary as raw bytes
+        # (torch has no fp6 dtype) and is reinterpreted in-kernel.
         a_mma_dtype = fmt_a.to_cutlass_dtype()
         b_mma_dtype = fmt_b.to_cutlass_dtype()
         assert not gather_A, "Blockscaled GEMM does not support gather_A yet"

--- a/quack/gemm_host.py
+++ b/quack/gemm_host.py
@@ -189,8 +189,8 @@ def _compile_gemm_epi(
     sf_dtype=None,
     sf_vec_size=None,
     sf_batched=True,
-    # Blockscaled MMA element types when they differ from the storage dtypes
-    # (byte-container sub-byte formats); None: same as the tensor dtypes.
+    # Blockscaled MMA element types when they differ from the boundary dtypes
+    # (packed fp6 crosses TVM-FFI as raw uint8); None: same as the tensor dtypes.
     a_mma_dtype=None,
     b_mma_dtype=None,
     post_init_attrs=(),  # ((attr, value), ...) setattr'd on the gemm object pre-trace
@@ -217,6 +217,8 @@ def _compile_gemm_epi(
         b_kn=b_kn,
         swap_ab=swap_ab,
         packed_cd=packed_cd,
+        a_mma_dtype=a_mma_dtype,
+        b_mma_dtype=b_mma_dtype,
     )
     fctx = FakeArgCtx(m, n, k, l, batched, varlen_m, swap_ab)
     ops = _ops_by_name(GemmCls)

--- a/quack/gemm_interface.py
+++ b/quack/gemm_interface.py
@@ -162,8 +162,9 @@ def _concat_interleave_bias(t):
 # K-blocks, matching torchao's ``to_blocked`` and ``torch._scaled_mm``.
 # All format properties (scale vec size, element packing, scale dtype) come from
 # the BlockScaledFormat descriptor; nothing below this layer may re-derive them
-# from tensor dtypes. fp4 operands use ``torch.float4_e2m1fn_x2`` storage: shapes
-# carry packed K (two elements per byte); K here always refers to logical K.
+# from tensor dtypes. Packed operands carry the storage K extent in their shapes
+# (fp4: ``torch.float4_e2m1fn_x2``, two elements per byte -> K/2; fp6: packed
+# 6-bit uint8 bit stream -> 3*K/4 bytes); K here always refers to logical K.
 
 
 def _launch(op):
@@ -1207,10 +1208,10 @@ def gemm_blockscaled_ref(
     SFB = opB.sf.unsqueeze(0) if opB.sf.ndim == 5 else opB.sf
     sf_vec = opA.fmt.sf_vec_size
     batched = A.ndim == 3
-    a3 = A if batched else A.unsqueeze(0)  # (l, m, k_packed)
-    b3 = (B if batched else B.unsqueeze(0)).mT  # (l, n, k_packed)
-    a_val = dequant_operand(a3)  # (l, m, k) fp32
-    b_val = dequant_operand(b3)
+    a3 = A if batched else A.unsqueeze(0)  # (l, m, k_storage)
+    b3 = (B if batched else B.unsqueeze(0)).mT  # (l, n, k_storage)
+    a_val = dequant_operand(a3, opA.fmt)  # (l, m, k) fp32
+    b_val = dequant_operand(b3, opB.fmt)
     l, m, k = a_val.shape
     n = b_val.shape[1]
     sfa = unpack_scale_blocked_to_2d(SFA, m, k // sf_vec).float()

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -94,9 +94,18 @@ def _reinterpret_packed_fp6(mT, dtype):
 
     The byte tensor holds a little-endian 6-bit stream along K (element i at
     bits [6i, 6i+6) of its row), so the K mode (mode 1, stride 1 - sub-byte
-    operands are K-major) scales by 8/6 in extent and keeps stride 1, while
-    the other modes' byte strides convert exactly to fp6-element strides
-    (x8/6): K %128 makes every row span whole 96-byte groups.
+    operands are K-major) scales by 8/6 in extent and keeps stride 1. The K
+    EXTENT conversion is exact: K % 128 makes every row whole 96-byte groups.
+
+    The non-K STRIDE conversion (x4//3, floor) is NOT exact for byte pitches
+    that aren't multiples of 3 (e.g. a padded 416 B row pitch -> 554.67 fp6
+    elements, floored to 554 = 415.5 B). This is safe because the FFI arg
+    spec admits only 32 B-aligned pitches and the tensormap encode rounds the
+    element stride back to the nearest TMA granule, recovering the true pitch
+    exactly: the residue is < 0.75 B either way (verified bit-exact with
+    poisoned padding at pitches 416/448/544/4128, both floor and ceil -
+    AI/probe_fp6_pitch.py). The 32 B stride validation is load-bearing for
+    correctness here, not just for the tensormap's alignment rule.
     """
     shape = tuple(s * 4 // 3 if i == 1 else s for i, s in enumerate(mT.shape))
     stride = tuple(st if i == 1 else st * 4 // 3 for i, st in enumerate(mT.stride))

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -375,6 +375,12 @@ class GemmSm100(GemmTmaBase):
 
         # Compute mma/cluster/tile shapes
         if self.mma_tiler[2] > 0:
+            if const_expr(self.blockscaled):
+                sf_chunk_k = self.sf_vec_size * 4
+                assert self.mma_tiler[2] % sf_chunk_k == 0, (
+                    f"Blockscaled MMA tiler K ({self.mma_tiler[2]}) must be divisible by "
+                    f"the scale-factor chunk K ({sf_chunk_k})"
+                )
             assert self.mma_tiler[2] % self.mma_inst_shape_mnk[2] == 0, (
                 f"MMA tiler K ({self.mma_tiler[2]}) must be divisible by "
                 f"MMA instruction K ({self.mma_inst_shape_mnk[2]})"
@@ -3032,6 +3038,10 @@ class GemmSm100(GemmTmaBase):
             return can_implement
         # Blockscaled: everything derives from the format descriptors.
         fmt_a, fmt_b = a_dtype, b_dtype
+        # Deprecated byte-container sub-byte formats are host-side migration
+        # inputs only; actual dispatch rejects them before kernel selection.
+        if fmt_a.is_byte_container or fmt_b.is_byte_container:
+            return False
         # tcgen05 blockscaled MMA accumulates in f32 only.
         if acc_dtype is not Float32:
             return False
@@ -3047,6 +3057,12 @@ class GemmSm100(GemmTmaBase):
         sf_dtype = torch2cute_dtype_map[fmt_a.scale_dtype]
         sf_vec_size = fmt_a.sf_vec_size
         can_implement = True
+        if (
+            len(mma_tiler_mnk) == 3
+            and mma_tiler_mnk[2] > 0
+            and mma_tiler_mnk[2] % (sf_vec_size * 4) != 0
+        ):
+            can_implement = False
         if not GemmSm100.is_valid_dtypes_and_scale_factor_vec_size(
             a_mma_dtype,
             b_mma_dtype,

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -360,7 +360,9 @@ class GemmSm100(GemmTmaBase):
                 f"(storage {self.a_dtype}), B={self.b_mma_dtype} (storage {self.b_dtype}), "
                 f"SF={self.sf_dtype}, sf_vec_size={self.sf_vec_size}, D={self.d_dtype}"
             )
-            self.tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            # quack's wrapper, not the DSL helper: both-fp4 pairs always run
+            # the single kind::mxf4nvf4 atom with the format's scale config.
+            self.tiled_mma = quack_sm100_utils.make_blockscaled_trivial_tiled_mma(
                 self.a_mma_dtype,
                 self.b_mma_dtype,
                 self.a_major_mode,

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -89,6 +89,21 @@ Constraints:
 """
 
 
+def _reinterpret_packed_fp6(mT, dtype):
+    """View a (mn, 3k/4[, l]) Uint8 tensor as a (mn, k[, l]) packed-fp6 tensor.
+
+    The byte tensor holds a little-endian 6-bit stream along K (element i at
+    bits [6i, 6i+6) of its row), so the K mode (mode 1, stride 1 - sub-byte
+    operands are K-major) scales by 8/6 in extent and keeps stride 1, while
+    the other modes' byte strides convert exactly to fp6-element strides
+    (x8/6): K %128 makes every row span whole 96-byte groups.
+    """
+    shape = tuple(s * 4 // 3 if i == 1 else s for i, s in enumerate(mT.shape))
+    stride = tuple(st if i == 1 else st * 4 // 3 for i, st in enumerate(mT.stride))
+    ptr = cute.recast_ptr(mT.iterator, dtype=dtype)
+    return cute.make_tensor(ptr, cute.make_layout(shape, stride=stride))
+
+
 class GemmSm100(GemmTmaBase):
     """This class implements batched matrix multiplication (C = A x B) with support for various data types
     and architectural features specific to Blackwell GPUs with persistent tile scheduling and warp specialization.
@@ -157,9 +172,9 @@ class GemmSm100(GemmTmaBase):
         split_k: int = 1,
         split_k_mode: int = SplitKMode.SERIAL,
         # MMA element types when they differ from the tensor (storage/copy) dtypes:
-        # byte-container sub-byte formats (fp6, byte-fp4 under kind::mxf8f6f4) store
-        # one code per uint8 in gmem/SMEM while the instruction computes in the
-        # sub-byte type. None: same as the tensor dtype.
+        # packed fp6 crosses the FFI boundary as raw uint8 bytes (torch has no fp6
+        # dtype) and is reinterpreted in-kernel to the fp6 MMA type. None: same as
+        # the tensor dtype.
         a_mma_dtype: Optional[Type[cutlass.Numeric]] = None,
         b_mma_dtype: Optional[Type[cutlass.Numeric]] = None,
     ):
@@ -460,8 +475,8 @@ class GemmSm100(GemmTmaBase):
             self.mma_tiler,
             self.cta_tile_shape_mnk,
             self.epi_tile,
-            self.a_dtype,
-            self.b_dtype,
+            self.a_smem_dtype,
+            self.b_smem_dtype,
             self.sf_dtype,
             self.sf_vec_size,
             self.d_dtype,
@@ -490,7 +505,7 @@ class GemmSm100(GemmTmaBase):
 
         # Compute A/B/SFA/SFB/C shared memory layout
         self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            self.tiled_mma, self.mma_tiler, self.a_dtype, self.ab_stage
+            self.tiled_mma, self.mma_tiler, self.a_smem_dtype, self.ab_stage
         )
         self.a_smem_load_layout_staged = self.a_smem_layout_staged
         if const_expr(self.gather_A):
@@ -503,7 +518,7 @@ class GemmSm100(GemmTmaBase):
                     self.tiled_mma, self.mma_tiler, self.a_dtype, self.ab_stage
                 )
         self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            self.tiled_mma, self.mma_tiler, self.b_dtype, self.ab_stage
+            self.tiled_mma, self.mma_tiler, self.b_smem_dtype, self.ab_stage
         )
         self.epi_smem_layout_staged = None
         if const_expr(self.d_dtype is not None):
@@ -618,13 +633,44 @@ class GemmSm100(GemmTmaBase):
             else mT
             for name, mT in [("A", mA), ("B", mB), ("out", mD), ("C", mC)]
         ]
+        # Packed 6-bit operands cross the FFI boundary as raw bytes (torch has
+        # no fp6 dtype): reinterpret (mn, 3k/4[, l]) Uint8 as (mn, k[, l]) fp6.
+        # The fp6-typed gmem tensor is what selects the U6_UNPACK_U8 unpack
+        # tensormap in the TMA atom builder.
+        if const_expr(self.a_mma_dtype is not None and self.a_mma_dtype.width == 6):
+            mA = _reinterpret_packed_fp6(mA, self.a_mma_dtype)
+        if const_expr(self.b_mma_dtype is not None and self.b_mma_dtype.width == 6):
+            mB = _reinterpret_packed_fp6(mB, self.b_mma_dtype)
         # Setup static attributes before smem/grid/tma computation
         self.a_dtype = mA.element_type  # storage/copy dtype (smem layouts, TMA, sizes)
         self.b_dtype = mB.element_type
         # MMA element types default to the storage dtypes (identical except for
-        # byte-container sub-byte formats).
+        # packed fp6, whose FFI-boundary dtype was Uint8 before the reinterpret
+        # above - post-reinterpret they coincide too).
         self.a_mma_dtype = self.a_mma_dtype if self.a_mma_dtype is not None else self.a_dtype
         self.b_mma_dtype = self.b_mma_dtype if self.b_mma_dtype is not None else self.b_dtype
+        # TMA-unpack operands: a packed sub-byte gmem operand under tcgen05
+        # kind::mxf8f6f4 (any blockscaled pair other than both-packed-fp4,
+        # which runs the denser kind::mxf4nvf4). TMA expands the packed
+        # stream to one byte of smem footprint per element (TmaDataFormat
+        # U4_UNPACK_U8/U6_UNPACK_U8 via internal_type=Uint8), so ALL smem-side
+        # accounting - layout atom selection, storage, capacity - is byte-domain
+        # (Uint8), mirroring CUTLASS C++ SmemAllocType. The sub-byte identity
+        # survives only in (1) the gmem tensor's element type (which selects the
+        # tensormap format) and (2) the MMA instruction descriptor via
+        # a/b_mma_dtype. The Uint8-typed smem tensor feeds make_fragment_A/B
+        # directly: the smem descriptor is built from width x stride products,
+        # and the byte layout is the convention kind::mxf8f6f4 expects.
+        if const_expr(self.blockscaled):
+            both_packed_fp4 = (
+                self.a_dtype is cutlass.Float4E2M1FN and self.b_dtype is cutlass.Float4E2M1FN
+            )
+            self.a_unpack = self.a_dtype.width < 8 and not both_packed_fp4
+            self.b_unpack = self.b_dtype.width < 8 and not both_packed_fp4
+        else:
+            self.a_unpack, self.b_unpack = False, False
+        self.a_smem_dtype = cutlass.Uint8 if self.a_unpack else self.a_dtype
+        self.b_smem_dtype = cutlass.Uint8 if self.b_unpack else self.b_dtype
         self.d_dtype = mD.element_type if mD is not None else None
         self.c_dtype = mC.element_type if mC is not None else None
         self.sf_dtype: Optional[Type[cutlass.Numeric]] = (
@@ -703,7 +749,13 @@ class GemmSm100(GemmTmaBase):
                 self.mma_tiler,
                 self.tiled_mma,
                 self.cluster_layout_vmnk.shape,
-                internal_type=(cutlass.TFloat32 if mA.element_type is Float32 else None),
+                # Uint8 internal type + sub-byte gmem element selects the
+                # U4/U6_UNPACK_U8 tensormap (packed gmem -> byte-container smem).
+                internal_type=(
+                    cutlass.Uint8
+                    if const_expr(self.a_unpack)
+                    else (cutlass.TFloat32 if mA.element_type is Float32 else None)
+                ),
             )
         elif const_expr(self.use_tma_gather):
             # gather4 descriptor: box has 1 in the gathered dim, tile size in the contiguous dim.
@@ -729,7 +781,11 @@ class GemmSm100(GemmTmaBase):
             self.mma_tiler,
             self.tiled_mma,
             self.cluster_layout_vmnk.shape,
-            internal_type=(cutlass.TFloat32 if mB.element_type is Float32 else None),
+            internal_type=(
+                cutlass.Uint8
+                if const_expr(self.b_unpack)
+                else (cutlass.TFloat32 if mB.element_type is Float32 else None)
+            ),
         )
 
         tma_atom_sfa, tma_tensor_sfa = None, None
@@ -791,6 +847,11 @@ class GemmSm100(GemmTmaBase):
                 sfb_window_layout.shape,
             )
 
+        # Transaction bytes are counted with the GMEM dtype: for unpack operands
+        # the layout is byte-domain (cosize == smem footprint bytes) but TMA
+        # reports only the packed data bytes it copies (elements x 4 or 6 bits;
+        # the intra-16B gaps are not written), matching CUTLASS C++
+        # (sizeof_bits<ElementA> x cosize of the uint8-alloc smem layout).
         self.num_tma_load_bytes = cute.size_in_bytes(self.b_dtype, b_smem_layout)
         if const_expr(not self.gather_A or self.use_tma_gather):
             self.num_tma_load_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
@@ -883,12 +944,16 @@ class GemmSm100(GemmTmaBase):
             epi: self.epi_get_smem_struct(epilogue_params)
             # (MMA, MMA_M, MMA_K, STAGE)
             sA: cute.struct.Align[
-                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                cute.struct.MemRange[
+                    self.a_smem_dtype, cute.cosize(self.a_smem_layout_staged.outer)
+                ],
                 self.buffer_align_bytes,
             ]
             # (MMA, MMA_N, MMA_K, STAGE)
             sB: cute.struct.Align[
-                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                cute.struct.MemRange[
+                    self.b_smem_dtype, cute.cosize(self.b_smem_layout_staged.outer)
+                ],
                 self.buffer_align_bytes,
             ]
             # (MMA, MMA_M, MMA_K, STAGE)
@@ -2668,14 +2733,13 @@ class GemmSm100(GemmTmaBase):
 
     @staticmethod
     def _blockscaled_mma_inst_k(a_copy_dtype, b_copy_dtype) -> int:
-        """Instruction K is a property of the MMA kind: kind::mxf4/mxf4nvf4 (both
-        operands PACKED fp4 - storage dtype Float4E2M1FN) consume 64 elements per
-        instruction; kind::mxf8f6f4 (everything else, incl. mixed A/B and
-        byte-container sub-byte operands whose storage is Uint8) consumes 32.
-        Keyed on the storage dtypes precisely so byte-container fp4 takes the 32
-        path. Mirrors quack.blockscaled.operand.mma_kind_for_pair (which keys on
-        format names at the torch layer) - keep the two in sync;
-        test_mma_kind_mirrors_kernel_inst_k pins the correspondence.
+        """Instruction K is a property of the MMA kind: kind::mxf4nvf4 (both
+        operands packed fp4 - ONE atom parameterized by the format's scale
+        config: vec 32 e8m0 = mxfp4, vec 16 = nvfp4) consumes 64 elements per
+        instruction; kind::mxf8f6f4 (everything else - mixed A/B pairs and fp6,
+        with sub-byte operands TMA-unpacked into byte-container smem) consumes
+        32. Mirrors quack.blockscaled.operand.mma_kind_for_pair; keep the two in
+        sync. test_mma_kind_mirrors_kernel_inst_k pins the correspondence.
         """
         both_packed_fp4 = (
             a_copy_dtype is cutlass.Float4E2M1FN and b_copy_dtype is cutlass.Float4E2M1FN
@@ -2695,11 +2759,10 @@ class GemmSm100(GemmTmaBase):
         """
         The per-architecture support gate: which (A, B, SF, D) dtype combinations
         THIS kernel implements. ``a_dtype``/``b_dtype`` are the MMA element types;
-        ``a/b_copy_dtype`` the storage dtypes (None: same - byte-container sub-byte
-        formats store Uint8). (Hardware pair legality is a separate, wider set -
-        see quack.blockscaled.operand.mma_kind_for_pair; the vec-16-requires-fp4
-        and mixed-pair constraints below are this kernel's subset of those kind
-        rules and must stay consistent with them.)
+        ``a/b_copy_dtype`` the storage dtypes as seen at the FFI boundary (None:
+        same; packed fp6 arrives as raw Uint8 bytes). (Hardware pair legality is
+        a separate, wider set - see quack.blockscaled.operand.mma_kind_for_pair;
+        this kernel's subset must stay consistent with those kind rules.)
 
         :param a_dtype: The data type of the A operand
         :type a_dtype: Type[cutlass.Numeric]
@@ -2719,26 +2782,24 @@ class GemmSm100(GemmTmaBase):
         a_copy_dtype = a_dtype if a_copy_dtype is None else a_copy_dtype
         b_copy_dtype = b_dtype if b_copy_dtype is None else b_copy_dtype
 
-        # Per-operand MMA element types this kernel implements. The hardware
-        # (tcgen05 kind::mxf8f6f4) admits any fp8/fp6/fp4 element mix with
-        # sub-byte elements in 8-bit SMEM containers, and CUTLASS C++ reaches it
-        # via *_unpacksmem_t element types + TMA sub-byte->container expansion
-        # (CU_TENSOR_MAP_DATA_TYPE_16U4/16U6_ALIGN16B). CuTe-DSL 4.6 ships NONE
-        # of that machinery (no unpacksmem analogue, no expansion tensormaps;
-        # its own blockscaled example enforces a_dtype == b_dtype), and both
-        # byte-container encodings fail empirically (wrong results / compiler
-        # ICE + misaligned address). Until the DSL grows this support, mixed
-        # pairs are fp8 x fp8 only, and sub-byte types run only via the packed
-        # both-fp4 kinds (mxf4/mxf4nvf4). The a/b_mma_dtype plumbing is in place
-        # for when it does.
+        # Per-operand MMA element types this kernel implements. Mixed A/B pairs
+        # (and any sub-byte operand outside both-packed-fp4) run tcgen05
+        # kind::mxf8f6f4: the packed sub-byte gmem operand is expanded by TMA
+        # into 8-bit smem containers (CU_TENSOR_MAP_DATA_TYPE_16U4/16U6_ALIGN16B,
+        # selected via internal_type=Uint8). Both-packed-fp4 runs the denser
+        # kind::mxf4nvf4 (one atom, scale config from the format). Storage must
+        # be the packed sub-byte dtype itself;
+        # byte-container (Uint8-per-element) storage has no kernel path.
         fp8 = {cutlass.Float8E5M2, cutlass.Float8E4M3FN}
-        supported = fp8 | {cutlass.Float4E2M1FN}
+        sub_byte = {cutlass.Float4E2M1FN, cutlass.Float6E2M3FN, cutlass.Float6E3M2FN}
+        supported = fp8 | sub_byte
         if a_dtype not in supported or b_dtype not in supported:
             is_valid = False
-        if a_copy_dtype is not a_dtype or b_copy_dtype is not b_dtype:
-            is_valid = False  # byte-container storage: no DSL path (see above)
-        if a_dtype != b_dtype and not (a_dtype in fp8 and b_dtype in fp8):
-            is_valid = False
+        # Copy dtype: the packed sub-byte dtype itself, except packed fp6 which
+        # crosses the FFI boundary as raw bytes and is reinterpreted in-kernel.
+        for mma_dt, copy_dt in ((a_dtype, a_copy_dtype), (b_dtype, b_copy_dtype)):
+            if copy_dt is not mma_dt and not (mma_dt.width == 6 and copy_dt is cutlass.Uint8):
+                is_valid = False
 
         # Check valid sf_vec_size
         if sf_vec_size not in {16, 32}:
@@ -2866,7 +2927,9 @@ class GemmSm100(GemmTmaBase):
         def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
             major_mode_idx = 0 if is_mode0_major else 1
             num_major_elements = tensor_shape[major_mode_idx]
-            num_contiguous_elements = 16 * 8 // dtype.width
+            # fp6 has no 16-byte packing quantum (16 * 8 / 6 is fractional); its
+            # ALIGN16B unpack tensormap instead requires 128-element granularity.
+            num_contiguous_elements = 128 if dtype.width == 6 else 16 * 8 // dtype.width
             return num_major_elements % num_contiguous_elements == 0
 
         b_dtype = ab_dtype if b_dtype is None else b_dtype
@@ -2879,60 +2942,9 @@ class GemmSm100(GemmTmaBase):
         return is_valid
 
     @staticmethod
-    def can_implement_blockscaled(
-        a_dtype: Type[cutlass.Numeric],
-        b_dtype: Type[cutlass.Numeric],
-        sf_dtype: Type[cutlass.Numeric],
-        sf_vec_size: int,
-        d_dtype: Type[cutlass.Numeric],
-        mma_tiler_mnk: Union[Tuple[int, int], Tuple[int, int, int]],
-        cluster_shape_mn: Tuple[int, int],
-        m: int,
-        n: int,
-        k: int,
-        l: int,
-        a_major: str,
-        b_major: str,
-        d_major: str,
-        a_copy_dtype: Optional[Type[cutlass.Numeric]] = None,
-        b_copy_dtype: Optional[Type[cutlass.Numeric]] = None,
-    ) -> bool:
-        can_implement = True
-        if not GemmSm100.is_valid_dtypes_and_scale_factor_vec_size(
-            a_dtype,
-            b_dtype,
-            sf_dtype,
-            sf_vec_size,
-            d_dtype,
-            a_copy_dtype=a_copy_dtype,
-            b_copy_dtype=b_copy_dtype,
-        ):
-            can_implement = False
-        sub_byte = {cutlass.Float4E2M1FN, cutlass.Float6E2M3FN, cutlass.Float6E3M2FN}
-        if (a_dtype in sub_byte or b_dtype in sub_byte) and not (a_major == "k" and b_major == "k"):
-            can_implement = False
-        if not GemmSm100.is_valid_mma_tiler_and_cluster_shape(
-            mma_tiler_mnk, cluster_shape_mn, blockscaled=True
-        ):
-            can_implement = False
-        if not GemmSm100.is_valid_tensor_alignment(
-            m,
-            n,
-            k,
-            l,
-            a_copy_dtype if a_copy_dtype is not None else a_dtype,
-            d_dtype,
-            a_major,
-            b_major,
-            d_major,
-            b_dtype=b_copy_dtype if b_copy_dtype is not None else b_dtype,
-        ):
-            can_implement = False
-        return can_implement
-
-    @staticmethod
     def can_implement(
-        ab_dtype: Type[cutlass.Numeric],
+        a_dtype,
+        b_dtype,
         acc_dtype: Type[cutlass.Numeric],
         d_dtype: Type[cutlass.Numeric],
         mma_tiler_mnk: Union[Tuple[int, int], Tuple[int, int, int]],
@@ -2948,8 +2960,17 @@ class GemmSm100(GemmTmaBase):
         """
         Check if the gemm can be implemented
 
-        :param ab_dtype: The data type of the A and B operands
-        :type ab_dtype: Type[cutlass.Numeric]
+        Polymorphic over the operand kind: ``a_dtype`` / ``b_dtype`` are either
+        both plain cutlass dtypes, selecting the dense kernel checks, or both
+        :class:`quack.blockscaled.operand.BlockScaledFormat` descriptors,
+        selecting the blockscaled checks with all format properties (scale
+        config, storage dtype, packing) read from the descriptors. One of each
+        is rejected.
+
+        :param a_dtype: The data type of the A operand, or its blockscaled format
+        :type a_dtype: Union[Type[cutlass.Numeric], BlockScaledFormat]
+        :param b_dtype: The data type of the B operand, or its blockscaled format
+        :type b_dtype: Union[Type[cutlass.Numeric], BlockScaledFormat]
         :param acc_dtype: The data type of the accumulator
         :type acc_dtype: Type[cutlass.Numeric]
         :param d_dtype: The data type of the output tensor
@@ -2976,18 +2997,90 @@ class GemmSm100(GemmTmaBase):
         :return: True if the gemm can be implemented, False otherwise
         :rtype: bool
         """
+        # Lazy import: blockscaled/__init__ pulls blockscaled/utils, which
+        # imports the kernel layer - a top-level import here would be circular.
+        from quack.blockscaled.operand import BlockScaledFormat
+        from quack.cute_dsl_utils import torch2cute_dtype_map
+
+        a_is_blockscaled = isinstance(a_dtype, BlockScaledFormat)
+        b_is_blockscaled = isinstance(b_dtype, BlockScaledFormat)
+        if a_is_blockscaled != b_is_blockscaled:
+            return False
+        if not a_is_blockscaled:
+            # Dense kernel: A and B must share one dtype.
+            if a_dtype is not b_dtype:
+                return False
+            ab_dtype = a_dtype
+            can_implement = True
+            # Skip unsupported types
+            if not GemmSm100.is_valid_dtypes(
+                ab_dtype, ab_dtype, acc_dtype, d_dtype, a_major, b_major
+            ):
+                can_implement = False
+            # Skip invalid mma tile shape and cluster shape
+            if not GemmSm100.is_valid_mma_tiler_and_cluster_shape(
+                mma_tiler_mnk, cluster_shape_mn, blockscaled=False
+            ):
+                can_implement = False
+            # Skip illegal problem shape for load/store alignment
+            if not GemmSm100.is_valid_tensor_alignment(
+                m, n, k, l, ab_dtype, d_dtype, a_major, b_major, d_major
+            ):
+                can_implement = False
+            return can_implement
+        # Blockscaled: everything derives from the format descriptors.
+        fmt_a, fmt_b = a_dtype, b_dtype
+        # tcgen05 blockscaled MMA accumulates in f32 only.
+        if acc_dtype is not Float32:
+            return False
+        # The scale config is instruction-wide: both operands must share the
+        # scale dtype and vec size (this also rejects nvfp4 mixed with anything
+        # else).
+        if fmt_a.scale_dtype != fmt_b.scale_dtype or fmt_a.sf_vec_size != fmt_b.sf_vec_size:
+            return False
+        a_mma_dtype = fmt_a.to_cutlass_dtype()
+        b_mma_dtype = fmt_b.to_cutlass_dtype()
+        a_copy_dtype = torch2cute_dtype_map[fmt_a.qdata_dtype]
+        b_copy_dtype = torch2cute_dtype_map[fmt_b.qdata_dtype]
+        sf_dtype = torch2cute_dtype_map[fmt_a.scale_dtype]
+        sf_vec_size = fmt_a.sf_vec_size
         can_implement = True
-        # Skip unsupported types
-        if not GemmSm100.is_valid_dtypes(ab_dtype, ab_dtype, acc_dtype, d_dtype, a_major, b_major):
-            can_implement = False
-        # Skip invalid mma tile shape and cluster shape
-        if not GemmSm100.is_valid_mma_tiler_and_cluster_shape(
-            mma_tiler_mnk, cluster_shape_mn, blockscaled=False
+        if not GemmSm100.is_valid_dtypes_and_scale_factor_vec_size(
+            a_mma_dtype,
+            b_mma_dtype,
+            sf_dtype,
+            sf_vec_size,
+            d_dtype,
+            a_copy_dtype=a_copy_dtype,
+            b_copy_dtype=b_copy_dtype,
         ):
             can_implement = False
-        # Skip illegal problem shape for load/store alignment
+        sub_byte = {cutlass.Float4E2M1FN, cutlass.Float6E2M3FN, cutlass.Float6E3M2FN}
+        if (a_mma_dtype in sub_byte and a_major != "k") or (
+            b_mma_dtype in sub_byte and b_major != "k"
+        ):
+            can_implement = False
+        # TMA-unpack operands (sub-byte under kind::mxf8f6f4, i.e. any pair other
+        # than both-packed-fp4) use the ALIGN16B tensormap formats, which require
+        # the contiguous gmem extent to be a multiple of 128 elements.
+        both_fp4 = a_mma_dtype is cutlass.Float4E2M1FN and b_mma_dtype is cutlass.Float4E2M1FN
+        if (a_mma_dtype in sub_byte or b_mma_dtype in sub_byte) and not both_fp4 and k % 128 != 0:
+            can_implement = False
+        if not GemmSm100.is_valid_mma_tiler_and_cluster_shape(
+            mma_tiler_mnk, cluster_shape_mn, blockscaled=True
+        ):
+            can_implement = False
         if not GemmSm100.is_valid_tensor_alignment(
-            m, n, k, l, ab_dtype, d_dtype, a_major, b_major, d_major
+            m,
+            n,
+            k,
+            l,
+            a_copy_dtype,
+            d_dtype,
+            a_major,
+            b_major,
+            d_major,
+            b_dtype=b_copy_dtype,
         ):
             can_implement = False
         return can_implement

--- a/quack/gemm_tvm_ffi_utils.py
+++ b/quack/gemm_tvm_ffi_utils.py
@@ -37,6 +37,35 @@ def resolve_blockscaled_formats(bs_format_a, bs_format_b):
     return fmt_a, fmt_b
 
 
+def _validate_tma_unpack_alignment(name, tensor, format_name):
+    """Validate the byte-addressing contract of U4/U6 TMA unpack tensor maps."""
+    alignment = 32
+    if tensor.data_ptr() % alignment != 0:
+        raise ValueError(
+            f"{name} ({format_name}) TMA-unpack base address must be {alignment}-byte aligned"
+        )
+    elem_bytes = tensor.element_size()
+    for dim, stride in enumerate(tensor.stride()):
+        stride_bytes = stride * elem_bytes
+        if stride_bytes != 1 and stride_bytes % alignment != 0:
+            raise ValueError(
+                f"{name} ({format_name}) TMA-unpack non-unit byte strides must be "
+                f"{alignment}-byte aligned, got stride[{dim}]={stride_bytes} bytes"
+            )
+
+
+def _validate_tma_unpack_operands(A, B):
+    """Per-launch guard for cached blockscaled plans, which do not key on pointers."""
+    fp4_dtype = torch.float4_e2m1fn_x2
+    subbyte_storage_dtypes = {fp4_dtype, torch.uint8}
+    both_fp4 = A.dtype == fp4_dtype and B.dtype == fp4_dtype
+    if both_fp4:
+        return
+    for name, tensor in (("A", A), ("B", B)):
+        if tensor.dtype in subbyte_storage_dtypes:
+            _validate_tma_unpack_alignment(name, tensor, str(tensor.dtype))
+
+
 def validate_blockscaled_sf(
     A, B, SFA, SFB, device_capacity, num_batches=None, varlen_k=False, b_kn=False, *, fmt_a, fmt_b
 ):
@@ -116,6 +145,14 @@ def validate_blockscaled_sf(
                 f"{fmt.name} operands require logical K divisible by 128 "
                 f"(TMA unpack tensormap granule), got K={k_logical}"
             )
+    # Under kind::mxf8f6f4, packed fp4/fp6 operands use U4/U6 TMA unpack into
+    # byte-container SMEM. Validate addressing after logical shape/granule checks
+    # so malformed K reports the format constraint rather than a derived row pitch.
+    # Both-fp4 runs kind::mxf4nvf4 and keeps the ordinary 16-byte contract.
+    both_fp4 = fmt_a.elem_bits == 4 and fmt_b.elem_bits == 4
+    for name, tensor, fmt in (("A", A, fmt_a), ("B", B, fmt_b)):
+        if fmt.elem_bits < 8 and not both_fp4:
+            _validate_tma_unpack_alignment(name, tensor, fmt.name)
     rk = (k_logical + 4 * sf_vec_size - 1) // (4 * sf_vec_size)
     if varlen_k:
         assert not fmt_a.is_packed and not fmt_b.is_packed, (
@@ -393,6 +430,8 @@ def plan_scheduler_args(plan, tile_count_semaphore, batch_idx_permute=None):
 
 def launch_gemm(plan, A, B, D, C, epi_args, scheduler_args, varlen_args, SFA=None, SFB=None):
     """Invoke the compiled kernel; SM100/110 signatures take trailing (SFA, SFB)."""
+    if SFA is not None:
+        _validate_tma_unpack_operands(A, B)
     if plan.is_sm100_family:
         plan.compiled_fn(A, B, D, C, epi_args, scheduler_args, varlen_args, SFA, SFB)
     else:
@@ -456,11 +495,13 @@ def make_fake_gemm_tensors(
     b_packed_f6 = b_mma_dtype is not None and b_mma_dtype.width == 6
     # Sub-byte tensors need their contiguous extent statically divisible; sub-byte
     # operands are k-major, so mark k. Both-packed-fp4 runs kind::mxf4nvf4 with
-    # packed smem (16-byte rule: 32 elements); a sub-byte operand in any other
-    # pair is TMA-unpacked
-    # under kind::mxf8f6f4, whose ALIGN16B tensormap formats require the
-    # contiguous extent to be a multiple of 128 elements. Harmless for 8-bit+.
+    # packed smem (16-byte rule: 32 elements). A sub-byte operand in any other
+    # pair is TMA-unpacked under kind::mxf8f6f4: logical K must be a multiple of
+    # 128, and the FFI signature must enforce the unpack tensor map's 32-byte
+    # base/non-unit-stride contract.
     both_fp4 = a_dtype is Float4E2M1FN and b_dtype is Float4E2M1FN
+    a_unpack = (a_dtype.width < 8 or a_packed_f6) and not both_fp4
+    b_unpack = (b_dtype.width < 8 or b_packed_f6) and not both_fp4
     if (
         any(dt.width < 8 for dt in (a_dtype, b_dtype)) or a_packed_f6 or b_packed_f6
     ) and not both_fp4:
@@ -476,8 +517,8 @@ def make_fake_gemm_tensors(
     # also satisfy the tensormap's 32-byte stride rule.
     a_k_sym = cute.sym_int(divisibility=96) if a_packed_f6 else k
     b_k_sym = cute.sym_int(divisibility=96) if b_packed_f6 else k
-    div_a = 32 if a_packed_f6 else div_for_dtype(a_dtype)
-    div_b = 32 if b_packed_f6 else div_for_dtype(b_dtype)
+    div_a = 256 // a_dtype.width if a_unpack else div_for_dtype(a_dtype)
+    div_b = 256 // b_dtype.width if b_unpack else div_for_dtype(b_dtype)
     div_d = div_for_dtype(d_dtype) if d_dtype is not None else 1
     div_c = div_for_dtype(c_dtype) if c_dtype is not None else 1
     # Doubled packed extent for raw 16-bit D/C — its own independent sym.

--- a/quack/gemm_tvm_ffi_utils.py
+++ b/quack/gemm_tvm_ffi_utils.py
@@ -6,7 +6,7 @@ from functools import partial
 import torch
 
 import cutlass.cute as cute
-from cutlass import Int32, Float32
+from cutlass import Int32, Float32, Float4E2M1FN
 from cutlass.cute.runtime import make_ptr
 
 from quack.compile_utils import make_fake_tensor as fake_tensor
@@ -52,9 +52,10 @@ def validate_blockscaled_sf(
     (e.g. GemmSm100's blockscaled setup assert) - this function validates only
     layout/consistency.
 
-    A is (l, m, k[/2 if fp4]) and B is (l, n, k[/2]); SFA/SFB are
-    (l, rm/rn, rk, 32, 4, 4) with the inner (32, 4, 4) block contiguous
-    (strides (16, 4, 1) — one 512 B atom per 128 rows x 4 K-blocks).
+    A is (l, m, k_storage) and B is (l, n, k_storage), where k_storage is the
+    format's storage K extent (fp8: k; fp4x2: k/2; packed fp6: 3k/4 bytes);
+    SFA/SFB are (l, rm/rn, rk, 32, 4, 4) with the inner (32, 4, 4) block
+    contiguous (strides (16, 4, 1) - one 512 B atom per 128 rows x 4 K-blocks).
 
     When num_batches is not None and varlen_k is False (varlen_m), A is
     (total_m, k) and SFA must be a single M-padded buffer (tile-aligned
@@ -94,22 +95,33 @@ def validate_blockscaled_sf(
     )
     sf_vec_size = fmt_a.sf_vec_size
     sf_dtype = torch2cute_dtype_map[fmt_a.scale_dtype]
-    # Operand shapes carry packed K (fp4x2: two elements per byte) while dlpack
-    # presents the logical extent to the kernel, so validate rk against logical K,
-    # and cross-check that A and B agree on it (their packings may differ).
-    # Under b_kn, B crosses as (k, n[, l]).
+    # Operand shapes carry the storage K extent (fp4x2: K/2; packed fp6: 3K/4
+    # bytes) while dlpack presents the logical extent to the kernel, so validate
+    # rk against logical K, and cross-check that A and B agree on it (their
+    # packings may differ). Under b_kn, B crosses as (k, n[, l]).
     b_storage_k = B.shape[-2] if b_kn else B.shape[-1]
-    k_logical = A.shape[-1] * fmt_a.elems_per_container
-    k_logical_b = b_storage_k * fmt_b.elems_per_container
+    k_logical = fmt_a.logical_k(A.shape[-1])
+    k_logical_b = fmt_b.logical_k(b_storage_k)
     assert k_logical == k_logical_b, (
-        f"logical K mismatch: A {A.shape[-1]} x{fmt_a.elems_per_container} ({fmt_a.name}) "
-        f"vs B {b_storage_k} x{fmt_b.elems_per_container} ({fmt_b.name})"
+        f"logical K mismatch: A storage K {A.shape[-1]} ({fmt_a.name}) => {k_logical} "
+        f"vs B storage K {b_storage_k} ({fmt_b.name}) => {k_logical_b}"
     )
+    # Packed fp6 is TMA-unpacked through the 16U6_ALIGN16B tensormap, whose
+    # granule is 128 logical elements (96 bytes): fail here with a clear message
+    # rather than at the compiled arg-spec binding. (Mixed pairs with packed fp4
+    # need K % 128 too - already enforced by the arg spec's k divisibility.)
+    for fmt in (fmt_a, fmt_b):
+        if fmt.elem_bits == 6:
+            assert k_logical % 128 == 0, (
+                f"{fmt.name} operands require logical K divisible by 128 "
+                f"(TMA unpack tensormap granule), got K={k_logical}"
+            )
     rk = (k_logical + 4 * sf_vec_size - 1) // (4 * sf_vec_size)
     if varlen_k:
-        assert fmt_a.elems_per_container == 1 and fmt_b.elems_per_container == 1, (
-            "varlen_k blockscaled supports byte-container formats only: fp4 operands "
-            "must be K-major, but varlen_k requires m-major A / n-major B"
+        assert not fmt_a.is_packed and not fmt_b.is_packed, (
+            "varlen_k blockscaled supports 8-bit element formats only: packed "
+            "sub-byte operands (fp4/fp6) must be K-major, but varlen_k requires "
+            "m-major A / n-major B"
         )
         assert A.ndim == 2 and B.ndim == 2, (
             f"varlen_k expects A (m, total_k) and B (n, total_k), "
@@ -403,6 +415,8 @@ def make_fake_gemm_tensors(
     b_kn=False,
     swap_ab=False,
     packed_cd=None,
+    a_mma_dtype=None,
+    b_mma_dtype=None,
 ):
     """Create fake tensors for mA, mB, mD, mC with shared sym_ints.
     Pass dtype=None to get None for that tensor (e.g. optional C).
@@ -424,6 +438,9 @@ def make_fake_gemm_tensors(
     dense and varlen_m (B is batched rank-3 there, so the same trace-time
     select applies); varlen_k keeps the host relabel (its B is the rank-2
     flattened operand, outside rotate_batch_last's transpose path).
+    ``a/b_mma_dtype``: blockscaled MMA element types when they differ from the
+    storage dtypes - a width-6 MMA dtype marks a packed-fp6 operand whose
+    storage tensor is raw bytes.
     """
     assert batched or not (varlen_m or varlen_k), "varlen operands are 2D already"
     assert not (b_kn and varlen_k), "b_kn does not support varlen_k"
@@ -435,14 +452,32 @@ def make_fake_gemm_tensors(
     d_leading = 1 if d_major == "n" else 0
     c_leading = 1 if c_major == "n" else 0
     m, n, l = cute.sym_int(), cute.sym_int(), cute.sym_int()
-    # Sub-byte (fp4) tensors need their contiguous extent statically divisible by the
-    # packing factor; fp4 operands are k-major, so mark k. A and B may have different
-    # widths (mixed-format pairs): take the strictest sub-byte requirement of either.
-    # Harmless for 8-bit+ dtypes.
-    k_div = max((div_for_dtype(dt) for dt in (a_dtype, b_dtype) if dt.width < 8), default=1)
+    a_packed_f6 = a_mma_dtype is not None and a_mma_dtype.width == 6
+    b_packed_f6 = b_mma_dtype is not None and b_mma_dtype.width == 6
+    # Sub-byte tensors need their contiguous extent statically divisible; sub-byte
+    # operands are k-major, so mark k. Both-packed-fp4 runs kind::mxf4nvf4 with
+    # packed smem (16-byte rule: 32 elements); a sub-byte operand in any other
+    # pair is TMA-unpacked
+    # under kind::mxf8f6f4, whose ALIGN16B tensormap formats require the
+    # contiguous extent to be a multiple of 128 elements. Harmless for 8-bit+.
+    both_fp4 = a_dtype is Float4E2M1FN and b_dtype is Float4E2M1FN
+    if (
+        any(dt.width < 8 for dt in (a_dtype, b_dtype)) or a_packed_f6 or b_packed_f6
+    ) and not both_fp4:
+        k_div = 128
+    else:
+        k_div = max((div_for_dtype(dt) for dt in (a_dtype, b_dtype) if dt.width < 8), default=1)
     k = cute.sym_int(divisibility=k_div)
-    div_a = div_for_dtype(a_dtype)
-    div_b = div_for_dtype(b_dtype)
+    # Packed-fp6 operands cross the FFI boundary as raw bytes (torch has no fp6
+    # dtype), so their K extent is 3k/4 bytes: an independent sym - the 4/3
+    # relation between shared syms is not expressible in the arg spec; logical-K
+    # consistency is validated host-side. 96-byte divisibility == 128 fp6
+    # elements (the unpack-tensormap granule), and rows of whole 96-byte groups
+    # also satisfy the tensormap's 32-byte stride rule.
+    a_k_sym = cute.sym_int(divisibility=96) if a_packed_f6 else k
+    b_k_sym = cute.sym_int(divisibility=96) if b_packed_f6 else k
+    div_a = 32 if a_packed_f6 else div_for_dtype(a_dtype)
+    div_b = 32 if b_packed_f6 else div_for_dtype(b_dtype)
     div_d = div_for_dtype(d_dtype) if d_dtype is not None else 1
     div_c = div_for_dtype(c_dtype) if c_dtype is not None else 1
     # Doubled packed extent for raw 16-bit D/C — its own independent sym.
@@ -451,11 +486,11 @@ def make_fake_gemm_tensors(
         # m is total_m in this case: the flattened M dimension of D/C
         m = cute.sym_int()
         a_m = cute.sym_int() if gather_A else m
-        mA = fake_batched(a_dtype, a_m, k, None, a_leading, div_a)
+        mA = fake_batched(a_dtype, a_m, a_k_sym, None, a_leading, div_a)
         if b_kn:
-            mB = fake_batched(b_dtype, k, n, l, 1 - b_leading, div_b)
+            mB = fake_batched(b_dtype, b_k_sym, n, l, 1 - b_leading, div_b)
         else:
-            mB = fake_batched(b_dtype, n, k, l, b_leading, div_b)
+            mB = fake_batched(b_dtype, n, b_k_sym, l, b_leading, div_b)
         dc_n = pd if packed_cd is not None else n  # "n" form only under varlen
         mD = fake_batched(d_dtype, m, dc_n, None, d_leading, div_d)
         mC = fake_batched(c_dtype, m, dc_n, None, c_leading, div_c)
@@ -477,18 +512,18 @@ def make_fake_gemm_tensors(
             # cd_transposed. The caller-stride major labels flip with the
             # shape order, so the standard leading formulas hold (build_
             # gemm_epi_plan flips d/c majors, the only non-cancelling pair).
-            mA = fake_batched(a_dtype, k, m, bl, 1 - a_leading, div_a)
-            mB = fake_batched(b_dtype, n, k, bl, b_leading, div_b)
+            mA = fake_batched(a_dtype, a_k_sym, m, bl, 1 - a_leading, div_a)
+            mB = fake_batched(b_dtype, n, b_k_sym, bl, b_leading, div_b)
             mD = fake_batched(d_dtype, n, m, bl, 1 - d_leading, div_d)
             mC = fake_batched(c_dtype, n, m, bl, 1 - c_leading, div_c)
             return mA, mB, mD, mC, m, n, k, l
-        mA = fake_batched(a_dtype, m, k, bl, a_leading, div_a)
+        mA = fake_batched(a_dtype, m, a_k_sym, bl, a_leading, div_a)
         if b_kn:
             # (k, n) orientation: b_major is still the logical (n, k) label, so
             # "k"-major means dim 0 of (k, n) is contiguous.
-            mB = fake_batched(b_dtype, k, n, bl, 1 - b_leading, div_b)
+            mB = fake_batched(b_dtype, b_k_sym, n, bl, 1 - b_leading, div_b)
         else:
-            mB = fake_batched(b_dtype, n, k, bl, b_leading, div_b)
+            mB = fake_batched(b_dtype, n, b_k_sym, bl, b_leading, div_b)
         dc_x, dc_y = (m, pd) if packed_cd == "n" else (pd, n) if packed_cd == "m" else (m, n)
         mD = fake_batched(d_dtype, dc_x, dc_y, bl, d_leading, div_d)
         mC = fake_batched(c_dtype, dc_x, dc_y, bl, c_leading, div_c)

--- a/quack/sm100_utils.py
+++ b/quack/sm100_utils.py
@@ -2,10 +2,57 @@
 
 from typing import Type, Union
 
+import cutlass
 import cutlass.cute as cute
 import cutlass.utils.blackwell_helpers as sm100_utils_og
 from cutlass.cutlass_dsl import Numeric, dsl_user_op
-from cutlass.cute.nvgpu import OperandMajorMode
+from cutlass.cute.nvgpu import OperandMajorMode, tcgen05
+
+
+class MmaMXF4NVF4Op(tcgen05.MmaMXF4NVF4Op):
+    """tcgen05 kind::mxf4nvf4 MMA op with the scale config as a parameter.
+
+    kind::mxf4nvf4 is ONE MMA atom covering both both-fp4 scale configs -
+    scale_vec::2X (vec 32, e8m0; the mxfp4 instantiation, which PTX also
+    spells ``kind::mxf4``) and scale_vec::4X (vec 16; nvfp4) - mirroring
+    CUTLASS C++'s ``SM100_MMA_MXF4_SS<..., VS>``. The DSL class pins
+    sf_vec_size = 16; this subclass restores the parameter. Both vec sizes
+    build the identical MLIR atom type (it has no kind attribute - the
+    backend derives the PTX spelling from the vec size), so this changes
+    which Python op models the atom, not the lowered instruction.
+    """
+
+    def __init__(self, sf_dtype, sf_vec_size, instruction_shape, cta_group, a_src):
+        tcgen05.BlockScaledMmaOp.__init__(
+            self,
+            cutlass.Float4E2M1FN,
+            cutlass.Float4E2M1FN,
+            cutlass.Float32,
+            sf_dtype,
+            sf_vec_size,
+            instruction_shape,
+            cta_group,
+            a_src,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
+        )
+        self._verify()
+
+
+def make_blockscaled_trivial_tiled_mma(
+    a_dtype, b_dtype, a_major, b_major, sf_dtype, sf_vec_size, cta_group, mma_tiler_mn
+) -> cute.TiledMma:
+    """Like the DSL helper, but both-fp4 pairs always run the single
+    kind::mxf4nvf4 atom with the format's scale config (the DSL helper splits
+    them into MmaMXF4Op / MmaMXF4NVF4Op by vec size)."""
+    if a_dtype is cutlass.Float4E2M1FN and b_dtype is cutlass.Float4E2M1FN:
+        op = MmaMXF4NVF4Op(
+            sf_dtype, sf_vec_size, (*mma_tiler_mn, 64), cta_group, tcgen05.OperandSource.SMEM
+        )
+        return cute.make_tiled_mma(cute.make_mma_atom(op))
+    return sm100_utils_og.make_blockscaled_trivial_tiled_mma(
+        a_dtype, b_dtype, a_major, b_major, sf_dtype, sf_vec_size, cta_group, mma_tiler_mn
+    )
 
 
 @dsl_user_op

--- a/tests/test_blockscaled_operand.py
+++ b/tests/test_blockscaled_operand.py
@@ -16,6 +16,7 @@ from quack.blockscaled.operand import (
     BLOCKSCALED_FORMAT_REGISTRY,
     MXFP4,
     MXFP6_E2M3,
+    MXFP6_E3M2,
     MXFP8_E4M3,
     MXFP8_E5M2,
     NVFP4,
@@ -23,7 +24,7 @@ from quack.blockscaled.operand import (
     BlockScaledOperand,
 )
 
-FORMATS = [MXFP8_E4M3, MXFP4, NVFP4]
+FORMATS = [MXFP8_E4M3, MXFP4, NVFP4, MXFP6_E2M3, MXFP6_E3M2]
 
 
 def _quantize(fmt, m=256, k=256, batched=False, seed=0):
@@ -43,6 +44,22 @@ def test_format_registry_and_legacy_names():
         BlockScaledFormat.from_name("fp8")
     for fmt in BLOCKSCALED_FORMAT_REGISTRY.values():
         assert BlockScaledFormat.from_name(fmt.name) is fmt
+
+
+def test_format_k_mapping():
+    """logical<->storage K mapping derives from elem_bits and the torch storage
+    element width: fp8 identity, fp4x2 ratio 2, packed fp6 (uint8) ratio 4/3."""
+    assert not MXFP8_E4M3.is_packed and MXFP4.is_packed and MXFP6_E2M3.is_packed
+    assert MXFP8_E4M3.storage_k(384) == 384 and MXFP8_E4M3.logical_k(384) == 384
+    assert MXFP4.storage_k(384) == 192 and MXFP4.logical_k(192) == 384
+    assert NVFP4.storage_k(384) == 192
+    for fmt in (MXFP6_E2M3, MXFP6_E3M2):
+        assert fmt.storage_k(384) == 288 and fmt.logical_k(288) == 384
+    # non-whole mappings are loud errors (fp6 rows are whole 3-byte groups)
+    with pytest.raises(ValueError, match="whole storage"):
+        MXFP6_E2M3.storage_k(30)  # 180 bits: not whole bytes
+    with pytest.raises(ValueError, match="whole packed groups"):
+        MXFP6_E2M3.logical_k(100)  # 100 bytes: not whole 3-byte groups
 
 
 def test_format_from_cutlass_dtypes():
@@ -144,23 +161,58 @@ def test_varlen_padded_scale_constructible():
     assert torch.equal(dense_view.dequantize(torch.float32), t.dequantize(torch.float32))
 
 
+def test_pack_uint6_bit_layout():
+    """The packed fp6 storage contract: element i occupies bits [6i, 6i+6) of a
+    little-endian byte stream, so 4 codes (c0..c3) pack into 3 bytes as
+    b0 = c0 | c1<<6; b1 = c1>>2 | c2<<4; b2 = c2>>4 | c3<<2 - the CUTLASS
+    SubbyteReference bit order (verified bit-exact against the DSL fp6 fill)."""
+    from quack.blockscaled.quantize import pack_uint6, unpack_uint6
+
+    codes = torch.tensor([[0x21, 0x33, 0x2A, 0x3F]], dtype=torch.uint8, device="cuda")
+    packed = pack_uint6(codes)
+    assert packed.shape == (1, 3) and packed.cpu().tolist() == [[0xE1, 0xAC, 0xFE]]
+    assert torch.equal(unpack_uint6(packed), codes)
+    # round trip on random 6-bit codes
+    rand = torch.randint(0, 64, (7, 5, 128), dtype=torch.uint8, device="cuda")
+    assert torch.equal(unpack_uint6(pack_uint6(rand)), rand)
+    with pytest.raises(AssertionError, match="divisible by 4"):
+        pack_uint6(torch.zeros(6, dtype=torch.uint8, device="cuda"))
+    with pytest.raises(AssertionError, match="3-byte groups"):
+        unpack_uint6(torch.zeros(4, dtype=torch.uint8, device="cuda"))
+
+
 @pytest.mark.parametrize(
-    "fmt_name, tol", [("mxfp4_byte", 0.6), ("mxfp6_e2m3", 0.12), ("mxfp6_e3m2", 0.25)]
+    "fmt_name, max_tol, norm_tol", [("mxfp6_e2m3", 0.12, 0.05), ("mxfp6_e3m2", 0.25, 0.10)]
 )
-def test_byte_container_formats_quantize(fmt_name, tol):
-    """Byte-container sub-byte formats (one code per uint8 - the form the
-    mixed-capable kind::mxf8f6f4 consumes) quantize and dequantize today; the
-    GEMM rejects them at the per-architecture gate until the DSL grows
-    unpacksmem/TMA-expansion support (see gemm_sm100 validity comment)."""
-    m, k = 256, 256
+def test_packed_fp6_quantize_roundtrip(fmt_name, max_tol, norm_tol):
+    """Packed fp6 qdata is a uint8 6-bit bit stream: 4 codes per 3 bytes, so
+    the storage K extent is 3*K/4 (what the TMA unpack tensormap consumes
+    under kind::mxf8f6f4). Round-trip quality on randn: e2m3 ~3.7% rel, e3m2
+    ~8% rel - both the eager and compiled quantizers must produce the same
+    packed layout."""
+    from quack.blockscaled.quantize import QUANTIZERS
+
+    m, k = 256, 512
     torch.manual_seed(0)
     x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
     t = BlockScaledOperand.quantize(x, fmt_name)
-    assert t.qdata.dtype == torch.uint8 and t.shape == (m, k) and t.quant_dim == -1
-    err = (t.dequantize(torch.float32) - x.float()).abs().max() / x.float().abs().max()
-    assert err.item() < tol, f"{fmt_name}: round-trip rel_err={err.item()}"
-    # transpose semantics hold for byte formats too
-    assert torch.equal(t.mT.dequantize(torch.float32), t.dequantize(torch.float32).mT)
+    assert t.qdata.dtype == torch.uint8 and t.qdata.shape == (m, 3 * k // 4)
+    assert t.shape == (m, k) and t.quant_dim == -1
+    dq = t.dequantize(torch.float32)
+    xf = x.float()
+    rel_max = ((dq - xf).abs().max() / xf.abs().max()).item()
+    rel_norm = ((dq - xf).norm() / xf.norm()).item()
+    assert rel_max < max_tol, f"{fmt_name}: round-trip rel_max={rel_max}"
+    assert rel_norm < norm_tol, f"{fmt_name}: round-trip rel_norm={rel_norm}"
+    # eager and compiled quantizers agree bit-exactly on the packed layout
+    eager_fn, compiled_fn = QUANTIZERS[fmt_name]
+    q_e, s_e = eager_fn(x, 32)
+    q_c, s_c = compiled_fn(x, 32)
+    assert torch.equal(q_e, q_c) and torch.equal(s_e.view(torch.uint8), s_c.view(torch.uint8))
+    assert torch.equal(q_e, t.qdata)
+    # transpose semantics hold for packed fp6 (quant_dim pinned to the packed dim)
+    assert t.mT.shape == (k, m) and t.mT.quant_dim == -2
+    assert torch.equal(t.mT.dequantize(torch.float32), dq.mT)
 
 
 def test_e5m2_from_parts_but_no_quantizer():
@@ -289,31 +341,27 @@ def test_rejection_guards():
 
 
 def test_mma_kind_for_pair():
-    from quack.blockscaled.operand import MXFP6_E3M2, mma_kind_for_pair
+    from quack.blockscaled.operand import mma_kind_for_pair
 
-    # equal pairs
+    # equal pairs: both-fp4 is ONE mxf4nvf4 atom, scale config from the format
+    # (mxfp4: vec 32 e8m0 - PTX spells that instantiation kind::mxf4)
     assert mma_kind_for_pair(NVFP4, NVFP4) == "mxf4nvf4"
-    assert mma_kind_for_pair(MXFP4, MXFP4) == "mxf4"
+    assert mma_kind_for_pair(MXFP4, MXFP4) == "mxf4nvf4"
     assert mma_kind_for_pair(MXFP8_E4M3, MXFP8_E4M3) == "mxf8f6f4"
-    # fp8/fp6 byte-container formats mix freely under mxf8f6f4
+    # fp8/fp6 mix freely under mxf8f6f4
     assert mma_kind_for_pair(MXFP8_E4M3, MXFP8_E5M2) == "mxf8f6f4"
     assert mma_kind_for_pair(MXFP8_E4M3, MXFP6_E2M3) == "mxf8f6f4"
     assert mma_kind_for_pair(MXFP6_E3M2, MXFP6_E2M3) == "mxf8f6f4"
+    # packed sub-byte operands join mixed pairs too: TMA unpack expands the
+    # packed gmem into 8-bit smem containers under kind::mxf8f6f4
+    assert mma_kind_for_pair(MXFP4, MXFP8_E4M3) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP8_E5M2, MXFP4) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP4, MXFP6_E2M3) == "mxf8f6f4"
     # nvfp4 pairs only with itself (e4m3 scales / vec 16 are per-kind)
     with pytest.raises(ValueError, match="mxf4nvf4"):
         mma_kind_for_pair(NVFP4, MXFP8_E4M3)
     with pytest.raises(ValueError, match="mxf4nvf4"):
         mma_kind_for_pair(MXFP4, NVFP4)
-    # packed fp4x2 storage cannot join a mixed byte-container pair
-    with pytest.raises(ValueError, match="8-bit"):
-        mma_kind_for_pair(MXFP4, MXFP8_E4M3)
-    # byte-container fp4 mixes under mxf8f6f4; a pure byte-fp4 pair has no kind
-    from quack.blockscaled.operand import MXFP4_BYTE
-
-    assert mma_kind_for_pair(MXFP4_BYTE, MXFP8_E4M3) == "mxf8f6f4"
-    assert mma_kind_for_pair(MXFP4_BYTE, MXFP6_E2M3) == "mxf8f6f4"
-    with pytest.raises(ValueError, match="use mxfp4"):
-        mma_kind_for_pair(MXFP4_BYTE, MXFP4_BYTE)
 
 
 # -- quantized-axis direction (CUTLASS SfK/MNMajorAtom analogue) --------------
@@ -373,7 +421,7 @@ def test_format_without_dsl_element_type():
     formats that do have DSL types. See AI/blockscaled_api.md section 9."""
     from quack.blockscaled.operand import BLOCKSCALED_FORMAT_REGISTRY, mma_kind_for_pair
 
-    weird = BlockScaledFormat("e3m4_test", torch.uint8, None, 8, 1, torch.float8_e8m0fnu, 32)
+    weird = BlockScaledFormat("e3m4_test", torch.uint8, None, 8, torch.float8_e8m0fnu, 32)
     with pytest.raises(ValueError, match="no CuTe-DSL element type"):
         weird.to_cutlass_dtype()
     with pytest.raises(ValueError, match="no tcgen05 MMA element type"):
@@ -402,7 +450,7 @@ def test_future_recipe_examples():
 
     # DeepSeek-style 1x128 fp32-scale fp8: hardware elements, software recipe.
     ds1d = BlockScaledFormat(
-        "fp8_e4m3_1x128", torch.float8_e4m3fn, "Float8E4M3FN", 8, 1, torch.float32, 128
+        "fp8_e4m3_1x128", torch.float8_e4m3fn, "Float8E4M3FN", 8, torch.float32, 128
     )
     with pytest.raises(ValueError, match="no hardware MMA kind"):
         mma_kind_for_pair(ds1d, ds1d)
@@ -411,19 +459,19 @@ def test_future_recipe_examples():
         mma_kind_for_pair(MXFP8_E4M3, ds1d)
 
     # kscale: bf16 elements + per-row fp32 K-block scales (one-sided customer).
-    kscale = BlockScaledFormat("bf16_1x128", torch.bfloat16, "BFloat16", 16, 1, torch.float32, 128)
+    kscale = BlockScaledFormat("bf16_1x128", torch.bfloat16, "BFloat16", 16, torch.float32, 128)
     with pytest.raises(ValueError, match="no tcgen05 MMA element type"):
         mma_kind_for_pair(kscale, MXFP8_E4M3)
 
     # W4A16 int4-g128 (AWQ/GPTQ): fixed-offset elements are element decode;
     # bf16 scale dtype is just data; no integer tcgen05 blockscaled kind.
-    int4 = BlockScaledFormat("int4_1x128", torch.uint8, "Int4", 4, 2, torch.bfloat16, 128)
+    int4 = BlockScaledFormat("int4_1x128", torch.uint8, "Int4", 4, torch.bfloat16, 128)
     with pytest.raises(ValueError, match="no tcgen05 MMA element type"):
         mma_kind_for_pair(int4, int4)
 
     # e3m4: no DSL element type at all -> host-side only (see
     # test_format_without_dsl_element_type for the full behavior pin).
-    e3m4 = BlockScaledFormat("mxfp8_e3m4", torch.uint8, None, 8, 1, torch.float8_e8m0fnu, 32)
+    e3m4 = BlockScaledFormat("mxfp8_e3m4", torch.uint8, None, 8, torch.float8_e8m0fnu, 32)
     with pytest.raises(ValueError, match="no CuTe-DSL element type"):
         e3m4.to_cutlass_dtype()
 

--- a/tests/test_blockscaled_operand.py
+++ b/tests/test_blockscaled_operand.py
@@ -343,14 +343,36 @@ def test_to_packed_canonicalizes_interim_name_and_rejects_custom_recipe():
         custom.to_packed()
 
 
-def test_e5m2_from_parts_but_no_quantizer():
+def test_e5m2_from_parts_and_quantizer():
+    # from_parts remains a valid construction path for pre-quantized e5m2 data
     _, t = _quantize(MXFP8_E4M3)
     q = t.qdata.view(torch.uint8).view(torch.float8_e5m2)
     t5 = BlockScaledOperand.from_parts(q, t.scale, MXFP8_E5M2)
     assert t5.format is MXFP8_E5M2
-    x = torch.randn(256, 256, device="cuda", dtype=torch.bfloat16)
-    with pytest.raises(NotImplementedError, match="e5m2"):
-        BlockScaledOperand.quantize(x, MXFP8_E5M2)
+    # the real e5m2 encoder: to_mx with the e5m2 target (fp8_max 57344)
+    torch.manual_seed(0)
+    x = torch.randn(256, 512, device="cuda", dtype=torch.bfloat16)
+    t5q = BlockScaledOperand.quantize(x, MXFP8_E5M2)
+    assert t5q.format is MXFP8_E5M2 and t5q.qdata.dtype == torch.float8_e5m2
+    qf = t5q.qdata.float()
+    # RCEIL scales guarantee the block max never saturates e5m2 (no inf codes)
+    assert torch.isfinite(qf).all()
+    dq = t5q.dequantize(torch.float32)
+    xf = x.float()
+    # 2 mantissa bits: <= 2^-3 rel error per element on normal values
+    # (measured on randn: rel_max ~0.11, rel_norm ~0.053)
+    rel_max = ((dq - xf).abs().max() / xf.abs().max()).item()
+    rel_norm = ((dq - xf).norm() / xf.norm()).item()
+    assert rel_max < 0.13, f"e5m2 round-trip rel_max={rel_max}"
+    assert rel_norm < 0.06, f"e5m2 round-trip rel_norm={rel_norm}"
+    # eager and compiled encoders agree bit-exactly
+    from quack.blockscaled.quantize import QUANTIZERS
+
+    eager_fn, compiled_fn = QUANTIZERS["mxfp8_e5m2"]
+    q_e, s_e = eager_fn(x, 32)
+    q_c, s_c = compiled_fn(x, 32)
+    assert torch.equal(q_e.view(torch.uint8), q_c.view(torch.uint8))
+    assert torch.equal(s_e.view(torch.uint8), s_c.view(torch.uint8))
 
 
 # -- logical metadata & transpose semantics ----------------------------------

--- a/tests/test_blockscaled_operand.py
+++ b/tests/test_blockscaled_operand.py
@@ -15,8 +15,11 @@ import torch
 from quack.blockscaled.operand import (
     BLOCKSCALED_FORMAT_REGISTRY,
     MXFP4,
+    MXFP4_BYTE,
     MXFP6_E2M3,
+    MXFP6_E2M3_PACKED,
     MXFP6_E3M2,
+    MXFP6_E3M2_PACKED,
     MXFP8_E4M3,
     MXFP8_E5M2,
     NVFP4,
@@ -24,7 +27,15 @@ from quack.blockscaled.operand import (
     BlockScaledOperand,
 )
 
-FORMATS = [MXFP8_E4M3, MXFP4, NVFP4, MXFP6_E2M3, MXFP6_E3M2]
+FORMATS = [
+    MXFP8_E4M3,
+    MXFP4,
+    NVFP4,
+    MXFP6_E2M3,
+    MXFP6_E3M2,
+    MXFP6_E2M3_PACKED,
+    MXFP6_E3M2_PACKED,
+]
 
 
 def _quantize(fmt, m=256, k=256, batched=False, seed=0):
@@ -38,8 +49,15 @@ def _quantize(fmt, m=256, k=256, batched=False, seed=0):
 
 
 def test_format_registry_and_legacy_names():
+    import quack.blockscaled as blockscaled
+
     assert BlockScaledFormat.from_name("mxfp8") is MXFP8_E4M3  # legacy short name
     assert BlockScaledFormat.from_name("nvfp4") is NVFP4
+    assert BlockScaledFormat.from_name("mxfp6_e2m3") is MXFP6_E2M3
+    assert BlockScaledFormat.from_name("mxfp6_e2m3_packed") is MXFP6_E2M3_PACKED
+    assert MXFP6_E2M3.is_byte_container and not MXFP6_E2M3_PACKED.is_byte_container
+    assert blockscaled.MXFP4_BYTE is MXFP4_BYTE
+    assert blockscaled.to_mxfp4_byte is not None
     with pytest.raises(ValueError, match="unknown blockscaled format"):
         BlockScaledFormat.from_name("fp8")
     for fmt in BLOCKSCALED_FORMAT_REGISTRY.values():
@@ -49,17 +67,40 @@ def test_format_registry_and_legacy_names():
 def test_format_k_mapping():
     """logical<->storage K mapping derives from elem_bits and the torch storage
     element width: fp8 identity, fp4x2 ratio 2, packed fp6 (uint8) ratio 4/3."""
-    assert not MXFP8_E4M3.is_packed and MXFP4.is_packed and MXFP6_E2M3.is_packed
+    assert not MXFP8_E4M3.is_packed and MXFP4.is_packed and MXFP6_E2M3_PACKED.is_packed
     assert MXFP8_E4M3.storage_k(384) == 384 and MXFP8_E4M3.logical_k(384) == 384
     assert MXFP4.storage_k(384) == 192 and MXFP4.logical_k(192) == 384
     assert NVFP4.storage_k(384) == 192
-    for fmt in (MXFP6_E2M3, MXFP6_E3M2):
+    for fmt in (MXFP6_E2M3_PACKED, MXFP6_E3M2_PACKED):
         assert fmt.storage_k(384) == 288 and fmt.logical_k(288) == 384
+    for fmt in (MXFP4_BYTE, MXFP6_E2M3, MXFP6_E3M2):
+        assert not fmt.is_packed and fmt.is_byte_container
+        assert fmt.storage_k(384) == 384 and fmt.logical_k(384) == 384
     # non-whole mappings are loud errors (fp6 rows are whole 3-byte groups)
     with pytest.raises(ValueError, match="whole storage"):
-        MXFP6_E2M3.storage_k(30)  # 180 bits: not whole bytes
+        MXFP6_E2M3_PACKED.storage_k(30)  # 180 bits: not whole bytes
     with pytest.raises(ValueError, match="whole packed groups"):
-        MXFP6_E2M3.logical_k(100)  # 100 bytes: not whole 3-byte groups
+        MXFP6_E2M3_PACKED.logical_k(100)  # 100 bytes: not whole 3-byte groups
+
+
+def test_format_legacy_positional_order_and_validation():
+    """The public constructor keeps the origin/main positional field order."""
+    fmt = BlockScaledFormat(
+        "legacy_fp4", torch.uint8, "Float4E2M1FN", 4, 1, torch.float8_e8m0fnu, 32
+    )
+    assert fmt.elems_per_container == 1
+    assert fmt.scale_dtype == torch.float8_e8m0fnu and fmt.sf_vec_size == 32
+    assert fmt.storage_layout is None and fmt.is_byte_container
+    # A call written against the short-lived signature without
+    # elems_per_container must fail, not silently shift all later fields.
+    with pytest.raises(TypeError, match="elems_per_container"):
+        BlockScaledFormat(
+            "shifted", torch.uint8, None, 4, torch.float8_e8m0fnu, 32, False
+        )
+    with pytest.raises(ValueError, match="do not fit"):
+        BlockScaledFormat(
+            "overfull", torch.uint8, None, 6, 2, torch.float8_e8m0fnu, 32
+        )
 
 
 def test_format_from_cutlass_dtypes():
@@ -79,8 +120,9 @@ def test_format_from_cutlass_dtypes():
     )
     assert (
         BlockScaledFormat.from_cutlass_dtypes(cutlass.Float6E2M3FN, cutlass.Float8E8M0FNU, 32)
-        is MXFP6_E2M3
+        is MXFP6_E2M3_PACKED
     )
+    assert MXFP6_E2M3.is_byte_container  # byte descriptors are never inferred for GEMM
     with pytest.raises(ValueError, match="no blockscaled format"):
         BlockScaledFormat.from_cutlass_dtypes(cutlass.Float8E4M3FN, cutlass.Float8E4M3FN, 32)
 
@@ -181,8 +223,25 @@ def test_pack_uint6_bit_layout():
         unpack_uint6(torch.zeros(4, dtype=torch.uint8, device="cuda"))
 
 
+def test_unversioned_fp6_quantizer_keeps_byte_container_contract():
+    from quack.blockscaled.quantize import (
+        to_mxfp6_e2m3,
+        to_mxfp6_e2m3_packed,
+        unpack_uint6,
+    )
+
+    x = torch.randn(7, 128, dtype=torch.bfloat16, device="cuda").contiguous()
+    q_byte, sf_byte = to_mxfp6_e2m3(x)
+    q_packed, sf_packed = to_mxfp6_e2m3_packed(x)
+    assert q_byte.shape == x.shape
+    assert q_packed.shape == (7, 96)
+    assert torch.equal(unpack_uint6(q_packed), q_byte)
+    assert torch.equal(sf_packed.view(torch.uint8), sf_byte.view(torch.uint8))
+
+
 @pytest.mark.parametrize(
-    "fmt_name, max_tol, norm_tol", [("mxfp6_e2m3", 0.12, 0.05), ("mxfp6_e3m2", 0.25, 0.10)]
+    "fmt_name,max_tol,norm_tol",
+    [("mxfp6_e2m3_packed", 0.12, 0.05), ("mxfp6_e3m2_packed", 0.25, 0.10)],
 )
 def test_packed_fp6_quantize_roundtrip(fmt_name, max_tol, norm_tol):
     """Packed fp6 qdata is a uint8 6-bit bit stream: 4 codes per 3 bytes, so
@@ -213,6 +272,75 @@ def test_packed_fp6_quantize_roundtrip(fmt_name, max_tol, norm_tol):
     # transpose semantics hold for packed fp6 (quant_dim pinned to the packed dim)
     assert t.mT.shape == (k, m) and t.mT.quant_dim == -2
     assert torch.equal(t.mT.dequantize(torch.float32), dq.mT)
+
+
+@pytest.mark.parametrize(
+    "fmt,max_tol",
+    [(MXFP4_BYTE, 0.6), (MXFP6_E2M3, 0.12), (MXFP6_E3M2, 0.25)],
+    ids=lambda f: f.name if isinstance(f, BlockScaledFormat) else str(f),
+)
+def test_byte_container_compatibility_roundtrip_and_gemm_rejection(fmt, max_tol):
+    """Deprecated byte formats remain host-side lossless compatibility paths."""
+    from quack.blockscaled.operand import mma_kind_for_pair
+
+    m, k = 7, 96
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    t = BlockScaledOperand.quantize(x, fmt)
+    assert t.qdata.dtype == torch.uint8 and t.qdata.shape == (m, k)
+    assert t.shape == (m, k) and t.quant_dim == -1
+    dq = t.dequantize(torch.float32)
+    rel = ((dq - x.float()).abs().max() / x.float().abs().max()).item()
+    assert rel < max_tol
+    packed = t.to_packed()
+    target = {
+        MXFP4_BYTE: MXFP4,
+        MXFP6_E2M3: MXFP6_E2M3_PACKED,
+        MXFP6_E3M2: MXFP6_E3M2_PACKED,
+    }[fmt]
+    assert packed.format is target and packed.shape == t.shape
+    assert packed.qdata.shape[-1] == target.storage_k(k)
+    assert torch.equal(packed.dequantize(torch.float32), dq)
+    with pytest.raises(ValueError, match="byte-per-element.*host-side compatibility"):
+        mma_kind_for_pair(t.format, MXFP8_E4M3)
+
+
+def test_to_packed_canonicalizes_interim_name_and_rejects_custom_recipe():
+    x, byte = _quantize(MXFP6_E2M3, m=7, k=128)
+    packed = byte.to_packed()
+    interim_fmt = BlockScaledFormat(
+        "mxfp6_e2m3",
+        torch.uint8,
+        "Float6E2M3FN",
+        6,
+        1,
+        torch.float8_e8m0fnu,
+        32,
+        storage_layout="packed_lsb_v1",
+    )
+    interim = BlockScaledOperand.from_parts(packed.qdata, packed.scale, interim_fmt)
+    canonical = interim.to_packed()
+    assert canonical.format is MXFP6_E2M3_PACKED
+    assert canonical.qdata is interim.qdata and canonical.scale is interim.scale
+    assert torch.equal(canonical.dequantize(torch.float32), interim.dequantize(torch.float32))
+    quantized = BlockScaledOperand.quantize(x, interim_fmt)
+    explicit = BlockScaledOperand.quantize(x, MXFP6_E2M3_PACKED)
+    assert quantized.format is MXFP6_E2M3_PACKED and quantized.qdata.shape == (7, 96)
+    assert torch.equal(quantized.qdata, explicit.qdata)
+    assert torch.equal(quantized.scale.view(torch.uint8), explicit.scale.view(torch.uint8))
+
+    custom_vec64 = BlockScaledFormat(
+        "customer_fp6_vec64",
+        torch.uint8,
+        "Float6E2M3FN",
+        6,
+        1,
+        torch.float8_e8m0fnu,
+        64,
+    )
+    custom = BlockScaledOperand.from_parts(byte.qdata, byte.scale, custom_vec64)
+    with pytest.raises(ValueError, match="recipe.*does not match"):
+        custom.to_packed()
 
 
 def test_e5m2_from_parts_but_no_quantizer():
@@ -308,6 +436,134 @@ def test_save_load_weights_only():
     assert torch.equal(t2.scale.view(torch.uint8), t.scale.view(torch.uint8))
 
 
+def test_origin_main_byte_fp6_pickle_migrates_without_reinterpretation():
+    """An old descriptor has no storage_layout field and canonical fp6 name.
+
+    Loading must materialize the missing default as legacy byte-container
+    semantics. K=96 is deliberately divisible by three: blindly applying the
+    new packed ratio would look superficially valid while changing logical K
+    to 128.
+    """
+    import torch.utils._pytree as pytree
+
+    from quack.blockscaled.operand import _unflatten, mma_kind_for_pair
+
+    x = torch.randn(5, 96, device="cuda", dtype=torch.bfloat16)
+    byte_op = BlockScaledOperand.quantize(x, MXFP6_E2M3)
+    name_only = BlockScaledOperand.from_parts(
+        byte_op.qdata, byte_op.scale, "mxfp6_e2m3", orig_dtype=torch.bfloat16
+    )
+    assert name_only.format is MXFP6_E2M3 and name_only.shape == (5, 96)
+    assert torch.equal(name_only.dequantize(torch.float32), byte_op.dequantize(torch.float32))
+    old_fmt = object.__new__(BlockScaledFormat)
+    for name, value in (
+        ("name", "mxfp6_e2m3"),
+        ("qdata_dtype", torch.uint8),
+        ("cutlass_dtype_name", "Float6E2M3FN"),
+        ("elem_bits", 6),
+        ("elems_per_container", 1),
+        ("scale_dtype", torch.float8_e8m0fnu),
+        ("sf_vec_size", 32),
+        ("has_per_tensor_scale", False),
+    ):
+        object.__setattr__(old_fmt, name, value)
+    assert "storage_layout" not in old_fmt.__dict__
+    old_op = BlockScaledOperand.from_parts(
+        byte_op.qdata, byte_op.scale, old_fmt, orig_dtype=torch.bfloat16
+    )
+
+    buf = io.BytesIO()
+    torch.save(old_op, buf)
+    buf.seek(0)
+    loaded = torch.load(buf, weights_only=True)
+    assert loaded.format.name == "mxfp6_e2m3"
+    assert loaded.format.storage_layout is None
+    assert "storage_layout" in loaded.format.__dict__
+    assert loaded.format.is_byte_container and loaded.shape == (5, 96)
+    assert loaded.format == MXFP6_E2M3
+    assert hash(loaded.format) == hash(old_fmt)
+    assert torch.equal(loaded.dequantize(torch.float32), byte_op.dequantize(torch.float32))
+    migrated = loaded.to_packed()
+    assert migrated.format is MXFP6_E2M3_PACKED and migrated.shape == (5, 96)
+    assert migrated.qdata.shape == (5, 72)
+    assert torch.equal(migrated.dequantize(torch.float32), loaded.dequantize(torch.float32))
+
+    leaves, spec = pytree.tree_flatten(loaded)
+    rt = pytree.tree_unflatten(leaves, spec)
+    assert rt.format.storage_layout is None and rt.shape == (5, 96)
+    assert torch.equal(rt.dequantize(torch.float32), loaded.dequantize(torch.float32))
+
+    # Name-only TreeSpec contexts emitted by origin/main keep byte semantics.
+    old_tree_rt = _unflatten(
+        (loaded.qdata, loaded.scale, None),
+        ("mxfp6_e2m3", loaded.orig_dtype, loaded.quant_dim),
+    )
+    assert old_tree_rt.format.storage_layout is None and old_tree_rt.shape == (5, 96)
+    with pytest.raises(ValueError, match="byte-per-element.*host-side compatibility"):
+        mma_kind_for_pair(loaded.format, MXFP8_E4M3)
+    from quack.gemm_interface import gemm
+
+    with pytest.raises(ValueError, match="byte-per-element.*host-side compatibility"):
+        gemm(loaded, loaded.mT, tuned=False)
+
+
+def test_feature_head_packed_fp6_pickle_migrates_to_versioned_name():
+    """The feature schema omitted epc/layout and derived 6-bit packing by width."""
+    x = torch.randn(5, 96, device="cuda", dtype=torch.bfloat16)
+    packed = BlockScaledOperand.quantize(x, MXFP6_E2M3_PACKED)
+
+    feature_fmt = object.__new__(BlockScaledFormat)
+    for name, value in (
+        ("name", "mxfp6_e2m3"),
+        ("qdata_dtype", torch.uint8),
+        ("cutlass_dtype_name", "Float6E2M3FN"),
+        ("elem_bits", 6),
+        ("scale_dtype", torch.float8_e8m0fnu),
+        ("sf_vec_size", 32),
+        ("has_per_tensor_scale", False),
+    ):
+        object.__setattr__(feature_fmt, name, value)
+    assert "elems_per_container" not in feature_fmt.__dict__
+    assert "storage_layout" not in feature_fmt.__dict__
+
+    feature_op = object.__new__(BlockScaledOperand)
+    for name, value in (
+        ("qdata", packed.qdata),
+        ("scale", packed.scale),
+        ("format", feature_fmt),
+        ("per_tensor_scale", None),
+        ("orig_dtype", packed.orig_dtype),
+        ("quant_dim", packed.quant_dim),
+    ):
+        object.__setattr__(feature_op, name, value)
+
+    buf = io.BytesIO()
+    torch.save(feature_op, buf)
+    buf.seek(0)
+    loaded = torch.load(buf, weights_only=True)
+    assert loaded.format == MXFP6_E2M3_PACKED
+    assert loaded.format.name == "mxfp6_e2m3_packed"
+    assert loaded.format.elems_per_container == 1
+    assert loaded.format.storage_layout == "packed_lsb_v1"
+    assert loaded.qdata.shape == (5, 72) and loaded.shape == (5, 96)
+    assert torch.equal(loaded.dequantize(torch.float32), packed.dequantize(torch.float32))
+
+    feature_fp4 = object.__new__(BlockScaledFormat)
+    feature_fp4.__setstate__(
+        {
+            "name": "mxfp4",
+            "qdata_dtype": torch.float4_e2m1fn_x2,
+            "cutlass_dtype_name": "Float4E2M1FN",
+            "elem_bits": 4,
+            "scale_dtype": torch.float8_e8m0fnu,
+            "sf_vec_size": 32,
+            "has_per_tensor_scale": False,
+        }
+    )
+    assert feature_fp4 == MXFP4
+    assert feature_fp4.elems_per_container == 2 and feature_fp4.storage_layout is None
+
+
 def test_pytree_roundtrip():
     import torch.utils._pytree as pytree
 
@@ -321,6 +577,42 @@ def test_pytree_roundtrip():
     leaves, spec = pytree.tree_flatten(t.mT)
     rt = pytree.tree_unflatten(leaves, spec)
     assert rt.quant_dim == t.mT.quant_dim and rt.shape == t.mT.shape
+    # Packed FP6 carries its explicit storage-version name through the context.
+    _, t6 = _quantize(MXFP6_E2M3_PACKED, m=8, k=128)
+    leaves, spec = pytree.tree_flatten(t6)
+    rt6 = pytree.tree_unflatten(leaves, spec)
+    assert rt6.format is MXFP6_E2M3_PACKED
+    assert rt6.format.storage_layout == "packed_lsb_v1"
+    assert rt6.shape == t6.shape
+
+
+def test_pytree_treespec_json_roundtrip_preserves_custom_and_legacy_formats():
+    import json
+
+    import torch.utils._pytree as pytree
+
+    _, packed = _quantize(MXFP6_E2M3_PACKED, m=8, k=128)
+    custom_fmt = BlockScaledFormat(
+        "customer_fp6_packed_v7",
+        torch.uint8,
+        "Float6E2M3FN",
+        6,
+        1,
+        torch.float8_e8m0fnu,
+        32,
+        storage_layout="packed_lsb_v1",
+    )
+    custom = BlockScaledOperand.from_parts(packed.qdata, packed.scale, custom_fmt)
+
+    for op in (custom, BlockScaledOperand.quantize(packed.dequantize(), MXFP6_E2M3)):
+        leaves, spec = pytree.tree_flatten(op)
+        dumped = pytree.treespec_dumps(spec)
+        json.loads(dumped)  # the entire context must be JSON-safe
+        restored = pytree.tree_unflatten(leaves, pytree.treespec_loads(dumped))
+        assert restored.format == op.format
+        assert restored.format.storage_layout == op.format.storage_layout
+        assert restored.orig_dtype == op.orig_dtype and restored.quant_dim == op.quant_dim
+        assert restored.shape == op.shape
 
 
 # -- rejection guards at non-blockscaled entry points ------------------------
@@ -350,13 +642,15 @@ def test_mma_kind_for_pair():
     assert mma_kind_for_pair(MXFP8_E4M3, MXFP8_E4M3) == "mxf8f6f4"
     # fp8/fp6 mix freely under mxf8f6f4
     assert mma_kind_for_pair(MXFP8_E4M3, MXFP8_E5M2) == "mxf8f6f4"
-    assert mma_kind_for_pair(MXFP8_E4M3, MXFP6_E2M3) == "mxf8f6f4"
-    assert mma_kind_for_pair(MXFP6_E3M2, MXFP6_E2M3) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP8_E4M3, MXFP6_E2M3_PACKED) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP6_E3M2_PACKED, MXFP6_E2M3_PACKED) == "mxf8f6f4"
     # packed sub-byte operands join mixed pairs too: TMA unpack expands the
     # packed gmem into 8-bit smem containers under kind::mxf8f6f4
     assert mma_kind_for_pair(MXFP4, MXFP8_E4M3) == "mxf8f6f4"
     assert mma_kind_for_pair(MXFP8_E5M2, MXFP4) == "mxf8f6f4"
-    assert mma_kind_for_pair(MXFP4, MXFP6_E2M3) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP4, MXFP6_E2M3_PACKED) == "mxf8f6f4"
+    with pytest.raises(ValueError, match="byte-per-element"):
+        mma_kind_for_pair(MXFP6_E2M3, MXFP8_E4M3)
     # nvfp4 pairs only with itself (e4m3 scales / vec 16 are per-kind)
     with pytest.raises(ValueError, match="mxf4nvf4"):
         mma_kind_for_pair(NVFP4, MXFP8_E4M3)
@@ -421,7 +715,7 @@ def test_format_without_dsl_element_type():
     formats that do have DSL types. See AI/blockscaled_api.md section 9."""
     from quack.blockscaled.operand import BLOCKSCALED_FORMAT_REGISTRY, mma_kind_for_pair
 
-    weird = BlockScaledFormat("e3m4_test", torch.uint8, None, 8, torch.float8_e8m0fnu, 32)
+    weird = BlockScaledFormat("e3m4_test", torch.uint8, None, 8, 1, torch.float8_e8m0fnu, 32)
     with pytest.raises(ValueError, match="no CuTe-DSL element type"):
         weird.to_cutlass_dtype()
     with pytest.raises(ValueError, match="no tcgen05 MMA element type"):
@@ -450,7 +744,7 @@ def test_future_recipe_examples():
 
     # DeepSeek-style 1x128 fp32-scale fp8: hardware elements, software recipe.
     ds1d = BlockScaledFormat(
-        "fp8_e4m3_1x128", torch.float8_e4m3fn, "Float8E4M3FN", 8, torch.float32, 128
+        "fp8_e4m3_1x128", torch.float8_e4m3fn, "Float8E4M3FN", 8, 1, torch.float32, 128
     )
     with pytest.raises(ValueError, match="no hardware MMA kind"):
         mma_kind_for_pair(ds1d, ds1d)
@@ -459,19 +753,21 @@ def test_future_recipe_examples():
         mma_kind_for_pair(MXFP8_E4M3, ds1d)
 
     # kscale: bf16 elements + per-row fp32 K-block scales (one-sided customer).
-    kscale = BlockScaledFormat("bf16_1x128", torch.bfloat16, "BFloat16", 16, torch.float32, 128)
+    kscale = BlockScaledFormat(
+        "bf16_1x128", torch.bfloat16, "BFloat16", 16, 1, torch.float32, 128
+    )
     with pytest.raises(ValueError, match="no tcgen05 MMA element type"):
         mma_kind_for_pair(kscale, MXFP8_E4M3)
 
     # W4A16 int4-g128 (AWQ/GPTQ): fixed-offset elements are element decode;
     # bf16 scale dtype is just data; no integer tcgen05 blockscaled kind.
-    int4 = BlockScaledFormat("int4_1x128", torch.uint8, "Int4", 4, torch.bfloat16, 128)
+    int4 = BlockScaledFormat("int4_1x128", torch.uint8, "Int4", 4, 2, torch.bfloat16, 128)
     with pytest.raises(ValueError, match="no tcgen05 MMA element type"):
         mma_kind_for_pair(int4, int4)
 
     # e3m4: no DSL element type at all -> host-side only (see
     # test_format_without_dsl_element_type for the full behavior pin).
-    e3m4 = BlockScaledFormat("mxfp8_e3m4", torch.uint8, None, 8, torch.float8_e8m0fnu, 32)
+    e3m4 = BlockScaledFormat("mxfp8_e3m4", torch.uint8, None, 8, 1, torch.float8_e8m0fnu, 32)
     with pytest.raises(ValueError, match="no CuTe-DSL element type"):
         e3m4.to_cutlass_dtype()
 

--- a/tests/test_gemm_blockscaled_interface.py
+++ b/tests/test_gemm_blockscaled_interface.py
@@ -474,19 +474,7 @@ def test_uint8_scale_view_construction():
     assert torch.equal(out, ref)
 
 
-def _e5m2_operand(rows, k, seed=0):
-    """mxfp8_e5m2 has no quantizer; build one by value-casting an e4m3
-    quantization (kernel and dequant reference then see identical stored data)."""
-    torch.manual_seed(seed)
-    x = torch.randn(rows, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
-    t = BlockScaledOperand.quantize(x, "mxfp8_e4m3")
-    q5 = t.qdata.float().to(torch.float8_e5m2)
-    return BlockScaledOperand.from_parts(q5, t.scale, "mxfp8_e5m2")
-
-
 def _mixed_operand(fmt, rows, k, seed=0):
-    if fmt == "mxfp8_e5m2":
-        return _e5m2_operand(rows, k, seed)
     torch.manual_seed(seed)
     x = torch.randn(rows, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
     return BlockScaledOperand.quantize(x, fmt)
@@ -727,9 +715,9 @@ def test_blockscaled_out_dtype_reserved():
 
 
 def test_e5m2_from_parts_kernel():
-    """mxfp8_e5m2 has no in-repo quantizer but the kernel accepts it; construct
-    via from_parts with unit e8m0 scales and check against the dequant reference.
-    (First e5m2 blockscaled kernel coverage in-repo.)"""
+    """from_parts stays a valid e5m2 construction path (pre-quantized data
+    with caller-provided scales): unit e8m0 scales, checked against the
+    dequant reference."""
     _skip_if_not_sm100()
     m, n, k = 256, 256, 512
     torch.manual_seed(0)

--- a/tests/test_gemm_blockscaled_interface.py
+++ b/tests/test_gemm_blockscaled_interface.py
@@ -492,6 +492,22 @@ def _mixed_operand(fmt, rows, k, seed=0):
     return BlockScaledOperand.quantize(x, fmt)
 
 
+def _relayout_packed_operand(op, offset_bytes, row_pad_bytes):
+    """Copy packed fp4/fp6 into a view with an explicit base offset and row pitch."""
+    rows, storage_k = op.qdata.shape
+    row_stride = storage_k + row_pad_bytes
+    raw = torch.empty(
+        offset_bytes + rows * row_stride,
+        dtype=op.qdata.dtype,
+        device=op.qdata.device,
+    )
+    qdata = raw[offset_bytes:].as_strided((rows, storage_k), (row_stride, 1))
+    qdata.view(torch.uint8).copy_(op.qdata.view(torch.uint8))
+    return BlockScaledOperand.from_parts(
+        qdata, op.scale, op.format, orig_dtype=op.orig_dtype
+    )
+
+
 @pytest.mark.parametrize(
     "fmt_pair",
     [
@@ -503,12 +519,12 @@ def _mixed_operand(fmt, rows, k, seed=0):
         ("mxfp8_e4m3", "mxfp4"),
         ("mxfp4", "mxfp8_e5m2"),
         # packed fp6 x fp8 (both orders)
-        ("mxfp6_e2m3", "mxfp8_e4m3"),
-        ("mxfp8_e4m3", "mxfp6_e2m3"),
+        ("mxfp6_e2m3_packed", "mxfp8_e4m3"),
+        ("mxfp8_e4m3", "mxfp6_e2m3_packed"),
         # both operands sub-byte: fp6 x fp6, fp6 x fp4, fp4 x fp6
-        ("mxfp6_e2m3", "mxfp6_e3m2"),
-        ("mxfp6_e2m3", "mxfp4"),
-        ("mxfp4", "mxfp6_e3m2"),
+        ("mxfp6_e2m3_packed", "mxfp6_e3m2_packed"),
+        ("mxfp6_e2m3_packed", "mxfp4"),
+        ("mxfp4", "mxfp6_e3m2_packed"),
     ],
 )
 def test_blockscaled_gemm_mixed(fmt_pair):
@@ -531,6 +547,67 @@ def test_blockscaled_gemm_mixed(fmt_pair):
     ref_dq = A.dequantize(torch.float32) @ W.dequantize(torch.float32).T
     rel_dq = (out.float() - ref_dq).abs().max().item() / ref_dq.abs().max().item()
     assert rel_dq < 5e-3, f"{fmt_a} x {fmt_b}: rel_err vs dequant={rel_dq}"
+
+
+@pytest.mark.parametrize("unpack_side", ["a", "b"])
+@pytest.mark.parametrize("unpack_fmt", ["mxfp4", "mxfp6_e2m3_packed"])
+@pytest.mark.parametrize(
+    "offset_bytes,row_pad_bytes",
+    [(16, 0), (32, 16)],
+    ids=["misaligned-base", "misaligned-row-stride"],
+)
+def test_mixed_unpack_alignment_rejected(
+    unpack_side, unpack_fmt, offset_bytes, row_pad_bytes
+):
+    """U4/U6 TMA unpack rejects bad bases/pitches before issuing a device instruction."""
+    _skip_if_not_sm100()
+    m = n = 128
+    k = 512
+    A = _mixed_operand(unpack_fmt if unpack_side == "a" else "mxfp8_e4m3", m, k, seed=0)
+    W = _mixed_operand("mxfp8_e4m3" if unpack_side == "a" else unpack_fmt, n, k, seed=1)
+
+    # Populate the pointer-agnostic plan cache before the offset-only case. The
+    # compiled argument signature must still reject the misaligned replacement.
+    if row_pad_bytes == 0:
+        gemm(A, W.mT, tuned=False)
+        torch.cuda.synchronize()
+    if unpack_side == "a":
+        A = _relayout_packed_operand(A, offset_bytes, row_pad_bytes)
+    else:
+        W = _relayout_packed_operand(W, offset_bytes, row_pad_bytes)
+
+    unpack_qdata = A.qdata if unpack_side == "a" else W.qdata
+    if unpack_fmt == "mxfp4" and row_pad_bytes == 16:
+        assert unpack_qdata.stride(0) == 272
+
+    with pytest.raises(ValueError) as exc_info:
+        gemm(A, W.mT, tuned=False)
+    assert "32" in str(exc_info.value)
+    assert "cudaError" not in str(exc_info.value)
+    torch.cuda.synchronize()
+
+
+@pytest.mark.parametrize("unpack_side", ["a", "b"])
+@pytest.mark.parametrize("unpack_fmt", ["mxfp4", "mxfp6_e2m3_packed"])
+def test_mixed_unpack_aligned_padded_numeric(unpack_side, unpack_fmt):
+    """A 32-byte-offset/padded packed view remains a valid unpack source."""
+    _skip_if_not_sm100()
+    m = n = 128
+    k = 512
+    A = _mixed_operand(unpack_fmt if unpack_side == "a" else "mxfp8_e4m3", m, k, seed=0)
+    W = _mixed_operand("mxfp8_e4m3" if unpack_side == "a" else unpack_fmt, n, k, seed=1)
+    if unpack_side == "a":
+        A = _relayout_packed_operand(A, offset_bytes=32, row_pad_bytes=32)
+    else:
+        W = _relayout_packed_operand(W, offset_bytes=32, row_pad_bytes=32)
+
+    unpack_qdata = A.qdata if unpack_side == "a" else W.qdata
+    assert unpack_qdata.data_ptr() % 32 == 0
+    assert all(stride == 1 or stride % 32 == 0 for stride in unpack_qdata.stride())
+    out = gemm(A, W.mT, tuned=False)
+    ref = gemm_blockscaled_ref(A, W.mT)
+    rel = (out.float() - ref.float()).abs().max().item() / ref.float().abs().max().item()
+    assert rel < 5e-3, f"aligned padded {unpack_fmt} on {unpack_side}: rel_err={rel}"
 
 
 def test_mixed_fp4_unpack_k_granule_rejected():
@@ -565,11 +642,16 @@ def test_mixed_format_pairs():
     with pytest.raises(ValueError, match="cannot pair"):
         gemm(A4, B8, tuned=False)
     # mixed packed-fp4 pairs are legal: pair legality maps to kind::mxf8f6f4
-    from quack.blockscaled.operand import MXFP4, MXFP6_E2M3, MXFP8_E4M3, mma_kind_for_pair
+    from quack.blockscaled.operand import (
+        MXFP4,
+        MXFP6_E2M3_PACKED,
+        MXFP8_E4M3,
+        mma_kind_for_pair,
+    )
 
     assert mma_kind_for_pair(MXFP4, MXFP8_E4M3) == "mxf8f6f4"
     assert mma_kind_for_pair(MXFP8_E4M3, MXFP4) == "mxf8f6f4"
-    assert mma_kind_for_pair(MXFP4, MXFP6_E2M3) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP4, MXFP6_E2M3_PACKED) == "mxf8f6f4"
 
 
 def test_sm100_dtype_gate():
@@ -619,8 +701,8 @@ def test_fp6_k_granule_rejected():
     torch.manual_seed(0)
     x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
     w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
-    a6 = BlockScaledOperand.quantize(x, "mxfp6_e2m3")
-    b6 = BlockScaledOperand.quantize(w, "mxfp6_e3m2")
+    a6 = BlockScaledOperand.quantize(x, "mxfp6_e2m3_packed")
+    b6 = BlockScaledOperand.quantize(w, "mxfp6_e3m2_packed")
     assert a6.qdata.shape == (m, 3 * k // 4)  # packed 6-bit storage
     with pytest.raises(AssertionError, match="divisible by 128"):
         gemm(a6, b6.mT, tuned=False)

--- a/tests/test_gemm_blockscaled_interface.py
+++ b/tests/test_gemm_blockscaled_interface.py
@@ -6,8 +6,9 @@ operand form ((data, scale_factor) tuples are rejected, see
 test_tuple_operand_rejected).
 
 Layout contract (see quack/gemm_interface.py and AI/blockscaled_api.md):
-  A:   (M, K) or (L, M, K)   fp8 e4m3 (mxfp8) or packed fp4x2 (mxfp4/nvfp4, K/2 bytes)
-  B:   (K, N) or (L, K, N)   same dtype as A, K-contiguous (pass W.mT of an (N, K) weight)
+  A:   (M, K) or (L, M, K)   fp8 e4m3/e5m2, packed fp4x2 (K/2 bytes), or packed fp6 (3K/4 bytes)
+  B:   (K, N) or (L, K, N)   K-contiguous (pass W.mT of an (N, K) weight); A/B formats are
+       independent under kind::mxf8f6f4 (nvfp4 pairs only with itself)
   SF:  (rm, rk, 32, 4, 4) or (L, rm, rk, 32, 4, 4) with rm = ceil(rows / 128),
        rk = ceil(K / VEC / 4); inner block strides (16, 4, 1) (one contiguous 512 B atom).
        All format properties come from the BlockScaledFormat descriptor.
@@ -491,11 +492,33 @@ def _mixed_operand(fmt, rows, k, seed=0):
     return BlockScaledOperand.quantize(x, fmt)
 
 
-@pytest.mark.parametrize("fmt_pair", [("mxfp8_e4m3", "mxfp8_e5m2"), ("mxfp8_e5m2", "mxfp8_e4m3")])
-def test_blockscaled_gemm_mixed_fp8(fmt_pair):
+@pytest.mark.parametrize(
+    "fmt_pair",
+    [
+        # fp8 x fp8 (independent a/b dtypes, no sub-byte unpack)
+        ("mxfp8_e4m3", "mxfp8_e5m2"),
+        ("mxfp8_e5m2", "mxfp8_e4m3"),
+        # packed fp4 x fp8 (sub-byte operand TMA-unpacked, both orders)
+        ("mxfp4", "mxfp8_e4m3"),
+        ("mxfp8_e4m3", "mxfp4"),
+        ("mxfp4", "mxfp8_e5m2"),
+        # packed fp6 x fp8 (both orders)
+        ("mxfp6_e2m3", "mxfp8_e4m3"),
+        ("mxfp8_e4m3", "mxfp6_e2m3"),
+        # both operands sub-byte: fp6 x fp6, fp6 x fp4, fp4 x fp6
+        ("mxfp6_e2m3", "mxfp6_e3m2"),
+        ("mxfp6_e2m3", "mxfp4"),
+        ("mxfp4", "mxfp6_e3m2"),
+    ],
+)
+def test_blockscaled_gemm_mixed(fmt_pair):
     """Mixed A/B element types on SM100 (tcgen05 kind::mxf8f6f4 takes independent
-    a/b dtypes): e4m3 x e5m2 in both orders, checked against the dequant
-    reference."""
+    a/b dtypes): fp8/fp4/fp6 pairings across {e4m3, e5m2, fp4, fp6_e2m3, fp6_e3m2},
+    including packed sub-byte operands (TMA-unpacked into 8-bit SMEM containers).
+    Checked against both the blockscaled reference and the dequantized product.
+    (Both-fp4 runs the single mxf4nvf4 atom - scale config from the format -
+    and is covered by test_blockscaled_gemm; nvfp4 pairs only with itself, see
+    test_mixed_format_pairs.)"""
     _skip_if_not_sm100()
     fmt_a, fmt_b = fmt_pair
     m, n, k = 256, 512, 512
@@ -510,12 +533,28 @@ def test_blockscaled_gemm_mixed_fp8(fmt_pair):
     assert rel_dq < 5e-3, f"{fmt_a} x {fmt_b}: rel_err vs dequant={rel_dq}"
 
 
+def test_mixed_fp4_unpack_k_granule_rejected():
+    """Packed sub-byte operands in mixed pairs require logical K % 128 == 0 (the
+    TMA-unpack tensormap granule). K=320 satisfies the old quantization rule
+    (K % 32 == 0) but violates the unpack granule: the mixed fp4 x fp8 pair must
+    be rejected cleanly (ValueError from the compiled arg-spec binding for fp4,
+    AssertionError from validate_blockscaled_sf for fp6), not crash or corrupt."""
+    _skip_if_not_sm100()
+    m, n, k = 256, 256, 320
+    A = _mixed_operand("mxfp4", m, k, seed=0)
+    W = _mixed_operand("mxfp8_e4m3", n, k, seed=1)
+    with pytest.raises((ValueError, AssertionError)):
+        gemm(A, W.mT, tuned=False)
+
+
 def test_mixed_format_pairs():
-    """A and B carry independent formats. Unrepresentable pairs raise ValueError
-    at the interface: nvfp4 pairs only with itself (mxf4nvf4), and packed-fp4x2
-    storage cannot feed the byte-container SMEM of the mixed mxf8f6f4 kind (a
-    byte-container fp4 format is backlog). Working mixed pairs are covered by
-    test_blockscaled_gemm_mixed_fp8."""
+    """A and B carry independent formats. nvfp4 pairs only with itself
+    (kind::mxf4nvf4 - the e4m3 scales / vec-16 config is per-instruction) and
+    is rejected with ValueError at the interface. Everything else - including
+    packed sub-byte operands - is hardware-legal under kind::mxf8f6f4: the
+    packed gmem operand is TMA-unpacked into 8-bit SMEM containers, so mixed
+    packed-fp4 x fp8 pairs must NOT be rejected. (End-to-end numerics for the
+    mixed matrix: test_blockscaled_gemm_mixed.)"""
     _skip_if_not_sm100()
     m, n, k = 256, 256, 512
     A8, B8 = _quantized_operands("mxfp8", m, n, k, batched=False)
@@ -523,36 +562,68 @@ def test_mixed_format_pairs():
     # nvfp4's mxf4nvf4 kind requires nvfp4 on both operands
     with pytest.raises(ValueError, match="cannot pair"):
         gemm(A8, B4, tuned=False)
-    # packed fp4x2 cannot join a mixed (mxf8f6f4, byte-container) pair
-    Am4, Bm4 = _quantized_operands("mxfp4", m, n, k, batched=False)
-    with pytest.raises(ValueError, match="8-bit"):
-        gemm(Am4, B8, tuned=False)
-    with pytest.raises(ValueError, match="8-bit"):
-        gemm(A8, Bm4, tuned=False)
+    with pytest.raises(ValueError, match="cannot pair"):
+        gemm(A4, B8, tuned=False)
+    # mixed packed-fp4 pairs are legal: pair legality maps to kind::mxf8f6f4
+    from quack.blockscaled.operand import MXFP4, MXFP6_E2M3, MXFP8_E4M3, mma_kind_for_pair
+
+    assert mma_kind_for_pair(MXFP4, MXFP8_E4M3) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP8_E4M3, MXFP4) == "mxf8f6f4"
+    assert mma_kind_for_pair(MXFP4, MXFP6_E2M3) == "mxf8f6f4"
 
 
 def test_sm100_dtype_gate():
-    """Kernel dtype support is a per-architecture assert (GemmSm100), not a
-    registry property: fp6 (uint8 byte containers) is constructible and flows
-    through interface + layout validation, then dies at the SM100 gate with a
-    message naming the unsupported combination."""
+    """Kernel dtype support is a per-architecture gate
+    (GemmSm100.is_valid_dtypes_and_scale_factor_vec_size), not a registry
+    property. New world: fp6 MMA dtypes are accepted with a Uint8 copy dtype
+    (packed fp6 crosses the FFI boundary as raw bytes and is TMA-unpacked
+    in-kernel) and mixed fp4/fp8 pairs are accepted with packed-fp4 storage;
+    byte-container (one code per uint8) sub-byte storage has no kernel path."""
+    import cutlass
+
+    from quack.gemm_sm100 import GemmSm100
+
+    ok = GemmSm100.is_valid_dtypes_and_scale_factor_vec_size
+    e8m0, e4m3, bf16 = cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN, cutlass.BFloat16
+    f4, f6a, f6b, u8 = (
+        cutlass.Float4E2M1FN,
+        cutlass.Float6E2M3FN,
+        cutlass.Float6E3M2FN,
+        cutlass.Uint8,
+    )
+    # fp6 MMA dtypes with Uint8 copy dtype (packed 6-bit gmem, raw bytes at FFI)
+    assert ok(f6a, e4m3, e8m0, 32, bf16, a_copy_dtype=u8)
+    assert ok(e4m3, f6b, e8m0, 32, bf16, b_copy_dtype=u8)
+    assert ok(f6a, f6b, e8m0, 32, bf16, a_copy_dtype=u8, b_copy_dtype=u8)
+    # mixed packed fp4 x fp8 (TMA unpack under kind::mxf8f6f4) and pure packed fp4
+    assert ok(f4, e4m3, e8m0, 32, bf16)
+    assert ok(e4m3, f4, e8m0, 32, bf16)
+    assert ok(f4, f4, e8m0, 32, bf16)
+    assert ok(f4, f4, e4m3, 16, bf16)  # nvfp4
+    # copy dtype must be the storage the kernel implements: byte-container fp4
+    # (one code per uint8) and non-Uint8 fp6 copy dtypes have no kernel path
+    assert not ok(f4, e4m3, e8m0, 32, bf16, a_copy_dtype=u8)
+    assert not ok(f6a, e4m3, e8m0, 32, bf16, a_copy_dtype=e4m3)
+    # vec-16 (nvfp4 scale config) requires fp4 on BOTH operands
+    assert not ok(f4, e4m3, e4m3, 16, bf16)
+    assert not ok(f6a, f6a, e4m3, 16, bf16, a_copy_dtype=u8, b_copy_dtype=u8)
+
+
+def test_fp6_k_granule_rejected():
+    """fp6 operands require logical K % 128 == 0 (the TMA unpack tensormap
+    granule): host-side validation must fail with a clear message instead of a
+    spec-binding error at compile. K=192 is quantizable (K % 32 == 0) but not
+    unpackable."""
     _skip_if_not_sm100()
-    m, k = 256, 512
+    m, n, k = 256, 256, 192
     torch.manual_seed(0)
     x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
-    sf = BlockScaledOperand.quantize(x, "mxfp8_e4m3").scale
-    t6 = BlockScaledOperand.from_parts(
-        torch.zeros(m, k, dtype=torch.uint8, device="cuda"), sf, "mxfp6_e2m3"
-    )
-    with pytest.raises(AssertionError, match="GemmSm100 blockscaled does not support"):
-        gemm(t6, t6.mT, tuned=False)
-    # byte-container fp4 in a mixed pair: hardware-legal (kind::mxf8f6f4), but
-    # CuTe-DSL 4.6 lacks the unpacksmem/TMA-expansion machinery - same gate.
-    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
-    a8 = BlockScaledOperand.quantize(x, "mxfp8_e4m3")
-    b4 = BlockScaledOperand.quantize(x, "mxfp4_byte")
-    with pytest.raises(AssertionError, match="GemmSm100 blockscaled does not support"):
-        gemm(a8, b4.mT, tuned=False)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) * k**-0.5
+    a6 = BlockScaledOperand.quantize(x, "mxfp6_e2m3")
+    b6 = BlockScaledOperand.quantize(w, "mxfp6_e3m2")
+    assert a6.qdata.shape == (m, 3 * k // 4)  # packed 6-bit storage
+    with pytest.raises(AssertionError, match="divisible by 128"):
+        gemm(a6, b6.mT, tuned=False)
 
 
 def test_blockscaled_out_dtype_reserved():
@@ -596,21 +667,40 @@ def test_e5m2_from_parts_kernel():
     assert rel < 5e-3, f"e5m2: rel_err={rel}"
 
 
-def test_gemm_act_pts_rejected():
-    """gemm_act has no alpha to fold the NVFP4 per-tensor scale into."""
+@pytest.mark.parametrize("activation", ["relu", "swiglu"])
+def test_gemm_act_pts_alpha(activation):
+    """NVFP4 per-tensor scales compose with pre-activation alpha."""
     _skip_if_not_sm100()
     m, n, k = 256, 256, 512
     torch.manual_seed(0)
     x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
     w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n, device="cuda", dtype=torch.float32)
     xq = BlockScaledOperand.quantize(
         x, "nvfp4", per_tensor_scale=nvfp4_per_tensor_scale(x.float().abs().amax())
     )
     wq = BlockScaledOperand.quantize(
         w, "nvfp4", per_tensor_scale=nvfp4_per_tensor_scale(w.float().abs().amax())
     )
-    with pytest.raises(NotImplementedError, match="per-tensor scale"):
-        gemm_act(xq, wq.mT, activation="relu", tuned=False)
+    alpha = 0.375
+    ref_pre = gemm_blockscaled_ref(xq, wq.mT, alpha=alpha, out_dtype=torch.float32) + bias
+    ref_post = (
+        F.silu(ref_pre[..., ::2]) * ref_pre[..., 1::2]
+        if activation == "swiglu"
+        else F.relu(ref_pre)
+    ).to(torch.bfloat16)
+
+    def f(a, b):
+        return gemm_act(a, b, bias=bias, activation=activation, alpha=alpha, tuned=False)
+
+    for fn in (f, torch.compile(f, dynamic=False, fullgraph=True)):
+        preact, postact = fn(xq, wq.mT)
+        rel_pre = (preact.float() - ref_pre).abs().max() / ref_pre.abs().max()
+        rel_post = (postact.float() - ref_post.float()).abs().max() / (
+            ref_post.float().abs().max() + 1e-9
+        )
+        assert rel_pre < 5e-3, f"{activation}: preact rel_err={rel_pre}"
+        assert rel_post < 1e-2, f"{activation}: postact rel_err={rel_post}"
 
 
 def test_blockscaled_gemm_torch_compile_container():

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -14,6 +14,7 @@ from quack.blockscaled.utils import (
     scale_blocked_for_cublas,
     scale_view_for_kernel,
 )
+from quack.blockscaled.operand import MXFP4, MXFP8_E4M3, NVFP4
 from quack.gemm_default_epi import GemmDefaultSm100
 from quack.blockscaled.quantize import to_blocked
 
@@ -68,11 +69,10 @@ def _run_blockscaled_gemm(compiled, args):
 
 
 def test_blockscaled_validation():
-    assert GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (128, 64),
         (1, 1),
@@ -84,11 +84,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (128, 192),
         (1, 1),
@@ -100,11 +99,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (128, 128),
         (1, 1),
@@ -116,11 +114,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float4E2M1FN,
-        cutlass.Float4E2M1FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert GemmDefaultSm100.can_implement(
+        MXFP4,
+        MXFP4,
+        cutlass.Float32,
         cutlass.Float32,
         (128, 128),
         (1, 1),
@@ -132,11 +129,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float4E2M1FN,
-        cutlass.Float4E2M1FN,
-        cutlass.Float8E4M3FN,
-        16,
+    assert GemmDefaultSm100.can_implement(
+        NVFP4,
+        NVFP4,
+        cutlass.Float32,
         cutlass.Float32,
         (128, 192),
         (1, 1),
@@ -148,11 +144,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert not GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert not GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (256, 384),
         (2, 1),
@@ -164,11 +159,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert not GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert not GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.Float32,
         (256, 224),
         (2, 1),
@@ -180,11 +174,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert not GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float4E2M1FN,
-        cutlass.Float4E2M1FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert not GemmDefaultSm100.can_implement(
+        MXFP4,
+        MXFP4,
+        cutlass.Float32,
         cutlass.Float32,
         (256, 384),
         (2, 1),
@@ -196,11 +189,10 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert not GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert not GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (64, 128),
         (1, 1),
@@ -212,27 +204,19 @@ def test_blockscaled_validation():
         "k",
         "n",
     )
-    assert not GemmDefaultSm100.can_implement_blockscaled(
+    # fp4 with e4m3 scales at vec 32 is an illegal scale config that no
+    # registry format descriptor can express; check the dtype gate directly.
+    assert not GemmDefaultSm100.is_valid_dtypes_and_scale_factor_vec_size(
         cutlass.Float4E2M1FN,
         cutlass.Float4E2M1FN,
         cutlass.Float8E4M3FN,
         32,
         cutlass.Float32,
-        (128, 128),
-        (1, 1),
-        256,
-        256,
-        256,
-        1,
-        "k",
-        "k",
-        "n",
     )
-    assert not GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        32,
+    assert not GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (256, 128),
         (1, 1),
@@ -243,6 +227,22 @@ def test_blockscaled_validation():
         "k",
         "k",
         "n",
+    )
+
+
+def test_can_implement_operand_kind_polymorphism():
+    """One preflight entry point for both kernels: plain cutlass dtypes select
+    the dense checks, BlockScaledFormat descriptors the blockscaled checks, and
+    one operand of each kind is rejected."""
+    common = ((128, 128), (1, 1), 256, 256, 256, 1, "k", "k", "n")
+    assert GemmDefaultSm100.can_implement(
+        cutlass.BFloat16, cutlass.BFloat16, cutlass.Float32, cutlass.BFloat16, *common
+    )
+    assert not GemmDefaultSm100.can_implement(
+        MXFP8_E4M3, cutlass.Float8E4M3FN, cutlass.Float32, cutlass.BFloat16, *common
+    )
+    assert not GemmDefaultSm100.can_implement(
+        cutlass.Float8E4M3FN, MXFP8_E4M3, cutlass.Float32, cutlass.BFloat16, *common
     )
 
 
@@ -626,11 +626,10 @@ def test_blockscaled_mxfp8_major_modes(a_major, b_major):
     b_sc = pack_scale_2d_to_blocked_contig(sb_2d)
     _, mD = create_blockscaled_operand_tensor(l, m, n, False, cutlass.BFloat16, init="empty")
 
-    assert GemmDefaultSm100.can_implement_blockscaled(
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E4M3FN,
-        cutlass.Float8E8M0FNU,
-        sf_vec,
+    assert GemmDefaultSm100.can_implement(
+        MXFP8_E4M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
         cutlass.BFloat16,
         (128, 128),
         (1, 1),

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -908,6 +908,57 @@ def test_blockscaled_varlen_k_public_api(seqlens_k):
 
 
 @pytest.mark.parametrize(
+    "a_fmt,b_fmt",
+    [("mxfp8_e4m3", "mxfp8_e5m2"), ("mxfp8_e5m2", "mxfp8_e4m3")],
+)
+@pytest.mark.parametrize("seqlens_k", [[128, 128, 128], [96, 160, 128]])
+def test_blockscaled_varlen_k_mixed_dtype(seqlens_k, a_fmt, b_fmt):
+    """varlen_k with mixed fp8 operand dtypes (mxf8f6f4 kind). Only fp8 pairs
+    are possible here: varlen_k needs m-major A / n-major B, while packed
+    sub-byte (fp4/fp6) operands must be K-major."""
+    _skip_if_not_sm100()
+    from quack.gemm import gemm as gemm_public
+    from quack.blockscaled.operand import BLOCKSCALED_FORMAT_REGISTRY
+
+    a_dtype = BLOCKSCALED_FORMAT_REGISTRY[a_fmt].to_cutlass_dtype()
+    b_dtype = BLOCKSCALED_FORMAT_REGISTRY[b_fmt].to_cutlass_dtype()
+    num_experts = len(seqlens_k)
+    m, n, sf_vec = 256, 256, 32
+
+    torch.manual_seed(0)
+    a_ref_list, b_ref_list, mA, mB, a_sc_contig, b_sc_contig, cu_seqlens_k = (
+        create_blockscaled_varlen_k_operands(
+            num_experts, 0, m, n, sf_vec, a_dtype, seqlens_k=seqlens_k, b_dtype=b_dtype
+        )
+    )
+    mD = torch.empty(num_experts, m, n, dtype=torch.bfloat16, device="cuda")
+    gemm_public(
+        mA,  # (m, total_k) m-major
+        mB,  # (n, total_k) n-major
+        mD,  # (L, m, n); gemm() permutes to (m, n, L) internally
+        None,
+        None,
+        tile_M=128,
+        tile_N=128,
+        cluster_M=1,
+        cluster_N=1,
+        cu_seqlens_k=cu_seqlens_k,
+        SFA=a_sc_contig,
+        SFB=b_sc_contig,
+        bs_format_a=a_fmt,
+        bs_format_b=b_fmt,
+    )
+    torch.cuda.synchronize()
+
+    for i in range(num_experts):
+        ref_i = a_ref_list[i] @ b_ref_list[i].T
+        err = (mD[i].float() - ref_i).abs().max().item()
+        assert err < 5e-3, (
+            f"varlen_k mixed a={a_fmt} b={b_fmt} seqlens_k={seqlens_k} expert={i} max_err={err}"
+        )
+
+
+@pytest.mark.parametrize(
     "tile_cluster",
     [((128, 128), (1, 1)), ((128, 256), (1, 2)), ((256, 128), (2, 1)), ((256, 256), (2, 2))],
 )

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -405,6 +405,20 @@ def test_direct_quantized_generator_rejects_packed_fp6():
             256,
             1,
         ),
+        # batched packed fp4: pins the generator's K-majorness for l > 1
+        # (a (mn, k/2, l) contiguous alloc would put stride 1 on L, not K)
+        (
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E8M0FNU,
+            32,
+            cutlass.Float32,
+            (128, 128),
+            (1, 1),
+            256,
+            256,
+            256,
+            2,
+        ),
         (
             cutlass.Float4E2M1FN,
             cutlass.Float8E8M0FNU,

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -14,7 +14,13 @@ from quack.blockscaled.utils import (
     scale_blocked_for_cublas,
     scale_view_for_kernel,
 )
-from quack.blockscaled.operand import MXFP4, MXFP8_E4M3, NVFP4
+from quack.blockscaled.operand import (
+    MXFP4,
+    MXFP6_E2M3,
+    MXFP6_E2M3_PACKED,
+    MXFP8_E4M3,
+    NVFP4,
+)
 from quack.gemm_default_epi import GemmDefaultSm100
 from quack.blockscaled.quantize import to_blocked
 
@@ -244,6 +250,60 @@ def test_can_implement_operand_kind_polymorphism():
     assert not GemmDefaultSm100.can_implement(
         cutlass.Float8E4M3FN, MXFP8_E4M3, cutlass.Float32, cutlass.BFloat16, *common
     )
+
+
+@pytest.mark.parametrize("fmt_a", [MXFP4, MXFP6_E2M3_PACKED])
+def test_mixed_unpack_explicit_tile_k_validation(fmt_a):
+    common = ((1, 1), 256, 256, 512, 1, "k", "k", "n")
+    for tile_k in (32, 64, 96, 160):
+        assert not GemmDefaultSm100.can_implement(
+            fmt_a,
+            MXFP8_E4M3,
+            cutlass.Float32,
+            cutlass.BFloat16,
+            (128, 128, tile_k),
+            *common,
+        )
+    for tile_k in (128, 256):
+        assert GemmDefaultSm100.can_implement(
+            fmt_a,
+            MXFP8_E4M3,
+            cutlass.Float32,
+            cutlass.BFloat16,
+            (128, 128, tile_k),
+            *common,
+        )
+    # NVFP4 uses vec-16 scales, so its complete SF chunk is 64 K elements.
+    assert GemmDefaultSm100.can_implement(
+        NVFP4,
+        NVFP4,
+        cutlass.Float32,
+        cutlass.BFloat16,
+        (128, 128, 64),
+        *common,
+    )
+    assert not GemmDefaultSm100.can_implement(
+        MXFP6_E2M3,
+        MXFP8_E4M3,
+        cutlass.Float32,
+        cutlass.BFloat16,
+        (128, 128, 128),
+        *common,
+    )
+
+
+def test_direct_quantized_generator_rejects_packed_fp6():
+    """The direct TVM-FFI helper has no separate uint8-storage/FP6-MMA dtype."""
+    with pytest.raises(ValueError, match="init=quant does not support"):
+        create_blockscaled_operand_quantized(
+            1,
+            128,
+            256,
+            False,
+            32,
+            cutlass.Float6E2M3FN,
+            cutlass.Float8E8M0FNU,
+        )
 
 
 @pytest.mark.parametrize(
@@ -665,7 +725,10 @@ def test_blockscaled_mxfp8_major_modes(a_major, b_major):
 VARLEN_FMT = {
     # format: (ab_dtype, sf_dtype, sf_vec_size)
     "mxfp8": (cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU, 32),
+    "mxfp8_e5m2": (cutlass.Float8E5M2, cutlass.Float8E8M0FNU, 32),
     "mxfp4": (cutlass.Float4E2M1FN, cutlass.Float8E8M0FNU, 32),
+    "mxfp6_e2m3_packed": (cutlass.Float6E2M3FN, cutlass.Float8E8M0FNU, 32),
+    "mxfp6_e3m2_packed": (cutlass.Float6E3M2FN, cutlass.Float8E8M0FNU, 32),
     "nvfp4": (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN, 16),
 }
 
@@ -946,6 +1009,58 @@ def test_blockscaled_varlen_m_public_api(seqlens_m, b_major, fmt):
     ref = torch.cat([a_ref_dq[cu[i] : cu[i + 1]] @ b_ref_dq[i].T for i in range(num_experts)])
     err = (mD.float() - ref).abs().max().item()
     assert err < 5e-3, f"public API varlen_m {fmt} seqlens_m={seqlens_m} max_err={err}"
+
+
+@pytest.mark.parametrize(
+    "fmt", ["mxfp8_e5m2", "mxfp6_e2m3_packed", "mxfp6_e3m2_packed"]
+)
+def test_blockscaled_varlen_m_extended_formats_public_api(fmt):
+    """The benchmark's varlen generator supports every advertised same-format input."""
+    _skip_if_not_sm100()
+    from quack.gemm import gemm as gemm_public
+
+    seqlens_m = [100, 156]
+    num_experts = len(seqlens_m)
+    n, k = 256, 256
+    ab_dtype, sf_dtype, sf_vec = VARLEN_FMT[fmt]
+
+    torch.manual_seed(0)
+    a_ref, b_ref, A, B, SFA, SFB, cu_seqlens_m = create_blockscaled_varlen_m_operands(
+        num_experts,
+        0,
+        n,
+        k,
+        sf_vec,
+        ab_dtype,
+        sf_dtype,
+        seqlens_m=seqlens_m,
+    )
+    if fmt.startswith("mxfp6"):
+        assert A.shape[1] == 3 * k // 4
+        assert B.shape[1] == 3 * k // 4
+
+    out = torch.empty(sum(seqlens_m), n, dtype=torch.bfloat16, device="cuda")
+    gemm_public(
+        A,
+        B.permute(2, 0, 1),
+        out,
+        None,
+        None,
+        tile_M=128,
+        tile_N=128,
+        cluster_M=1,
+        cluster_N=1,
+        cu_seqlens_m=cu_seqlens_m,
+        SFA=SFA,
+        SFB=SFB,
+        bs_format_a=fmt,
+        bs_format_b=fmt,
+    )
+    torch.cuda.synchronize()
+
+    cu = cu_seqlens_m.tolist()
+    ref = torch.cat([a_ref[cu[i] : cu[i + 1]] @ b_ref[i].T for i in range(num_experts)])
+    torch.testing.assert_close(out.float(), ref, atol=5e-3, rtol=1e-3)
 
 
 @pytest.mark.parametrize("rk_pad", [1, 3, 5])


### PR DESCRIPTION
Stacked on #169

- Add native SM100 mixed MXFP8/MXFP4/MXFP6 GEMMs using U4/U6 TMA unpack into byte-domain shared memory.
- Introduce packed MXFP6 formats, quantizers, logical/storage shape mapping, and bit-exact legacy conversion.
- Preserve existing FP6 APIs, pickles, and pytrees with versioned, JSON-safe serialization and migration.
- Strengthen tile, instruction/atom K shape, format, pointer, and stride validation across dispatch and cached launches.
- Extend mixed-format benchmarks, varlen-M support, documentation, and numerical regression coverage.

Every A/B pair drawn from `{mxfp8_e4m3, mxfp8_e5m2, mxfp4, mxfp6_e2m3_packed, mxfp6_e3m2_packed}` is now supported natively on SM100. Mixed pairs use tcgen05 `kind::mxf8f6f4`; homogeneous MXFP4 uses `kind::mxf4nvf4` path. NVFP4 remains restricted to NVFP4 x NVFP4.

Sub-byte operands in `mxf8f6f4` pairs stay packed in global memory and are expanded through the U4/U6 TMA unpack tensor maps (`CU_TENSOR_MAP_DATA_TYPE_16U4/16U6_ALIGN16B`). This includes FP6 x FP4, where both operands use the unpack path.

## Implementation

### TMA Unpack

- The TMA builder receives `internal_type=cutlass.Uint8` while the global-memory
  tensor retains, or is reinterpreted to, its true sub-byte element type.
  Recasting the source itself to `Uint8` would select a plain U8 tensor map and
  disable unpacking.
- Shared-memory layouts, `MemRange` storage, and stage budgeting use byte-domain
  `Uint8`, matching CUTLASS's `SmemAllocType = uint8_t` convention. Each group
  of 16 packed elements expands to a 16-byte shared-memory footprint.
- The `Uint8` shared-memory tensor feeds `make_fragment_A/B` directly. Its width
  and strides produce the correct MMA descriptor offsets; an FP4-domain layout
  would instead encode the packed `mxf4` convention.
- The mbarrier transaction count still uses packed source bytes, matching
  CUTLASS's `sizeof_bits<Element> * cosize(SmemLayout)` calculation.

Unpack operands must be K-major, have logical `K % 128 == 0`, and satisfy
32-byte base and non-unit stride alignment. These checks run during planning and
again at launch so cached plans cannot bypass pointer validation. Explicit tile-K
values must also contain complete scale-factor chunks.

### Packed FP6 and Compatibility

PyTorch has no packed FP6 dtype, so FP6 crosses TVM FFI as a raw `uint8` tensor
with shape `(..., 3K/4)`. The bytes contain a little-endian 6-bit stream matching
CUTLASS `SubbyteReference`; the kernel reinterprets this storage as the selected
FP6 element type. `a_mma_dtype` and `b_mma_dtype` carry that distinction through
both compilation paths.

The existing `mxfp6_e2m3` and `mxfp6_e3m2` names retain their byte-container
semantics for API and checkpoint compatibility. Kernel-ready storage uses the
explicit `*_packed` formats, and `BlockScaledOperand.to_packed()` converts legacy
operands without requantization. `mxfp4_byte` is likewise retained as a host-side
compatibility format but rejected by GEMM.

`BlockScaledFormat` keeps the positional `elems_per_container` field for
compatibility and adds versioned storage-layout metadata plus `storage_k()` and
`logical_k()` helpers for FP6's four-elements-per-three-bytes mapping. Legacy
pickles and pytrees remain loadable, while new pytree contexts are versioned and
JSON-safe.

### Unified FP4 Atom

Both MXFP4 and NVFP4 homogeneous pairs now construct `MmaMXF4NVF4Op`. This
models `kind::mxf4nvf4` as one atom parameterized by its scale configuration:

- MXFP4: E8M0 scales, vector size 32
- NVFP4: E4M3 scales, vector size 16

The wrapper removes the DSL class's hardcoded vector size. The backend continues
to derive the final PTX spelling from the scale configuration, so
`mma_kind_for_pair` no longer models MXFP4 as a separate atom.

## Testing

- Added a 10-pair mixed-format numerical matrix covering FP8, packed FP4, and
  both packed FP6 encodings.
- Added rejection tests for invalid K granularity, tile K, base alignment, and
  row stride, plus numerical tests for valid padded layouts.
- Added bit-exact FP6 packing, eager/compiled quantizer parity, dequantization,
  serialization migration, and byte-to-packed conversion tests.
- Extended varlen-M coverage to E5M2 and packed FP6 and revalidated MXFP4/NVFP4
  through the unified FP4 atom.
- Full suite: `pytest tests/ -n 8 --async-compile=32`. Remaining failures were
  limited to the pre-existing non-blockscaled BF16 `test_linear_varlen_m`
  multiprocessing flake, which reproduces on `main` and passes in isolation,
  plus environment-dependent async-compilation infrastructure tests.
