### PR TITLE
Migrate deprecated cutlass.utils spellings to canonical namespaces

### DIFF
--- a/AI/repro_clc_grant_monotonicity.py
+++ b/AI/repro_clc_grant_monotonicity.py
@@ -89,7 +89,7 @@ class ClcMonotonicityProbe:
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         if const_expr(self.smem_pad_kb > 0):  # residency limiter (GEMM-like footprint)
             smem.allocate_tensor(Int32, cute.make_layout(self.smem_pad_kb * 256), byte_alignment=16)
         # STAGES response slots + barriers (same static smem offsets in every
@@ -292,7 +292,7 @@ class ClcMonotonicityProbe:
         as the sprayer kernel => same static smem offsets."""
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         if const_expr(self.smem_pad_kb > 0):
             smem.allocate_tensor(Int32, cute.make_layout(self.smem_pad_kb * 256), byte_alignment=16)
         resp = smem.allocate_tensor(Int32, cute.make_layout((4, STAGES)), byte_alignment=16)

--- a/AI/repro_clc_spurious_invalid.py
+++ b/AI/repro_clc_spurious_invalid.py
@@ -95,7 +95,7 @@ class SpuriousInvalidProbe:
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         if const_expr(self.smem_pad_kb > 0):
             smem.allocate_tensor(Int32, cute.make_layout(self.smem_pad_kb * 256), byte_alignment=16)
         resp = smem.allocate_tensor(Int32, cute.make_layout(4), byte_alignment=16)

--- a/media/2025-07-10-membound-sol.md
+++ b/media/2025-07-10-membound-sol.md
@@ -117,7 +117,7 @@ The code snippet below is our load implementation in Python CuTe DSL. Here we om
 blkX = ...
 
 # allocate shared memory for the input vectors
-smem = cutlass.utils.SmemAllocator()
+smem = cutlass.memory.SmemAllocator()
 sX   = smem.allocate_tensor(gX.element_type, ...)
 
 # declare the copy atoms which will be used later for memory copy

--- a/microbenchmarks/gpu_pipe_microbench.py
+++ b/microbenchmarks/gpu_pipe_microbench.py
@@ -317,7 +317,7 @@ class PipeBench:
         f7 = Float32(tidx) + Float32(113.0)
 
         if const_expr(self.uses_smem):
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             s = smem.allocate_tensor(
                 Int32, cute.make_layout(self.smem_int32), byte_alignment=ALIGN_BYTES
             )

--- a/quack/complex.py
+++ b/quack/complex.py
@@ -231,7 +231,7 @@ def allocate_smem_complex(
 ):
     """Allocate a `Complex64` smem tensor.
 
-    Wraps `cutlass.utils.SmemAllocator.allocate_tensor(Complex64, ...)` and
+    Wraps `cutlass.memory.SmemAllocator.allocate_tensor(Complex64, ...)` and
     re-tags the result so `tensor.element_type is Complex64`. Without the
     re-tag, the JIT-side tensor's element_type is `Float64` (derived from the
     f64 memref) and writes go through `Complex64.to(Float64)` and corrupt the

--- a/quack/copy_utils.py
+++ b/quack/copy_utils.py
@@ -12,7 +12,8 @@ from cutlass.base_dsl.arch import Arch
 from cutlass.cute.nvgpu import cpasync, tcgen05, warp
 from cutlass.cute.nvgpu.tcgen05.mma import CtaGroup  # noqa
 from cutlass.cutlass_dsl import dsl_user_op
-from cutlass.utils import LayoutEnum, block_copy
+from cutlass.tensor_utils import LayoutEnum
+from cutlass.block import block_copy
 import cutlass.pipeline
 from cutlass._mlir import ir
 from cutlass._mlir.dialects import cute_nvgpu as _cute_nvgpu_ir
@@ -454,7 +455,7 @@ def partition_S_position_independent(thr_copy: cute.ThrCopy, tensor: cute.Tensor
 
 @dsl_user_op
 def sm90_get_smem_load_op(
-    layout_c: cutlass.utils.LayoutEnum,
+    layout_c: cutlass.tensor_utils.LayoutEnum,
     elem_ty_c: Type[cutlass.Numeric],
     *,
     loc=None,

--- a/quack/cross_entropy.py
+++ b/quack/cross_entropy.py
@@ -135,7 +135,7 @@ class CrossEntropy(ReductionBase):
         # slice for CTAs
         gX, cX = [cute.local_tile(mT, tiler_mn, (bidx, cluster_y)) for mT in (mX, idX)]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sX = smem.allocate_tensor(
             mX.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
         )
@@ -478,7 +478,7 @@ class CrossEntropyBackward:
         tidx, _, _ = cute.arch.thread_idx()
         bidx, bidy, _ = cute.arch.block_idx()
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sX = smem.allocate_tensor(
             mX.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
         )

--- a/quack/dsl/smem_struct.py
+++ b/quack/dsl/smem_struct.py
@@ -29,7 +29,7 @@ This is trace-time-only machinery (no monkey-patching of the DSL).
 from types import SimpleNamespace
 
 import cutlass.cute as cute
-from cutlass.utils import SmemPartition
+from cutlass.memory import SmemPartition
 
 
 class Reserved:

--- a/quack/epi_ops.py
+++ b/quack/epi_ops.py
@@ -598,7 +598,7 @@ class TileLoad(EpiOp):
 
     def to_params(self, gemm, args):
         tensor = getattr(args, self.name)
-        setattr(gemm, self._layout_gemm_attr(), cutlass.utils.LayoutEnum.from_tensor(tensor))
+        setattr(gemm, self._layout_gemm_attr(), cutlass.tensor_utils.LayoutEnum.from_tensor(tensor))
         setattr(gemm, self._dtype_gemm_attr(), tensor.element_type)
         epi_tile = self.epi_tile_fn(gemm, gemm.epi_tile) if self.epi_tile_fn else None
         tma_atom, tma_tensor, smem_layout, epi_tile_out = setup_epi_tensor(

--- a/quack/epi_utils.py
+++ b/quack/epi_utils.py
@@ -49,7 +49,7 @@ def setup_epi_tensor(gemm, tensor, epi_tile=None, op_type="store", stage=None):
     if stage is None:
         stage = gemm.epi_stage
     dtype = tensor.element_type
-    layout = cutlass.utils.LayoutEnum.from_tensor(tensor)
+    layout = cutlass.tensor_utils.LayoutEnum.from_tensor(tensor)
     utils_cls = sm100_utils if gemm.arch >= 100 else sm90_utils
     smem_layout_staged = utils_cls.make_smem_layout_epi(dtype, layout, epi_tile, stage)
     # Ragging-for-TMA is for varlen_m stores that need a per-batch row offset baked

--- a/quack/gemm_act.py
+++ b/quack/gemm_act.py
@@ -78,7 +78,7 @@ class GemmActMixin(ComposableEpiMixin):
     def epi_to_underlying_arguments(self, args: EpilogueArguments, *, loc=None, ip=None):
         self.rounding_mode = args.rounding_mode
         self.aux_out_dtype = args.mAuxOut.element_type
-        self.aux_out_layout = cutlass.utils.LayoutEnum.from_tensor(args.mAuxOut)
+        self.aux_out_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(args.mAuxOut)
         self.cta_tile_shape_aux_out_mn = self.cta_tile_shape_mnk[:2]
         d = self._epi_ops_to_params_dict(args)
         d["act_fn"] = args.act_fn
@@ -99,7 +99,7 @@ class GemmActMixin(ComposableEpiMixin):
         else:
             return copy_utils.get_smem_store_atom(
                 self.aux_out_dtype,
-                transpose=self.aux_out_layout != cutlass.utils.LayoutEnum.ROW_MAJOR,
+                transpose=self.aux_out_layout != cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
                 major_mode_size=cute.size(params.epi_tile_mAuxOut, mode=[1])
                 // self.atom_layout_mnk[1],
             )
@@ -231,14 +231,14 @@ class GemmGatedMixin(GemmActMixin):
             "GemmGated only supports 16bit postact for now"
         )
         assert self.d_layout is None or self.d_layout.is_n_major_c()
-        assert cutlass.utils.LayoutEnum.from_tensor(args.mAuxOut).is_n_major_c()
+        assert cutlass.tensor_utils.LayoutEnum.from_tensor(args.mAuxOut).is_n_major_c()
         if self.arch == 90:
             assert self.cta_tile_shape_mnk[1] % 32 == 0, (
                 "GemmGatedSm90 requires tileN to be divisible by 32"
             )
         self.rounding_mode = args.rounding_mode
         self.aux_out_dtype = args.mAuxOut.element_type
-        self.aux_out_layout = cutlass.utils.LayoutEnum.from_tensor(args.mAuxOut)
+        self.aux_out_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(args.mAuxOut)
         self.cta_tile_shape_aux_out_mn = (
             self.cta_tile_shape_mnk[0],
             self.cta_tile_shape_mnk[1] // 2,

--- a/quack/gemm_base.py
+++ b/quack/gemm_base.py
@@ -10,7 +10,7 @@ import cutlass.cute as cute
 import cutlass.pipeline as pipeline
 from cutlass import Boolean, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 import quack.copy_utils as copy_utils
 import quack.layout_utils as layout_utils

--- a/quack/gemm_dact.py
+++ b/quack/gemm_dact.py
@@ -116,7 +116,7 @@ class GemmDGatedMixin(GemmActMixin):
         assert self.c_dtype.width == 32, "C storage type must be 32 bit"
         self.rounding_mode = args.rounding_mode
         self.aux_out_dtype = args.mAuxOut.element_type
-        self.aux_out_layout = cutlass.utils.LayoutEnum.from_tensor(args.mAuxOut)
+        self.aux_out_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(args.mAuxOut)
         self.cta_tile_shape_aux_out_mn = self.cta_tile_shape_mnk[:2]
         d = self._epi_ops_to_params_dict(args)
         d["act_bwd_fn"] = args.act_bwd_fn

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -22,7 +22,7 @@ from cutlass.cute.nvgpu.warp import (
     StMatrix16x8x8bOp,
 )
 from cutlass import Int32, Float32, Boolean, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 from cutlass.cute.experimental import iket
 
 
@@ -443,7 +443,7 @@ class GemmSm100(GemmTmaBase):
             self.c_layout,
             epilogue_args,
             prefetch_A_idx,
-            cutlass.utils.get_smem_capacity_in_bytes(f"sm_{self.arch}"),  # smem_capacity
+            cutlass.memory.get_smem_capacity_in_bytes(f"sm_{self.arch}"),  # smem_capacity
             self.occupancy,
             self.epi_smem_warp_shape_mnk(),
         )
@@ -980,7 +980,7 @@ class GemmSm100(GemmTmaBase):
         tidx, _, _ = cute.arch.thread_idx()
 
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = self.shared_storage.allocate(smem)
 
         # Initialize pipelines and states
@@ -1007,7 +1007,7 @@ class GemmSm100(GemmTmaBase):
             num_threads=cute.arch.WARP_SIZE * len((self.mma_warp_id, *self.epilog_warp_id)),
         )
         # Tensor memory dealloc barrier init
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
             is_two_cta=use_2cta_instrs,
@@ -2537,7 +2537,7 @@ class GemmSm100(GemmTmaBase):
         """
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = cutlass.utils.get_num_tmem_alloc_cols(tCtAcc_fake)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(tCtAcc_fake)
         return num_tmem_alloc_cols
 
     @staticmethod

--- a/quack/gemm_sm120.py
+++ b/quack/gemm_sm120.py
@@ -17,7 +17,7 @@ import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass import Int32, Boolean, const_expr
-from cutlass.utils import SmemPartition
+from cutlass.memory import SmemPartition
 
 from quack.varlen_utils import VarlenManager
 from quack.pipeline import make_pipeline_state
@@ -101,7 +101,7 @@ class GemmSm120(GemmSm90):
         self.is_b_mcast = self.num_mcast_ctas_b > 1
 
         self.occupancy = 1
-        self.smem_capacity = cutlass.utils.get_smem_capacity_in_bytes(f"sm_{self.arch}")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(f"sm_{self.arch}")
 
         # In pingpong, only 1 warp group (4 warps) participates in epilogue at a time
         self.num_epi_warps = (self.mma_warp_groups if not self.pingpong else 1) * 4
@@ -200,7 +200,7 @@ class GemmSm120(GemmSm90):
                     cpasync.prefetch_descriptor(tma_atom)
 
         # Allocate shared memory
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         ab_pipeline = self.make_ab_pipeline(

--- a/quack/gemm_sm80.py
+++ b/quack/gemm_sm80.py
@@ -120,7 +120,7 @@ class GemmSm80(GemmBase):
         # but this CUTLASS helper build does not accept "sm_87".
         if arch == 87:
             arch = 80
-        return cutlass.utils.get_smem_capacity_in_bytes(f"sm_{arch}")
+        return cutlass.memory.get_smem_capacity_in_bytes(f"sm_{arch}")
 
     def _setup_tiled_mma(self):
         op = warp.MmaF16BF16Op(self.a_dtype, self.acc_dtype, self.mma_inst_mnk)

--- a/quack/gemm_sm90.py
+++ b/quack/gemm_sm90.py
@@ -17,7 +17,8 @@ from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, warp, warpgroup
 import cutlass.utils.hopper_helpers as sm90_utils
 from cutlass import Int32, Float32, Float16, Boolean, const_expr
-from cutlass.utils import LayoutEnum, SmemPartition
+from cutlass.memory import SmemPartition
+from cutlass.tensor_utils import LayoutEnum
 
 
 from quack import layout_utils
@@ -220,7 +221,7 @@ class GemmSm90(GemmTmaBase):
         assert self.mma_warp_groups in [1, 2, 3]
         self.num_threads_per_warp_group = 128
         self.threads_per_cta = (self.mma_warp_groups + 1) * self.num_threads_per_warp_group
-        self.smem_capacity = cutlass.utils.get_smem_capacity_in_bytes("sm_90")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_90")
         self.num_epi_warps = (self.mma_warp_groups if not self.pingpong else 1) * 4
         self.epilogue_barrier = pipeline.NamedBarrier(
             barrier_id=int(NamedBarrierGemm.Epilogue),
@@ -338,7 +339,7 @@ class GemmSm90(GemmTmaBase):
             self.d_dtype,
             self.c_dtype,
             epilogue_args,
-            cutlass.utils.get_smem_capacity_in_bytes(f"sm_{self.arch}"),  # smem_capacity
+            cutlass.memory.get_smem_capacity_in_bytes(f"sm_{self.arch}"),  # smem_capacity
             self.occupancy,
             self.epi_smem_warp_shape_mnk(),
         )
@@ -602,7 +603,7 @@ class GemmSm90(GemmTmaBase):
                     cpasync.prefetch_descriptor(tma_atom)
 
         # Alloc and init AB full/empty + ACC full mbar (pipeline)
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         ab_pipeline = self.make_ab_pipeline(

--- a/quack/gemm_sq_reduce.py
+++ b/quack/gemm_sq_reduce.py
@@ -86,7 +86,7 @@ class GemmSqReduceMixin(GemmActMixin):
         self.rounding_mode = args.rounding_mode
         if args.mAuxOut is not None:
             self.aux_out_dtype = args.mAuxOut.element_type
-            self.aux_out_layout = cutlass.utils.LayoutEnum.from_tensor(args.mAuxOut)
+            self.aux_out_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(args.mAuxOut)
             self.cta_tile_shape_aux_out_mn = self.cta_tile_shape_mnk[:2]
         d = self._epi_ops_to_params_dict(args)
         return self.EpilogueParams(**d)

--- a/quack/reduction_base.py
+++ b/quack/reduction_base.py
@@ -68,7 +68,7 @@ class ReductionBase:
         )
 
     def _allocate_reduction_buffer_and_mbar(
-        self, smem: cutlass.utils.SmemAllocator, tv_layout: cute.Layout
+        self, smem: cutlass.memory.SmemAllocator, tv_layout: cute.Layout
     ) -> Tuple[cute.Tensor, Optional[cute.Pointer]]:
         """Single-shot (non-persistent) reduction: full barriers only. Persistent
         kernels use quack.pipeline.PipelineStasAsync instead, which also manages

--- a/quack/rms_final_reduce.py
+++ b/quack/rms_final_reduce.py
@@ -78,7 +78,7 @@ class RmsFinalReduce(ReductionBase):
         bidx, _, _ = cute.arch.block_idx()
         tv_layout = tiled_copy.layout_tv_tiled
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(smem, tv_layout)
 
         shape = mX.shape

--- a/quack/rmsnorm.py
+++ b/quack/rmsnorm.py
@@ -168,7 +168,7 @@ class RMSNorm(ReductionBase):
         cluster_y = const_expr(0) if const_expr(self.cluster_n == 1) else cute.arch.block_idx()[1]
         tv_layout = tiled_copy.layout_tv_tiled
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sX = smem.allocate_tensor(
             mX.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
         )
@@ -767,7 +767,7 @@ class RMSNormBackward(ReductionBase):
 
         idX = cute.make_identity_tensor(shape)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         USE_TMA = const_expr(self.USE_TMA)
         n_smem_stages = const_expr(self.config.smem_stages)
         smem_layout = cute.make_ordered_layout(

--- a/quack/rmsnorm_config.py
+++ b/quack/rmsnorm_config.py
@@ -328,7 +328,7 @@ def _max_dynamic_smem_bytes() -> int:
 
     if os.environ.get("QUACK_ARCH") is None and not torch.cuda.is_available():
         return 0
-    from cutlass.utils import SmemAllocator
+    from cutlass.memory import SmemAllocator
 
     from quack.cute_dsl_utils import get_device_capacity
 

--- a/quack/rotary.py
+++ b/quack/rotary.py
@@ -148,7 +148,7 @@ class RotaryKernel:
         tiler_mnh = (tiler_mn[0], tiler_mn[1], self.tile_h)
         tiler_cossin = (tiler_mn[0], tiler_mn[1] // 2)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sX = None
         if const_expr(not self.interleaved):
             sX = smem.allocate_tensor(

--- a/quack/sm90_utils.py
+++ b/quack/sm90_utils.py
@@ -8,7 +8,7 @@ import cutlass.utils.hopper_helpers as sm90_utils_og
 from cutlass.cute.nvgpu import warpgroup
 from cutlass.cutlass_dsl import Numeric, dsl_user_op
 from cutlass import Float32, Int32, Boolean, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 
 @dsl_user_op

--- a/quack/softmax.py
+++ b/quack/softmax.py
@@ -104,7 +104,7 @@ class Softmax(ReductionBase):
         # slice for CTAs
         gX, gO, cX = [cute.local_tile(mT, tiler_mn, (bidx, cluster_y)) for mT in (mX, mO, idX)]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sX = smem.allocate_tensor(
             mX.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
         )
@@ -294,7 +294,7 @@ class SoftmaxBackward(ReductionBase):
             cute.local_tile(mT, tiler_mn, (bidx, cluster_y)) for mT in (mdY, mY, mdX, idX)
         ]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sdY = smem.allocate_tensor(
             mdY.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
         )

--- a/quack/spec/mma.py
+++ b/quack/spec/mma.py
@@ -10,7 +10,7 @@ from cutlass.cute.nvgpu import OperandMajorMode
 from cutlass.cutlass_dsl import Numeric
 import cutlass.utils.hopper_helpers as sm90_utils
 import cutlass.utils.blackwell_helpers as sm100_utils
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 
 @cute.jit

--- a/quack/spec/smem.py
+++ b/quack/spec/smem.py
@@ -9,7 +9,7 @@ from cutlass.cutlass_dsl import Numeric, dsl_user_op
 from cutlass import const_expr
 import cutlass.utils.hopper_helpers as sm90_utils
 import cutlass.utils.blackwell_helpers as sm100_utils
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 from quack.spec import mma as spec_mma
 

--- a/quack/spec/tensor_spec.py
+++ b/quack/spec/tensor_spec.py
@@ -44,7 +44,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 import cutlass.utils.blackwell_helpers as sm100_utils
 
 

--- a/quack/tensormap_manager.py
+++ b/quack/tensormap_manager.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass
 import cutlass
 import cutlass.cute as cute
 from cutlass.cutlass_dsl import Boolean, const_expr, Int32
-from cutlass.utils import TensorMapUpdateMode, TensorMapManager
+from cutlass.tensor_utils import TensorMapUpdateMode, TensorMapManager
 
 
 @dataclass(frozen=True)
 class TensorMapManagerSm90(TensorMapManager):
     """
-    We have to subclass cutlass.utils.TensorMapManager bc it takes in warp_id and only
+    We have to subclass cutlass.tensor_utils.TensorMapManager bc it takes in warp_id and only
     perform the operation if warp_id matches the current warp.
     But for Hopper pingpong gemm we want to call it with warp_id 0 and 4.
     So we take in a boolean `is_manager_warp` to determine whether to perform the operation or not.

--- a/quack/topk.py
+++ b/quack/topk.py
@@ -361,7 +361,7 @@ class TopKBackward(ReductionBase):
         ]
 
         # Allocate smem for output gradients
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sdX = smem.allocate_tensor(
             mdX.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
         )

--- a/quack/transform/hadamard.py
+++ b/quack/transform/hadamard.py
@@ -689,7 +689,7 @@ class HadamardTransform:
         row_in_cta = 0 if const_expr(plan.rows_per_block == 1) else cute.arch.thread_idx()[1]
         block_row, _, _ = cute.arch.block_idx()
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         shape = mX.shape
         # Each CTA, per iteration, processes a (rows_per_block, N_padded) tile starting at

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -124,7 +124,7 @@ class _SmemRoundTrip:
         for i in cutlass.range_constexpr(_SMEM_ELEMS_PER_THREAD):
             rmem[i] = mX[bidx, tidx * const_expr(_SMEM_ELEMS_PER_THREAD) + const_expr(i)]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         exchange = allocate_smem_complex(smem, cute.make_layout(_SMEM_BLOCK_ELEMS))
 
         for i in cutlass.range_constexpr(_SMEM_ELEMS_PER_THREAD):


### PR DESCRIPTION
Memory allocators and capacity queries:

- cutlass.utils.SmemAllocator -> cutlass.memory.SmemAllocator
- cutlass.utils.SmemPartition -> cutlass.memory.SmemPartition
- cutlass.utils.TmemAllocator -> cutlass.memory.TmemAllocator
- cutlass.utils.TmemBufferPool -> cutlass.memory.TmemBufferPool
- cutlass.utils.VirtualMemoryManager -> cutlass.memory.VirtualMemoryManager
- cutlass.utils.get_smem_capacity_in_bytes -> cutlass.memory.get_smem_capacity_in_bytes
- cutlass.utils.get_kernel_smem_size -> cutlass.memory.get_kernel_smem_size
- cutlass.utils.get_num_tmem_alloc_cols -> cutlass.memory.get_num_tmem_alloc_cols
- cutlass.utils.compute_tmem_cols_from_layout -> cutlass.memory.compute_tmem_cols_from_layout

Tensor description utilities:

- cutlass.utils.LayoutEnum -> cutlass.tensor_utils.LayoutEnum
- cutlass.utils.TensorMapManager -> cutlass.tensor_utils.TensorMapManager
- cutlass.utils.TensorMapUpdateMode -> cutlass.tensor_utils.TensorMapUpdateMode

Block copy:

- cutlass.utils.block_copy -> cutlass.block.block_copy

Layout visualization:

- cutlass.utils.print_latex -> cutlass.cute.viz.print_latex
- cutlass.utils.print_latex_tv -> cutlass.cute.viz.print_latex_tv
- cutlass.utils.PALETTES / Band / tikz_* -> cutlass.cute.viz.*