### PR TITLE
[Epi] Expose pre-activation alpha through `gemm_act`

### DIFF
--- a/quack/epilogues.py
+++ b/quack/epilogues.py
@@ -412,12 +412,16 @@ _SR_OPS = (Scalar("sr_seed", dtype=Int32),)
 
 
 @functools.lru_cache(maxsize=None)
-def linear_act_mod(activation, *, gated, has_c, has_rowvec, has_colvec, sr=False):
-    """gemm_act/gemm_gated as a mod: D = acc (+ C + rowvec + colvec), aux =
-    act(D). Math order matches apply_linear_epilogue: C, rowvec, colvec."""
+def linear_act_mod(activation, *, gated, has_c, has_rowvec, has_colvec, sr=False, has_alpha=False):
+    """gemm_act/gemm_gated as a mod: D = alpha * acc (+ C + rowvec + colvec),
+    aux = act(D). Math order matches apply_linear_epilogue: alpha scales the
+    accumulator only (before C / rowvec / colvec), so ``act(alpha * A @ B)``
+    is a pre-activation scale."""
     fn_map = gate_fn_map if gated else act_fn_map
     act = fn_map[activation]
     params, body = [], []
+    if has_alpha:
+        params.append("alpha")
     if has_c:
         params.append("c")
     if has_rowvec:
@@ -425,8 +429,11 @@ def linear_act_mod(activation, *, gated, has_c, has_rowvec, has_colvec, sr=False
     if has_colvec:
         params.append("mColVecBroadcast")
     expr = "acc"
+    if has_alpha:
+        body.append("x = acc * alpha")
+        expr = "x"
     if has_c:
-        body.append("x = acc + c")
+        body.append(f"x = {expr} + c")
         expr = "x"
     if has_rowvec:
         body.append(f"x = {expr} + mRowVecBroadcast")
@@ -441,11 +448,17 @@ def linear_act_mod(activation, *, gated, has_c, has_rowvec, has_colvec, sr=False
         body.append(f'return {{"D": {expr}, "mAuxOut": act({expr})}}')
     else:
         body.append(f'return {{"D": {expr}, "mAuxOut": {expr}}}')
-    tag = f"act:{activation}:g{int(gated)}c{int(has_c)}r{int(has_rowvec)}v{int(has_colvec)}"
+    tag = (
+        f"act:{activation}:g{int(gated)}c{int(has_c)}r{int(has_rowvec)}"
+        f"v{int(has_colvec)}a{int(has_alpha)}"
+    )
     fn = _gen_epi_fn("linear_act_epi", tag, params, body, {"act": act})
+    ops = _vec_pins(params)
+    if has_alpha:
+        ops["alpha"] = Scalar("alpha")
     return gemm_epilogue(
         outputs=("mAuxOut",),
-        ops=_vec_pins(params),
+        ops=ops,
         mode="acc_pair" if gated else None,
         extra_ops=_SR_OPS if sr else (),
     )(fn)

--- a/quack/gemm_act.py
+++ b/quack/gemm_act.py
@@ -9,6 +9,7 @@ from torch import Tensor
 
 from quack.activation import act_fn_map, gate_fn_map
 from quack.gemm_host import GemmEpiPlan, run_gemm_epi_plan
+from quack.gemm_tvm_ffi_utils import scalar_mode
 from quack.rounding import RoundingMode
 
 
@@ -31,6 +32,7 @@ def gemm_act(
     max_swizzle_size: int = 8,
     rowvec_bias: Optional[Tensor] = None,  # (l, n)
     colvec_bias: Optional[Tensor] = None,  # (l, m), or (total_m,) if varlen_m
+    alpha: float | Tensor | None = None,  # pre-activation accumulator scale
     cu_seqlens_m: Optional[Tensor] = None,  # (l+1,) cumulative sum of m values for variable length
     A_idx: Optional[Tensor] = None,  # (total_m,) if gather_A with varlen_m
     rounding_mode: int = RoundingMode.RN,
@@ -42,7 +44,10 @@ def gemm_act(
     b_kn: bool = False,  # B passed (k, n) / (l, k, n), transposed at trace time (dense SM90+)
 ) -> GemmEpiPlan:
     """GEMM + activation (optionally gated), on the epilogue-mod path
-    (quack.epilogues.linear_act_mod)."""
+    (quack.epilogues.linear_act_mod). ``alpha`` scales the accumulator BEFORE
+    the activation (``aux = act(alpha * A @ B + ...)``) -- an output alpha
+    cannot produce that through the nonlinearity. Neutral values (None or
+    1.0) keep the alpha-free epilogue."""
     from quack.epilogues import linear_act_mod
 
     gated = activation in gate_fn_map
@@ -52,6 +57,8 @@ def gemm_act(
         2 if isinstance(sr_seed, Tensor) else (1 if rounding_mode == RoundingMode.RS else 0)
     )
     sr = sr_seed_mode != 0
+    if alpha is not None and scalar_mode(alpha) == 0:
+        alpha = None  # neutral 1.0: keep the alpha-free epilogue
     mod = linear_act_mod(
         activation,
         gated=gated,
@@ -59,12 +66,15 @@ def gemm_act(
         has_rowvec=rowvec_bias is not None,
         has_colvec=colvec_bias is not None,
         sr=sr,
+        has_alpha=alpha is not None,
     )
     epi_args = dict(mAuxOut=PostAct)
     if rowvec_bias is not None:
         epi_args["mRowVecBroadcast"] = rowvec_bias
     if colvec_bias is not None:
         epi_args["mColVecBroadcast"] = colvec_bias
+    if alpha is not None:
+        epi_args["alpha"] = alpha
     if sr:
         epi_args["sr_seed"] = sr_seed
     return mod.gemm(
@@ -106,6 +116,7 @@ def run_gemm_act_plan(
     tile_count_semaphore: Optional[Tensor] = None,
     rowvec_bias: Optional[Tensor] = None,
     colvec_bias: Optional[Tensor] = None,
+    alpha: float | Tensor | None = None,
     sr_seed: int | Tensor = 0,
     cu_seqlens_m: Optional[Tensor] = None,
     A_idx: Optional[Tensor] = None,
@@ -128,6 +139,7 @@ def run_gemm_act_plan(
             mAuxOut=PostAct,
             mRowVecBroadcast=rowvec_bias,
             mColVecBroadcast=colvec_bias,
+            alpha=alpha if alpha is None or scalar_mode(alpha) != 0 else None,
             sr_seed=sr_seed,
         ),
         tile_count_semaphore=tile_count_semaphore,

--- a/quack/gemm_interface.py
+++ b/quack/gemm_interface.py
@@ -618,6 +618,7 @@ def _gemm_act_call(
     SFB: Optional[Tensor] = None,
     concat_layout: tuple | None = None,
     dynamic_scheduler: bool,
+    alpha: float | Tensor = 1.0,
     tuned: bool,
     config: Optional[GemmConfig] = None,
 ) -> None:
@@ -629,6 +630,7 @@ def _gemm_act_call(
         # structurally excluded on the concat path (it vetoes b_kn).
         bias, concat_layout = _act_concat_bias(bias, concat_layout, False)
         concat_layout = tuple(sorted(concat_layout)) if concat_layout else None
+    has_alpha = scalar_mode(alpha) != 0
     mod = linear_act_mod(
         activation,
         gated=activation in gated_to_pytorch_fn_map,
@@ -636,6 +638,7 @@ def _gemm_act_call(
         has_rowvec=bias is not None,
         has_colvec=False,
         sr=False,
+        has_alpha=has_alpha,
     )
     outs = {"mAuxOut": postact_out}
     store_d = preact_out is not None
@@ -644,6 +647,8 @@ def _gemm_act_call(
     operands = {}
     if bias is not None:
         operands["mRowVecBroadcast"] = bias
+    if has_alpha:
+        operands["alpha"] = alpha
     mod(
         A,
         B,
@@ -1498,6 +1503,7 @@ def gemm_act(
     C: Optional[Tensor] = None,  # (M, N) or (L, M, N) or (total_M, N) if varlen_m
     bias: Optional[Tensor] = None,  # (N,) or (L, N)
     activation: Activation = None,
+    alpha: float | Tensor = 1.0,  # pre-activation accumulator scale
     preact_out: Optional[Tensor] = None,  # (M, N) or (L, M, N) or (total_M, N) if varlen_m
     postact_out: Optional[Tensor] = None,  # (M, N) or (L, M, N) or (total_M, N) if varlen_m
     out_dtype: Optional[torch.dtype] = None,
@@ -1512,7 +1518,12 @@ def gemm_act(
     split_k: Optional[int] = 1,
     split_k_mode: int = SplitKMode.SERIAL,
 ) -> Tuple[Optional[Tensor], Tensor]:
-    """GEMM with activation (or gated activation) and optional output tensors."""
+    """GEMM with activation (or gated activation) and optional output tensors.
+
+    ``alpha`` scales the accumulator before the activation
+    (``postact = act(alpha * A @ B + C + bias)``). It is applied in fp32 and
+    may be a float or a 1-element CUDA tensor; 1.0 keeps the alpha-free epilogue.
+    """
     _check_split_k_unsupported("gemm_act", split_k)
     A, SFA = _unpack_operand(A)
     B, SFB = _unpack_operand(B)
@@ -1569,6 +1580,8 @@ def gemm_act(
             tuned,
             SFA=SFA,
             SFB=SFB,
+            alpha=alpha if isinstance(alpha, float) else 1.0,
+            alpha_tensor=alpha if not isinstance(alpha, float) else None,
             **kwargs,
         )
         return preact_out, postact_out
@@ -1586,6 +1599,7 @@ def gemm_act(
         SFB=SFB,
         concat_layout=concat_layout if is_gated else None,
         dynamic_scheduler=dynamic_scheduler,
+        alpha=alpha,
         tuned=tuned,
         config=config,
     )
@@ -1599,7 +1613,7 @@ gemm_gated = gemm_act
     "quack::gemm_act_out",
     mutates_args=("preact_out", "postact_out"),
     device_types="cuda",
-    schema="(Tensor A, Tensor B, Tensor(a2!)? preact_out, Tensor(a3!) postact_out, Tensor? C=None, Tensor? bias=None, str? activation=None, Tensor? cu_seqlens_m=None, Tensor? A_idx=None, bool dynamic_scheduler=False, bool tuned=True, Tensor? SFA=None, Tensor? SFB=None) -> ()",
+    schema="(Tensor A, Tensor B, Tensor(a2!)? preact_out, Tensor(a3!) postact_out, Tensor? C=None, Tensor? bias=None, str? activation=None, Tensor? cu_seqlens_m=None, Tensor? A_idx=None, bool dynamic_scheduler=False, bool tuned=True, Tensor? SFA=None, Tensor? SFB=None, float alpha=1.0, Tensor? alpha_tensor=None) -> ()",
 )
 def gemm_act_out(
     A: Tensor,  # (M, K) or (L, M, K) or (total_M, K) if varlen_m or (whatever, K) if gather_A with varlen_m
@@ -1615,6 +1629,8 @@ def gemm_act_out(
     tuned: bool = True,
     SFA: Optional[Tensor] = None,  # blocked scale factors, (L, rm, rk, 32, 4, 4) (see gemm_out)
     SFB: Optional[Tensor] = None,
+    alpha: float = 1.0,
+    alpha_tensor: Optional[Tensor] = None,
 ) -> None:
     """GEMM with activation and pre-allocated output tensors."""
     _gemm_act_call(
@@ -1630,6 +1646,7 @@ def gemm_act_out(
         SFA=_sf_decode(SFA),
         SFB=_sf_decode(SFB),
         dynamic_scheduler=dynamic_scheduler,
+        alpha=_merge_tensor(alpha, alpha_tensor),
         tuned=tuned,
     )
 
@@ -1640,6 +1657,7 @@ def gemm_act_ref(
     C: Optional[Tensor] = None,  # (M, N) or (L, M, N) or (total_M, N) if varlen_m
     bias: Optional[Tensor] = None,  # (N,) or (L, N)
     activation: Activation = None,
+    alpha: float | Tensor = 1.0,  # pre-activation accumulator scale
     cu_seqlens_m: Optional[Tensor] = None,
     A_idx: Optional[Tensor] = None,  # (total_M,) if gather_A with varlen_m
     out_dtype: Optional[torch.dtype] = None,
@@ -1652,11 +1670,24 @@ def gemm_act_ref(
     postact_dtype = A.dtype if postact_dtype is None else postact_dtype
     if C is None:
         preact = gemm_ref(
-            A, B, bias=bias, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx, concat_layout=concat_layout
+            A,
+            B,
+            bias=bias,
+            alpha=alpha,
+            cu_seqlens_m=cu_seqlens_m,
+            A_idx=A_idx,
+            concat_layout=concat_layout,
         )
     else:
         preact = gemm_add_ref(
-            A, B, C, bias=bias, cu_seqlens_m=cu_seqlens_m, A_idx=A_idx, concat_layout=concat_layout
+            A,
+            B,
+            C,
+            bias=bias,
+            alpha=alpha,
+            cu_seqlens_m=cu_seqlens_m,
+            A_idx=A_idx,
+            concat_layout=concat_layout,
         )
     if is_gated:
         # With concat=("B",), gemm_ref already interleaves the output columns,
@@ -2054,7 +2085,7 @@ def gemm_symmetric(
     "quack::gemm_gated_out",
     mutates_args=("preact_out", "postact_out"),
     device_types="cuda",
-    schema="(Tensor A, Tensor B, Tensor(a2!)? preact_out, Tensor(a3!) postact_out, Tensor? C=None, Tensor? bias=None, str activation='swiglu', Tensor? cu_seqlens_m=None, Tensor? A_idx=None, bool dynamic_scheduler=False, bool tuned=True, str? concat_layout=None, Tensor? SFA=None, Tensor? SFB=None) -> ()",
+    schema="(Tensor A, Tensor B, Tensor(a2!)? preact_out, Tensor(a3!) postact_out, Tensor? C=None, Tensor? bias=None, str activation='swiglu', Tensor? cu_seqlens_m=None, Tensor? A_idx=None, bool dynamic_scheduler=False, bool tuned=True, str? concat_layout=None, Tensor? SFA=None, Tensor? SFB=None, float alpha=1.0, Tensor? alpha_tensor=None) -> ()",
 )
 def gemm_gated_out(
     A: Tensor,  # (M, K) or (L, M, K) or (total_M, K) if varlen_m or (whatever, K) if gather_A with varlen_m
@@ -2071,6 +2102,8 @@ def gemm_gated_out(
     concat_layout: Optional[str] = None,
     SFA: Optional[Tensor] = None,  # blocked scale factors, (L, rm, rk, 32, 4, 4) (see gemm_out)
     SFB: Optional[Tensor] = None,
+    alpha: float = 1.0,
+    alpha_tensor: Optional[Tensor] = None,
 ) -> None:
     """GEMM with gated activation and pre-allocated output tensors."""
     _gemm_act_call(
@@ -2087,6 +2120,7 @@ def gemm_gated_out(
         SFB=_sf_decode(SFB),
         concat_layout=_parse_concat_layout(concat_layout),
         dynamic_scheduler=dynamic_scheduler,
+        alpha=_merge_tensor(alpha, alpha_tensor),
         tuned=tuned,
     )
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -191,6 +191,58 @@ def test_linear_act(in_features, out_features, has_bias, input_dtype, activation
         assert (preact - preact_ref).abs().max() < 2 * (preact_pt - preact_ref).abs().max() + 1e-6
 
 
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("alpha_kind", ["float", "tensor"])
+@pytest.mark.parametrize("activation", ["tanh", "relu"])
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16])
+def test_gemm_act_alpha(input_dtype, activation, alpha_kind, has_bias):
+    """Pre-activation alpha: postact = act(alpha * A @ B + bias). The scale
+    is applied to the fp32 accumulator BEFORE the activation (and before
+    bias), which no output alpha can reproduce through the nonlinearity --
+    so parity against the alpha-carrying reference pins the application
+    point, not just the value."""
+    device = "cuda"
+    torch.random.manual_seed(0)
+    m, k, n = 512, 1024, 1504
+    A = torch.randn((m, k), device=device, dtype=input_dtype)
+    B = (torch.randn((n, k), device=device, dtype=input_dtype) / math.sqrt(k)).T
+    bias = torch.randn(n, device=device) if has_bias else None
+    alpha_val = 0.7371
+    alpha = (
+        alpha_val
+        if alpha_kind == "float"
+        else torch.tensor(alpha_val, device=device, dtype=torch.float32)
+    )
+    preact, postact = gemm_act(A, B, bias=bias, activation=activation, alpha=alpha, tuned=False)
+    preact_ref, postact_ref = gemm_act_ref(
+        A.float(), B.float(), bias=bias, activation=activation, alpha=alpha_val
+    )
+    preact_pt, postact_pt = gemm_act_ref(A, B, bias=bias, activation=activation, alpha=alpha_val)
+    assert (postact - postact_ref).abs().max() < 2 * (postact_pt - postact_ref).abs().max() + 1e-6
+    assert (preact - preact_ref).abs().max() < 2 * (preact_pt - preact_ref).abs().max() + 1e-6
+    # Warm-plan replay with a DIFFERENT alpha of the same mode: the scalar is
+    # a runtime argument (mode is what's compiled/keyed), so the cached
+    # interface plan must pick up the new value.
+    alpha2_val = 0.25
+    alpha2 = (
+        alpha2_val
+        if alpha_kind == "float"
+        else torch.tensor(alpha2_val, device=device, dtype=torch.float32)
+    )
+    _, postact2 = gemm_act(A, B, bias=bias, activation=activation, alpha=alpha2, tuned=False)
+    _, postact2_ref = gemm_act_ref(
+        A.float(), B.float(), bias=bias, activation=activation, alpha=alpha2_val
+    )
+    _, postact2_pt = gemm_act_ref(A, B, bias=bias, activation=activation, alpha=alpha2_val)
+    assert (postact2 - postact2_ref).abs().max() < 2 * (
+        postact2_pt - postact2_ref
+    ).abs().max() + 1e-6
+    # alpha=1.0 folds to the alpha-free epilogue: bitwise vs the no-alpha call.
+    _, postact_neutral = gemm_act(A, B, bias=bias, activation=activation, alpha=1.0, tuned=False)
+    _, postact_plain = gemm_act(A, B, bias=bias, activation=activation, tuned=False)
+    assert torch.equal(postact_neutral, postact_plain)
+
+
 @pytest.mark.parametrize("activation", ["relu", "relu_sq", "gelu_tanh_approx", "tanh"])
 @pytest.mark.parametrize("input_dtype", [torch.bfloat16])
 @pytest.mark.parametrize("k", [736, 1024])


### PR DESCRIPTION
The default-epi GEMM already plumbs alpha end-to-end, but the act/gated path never exposed it: linear_act_mod builds its own epilogue fn without the Scalar("alpha") op, so callers needing `act(alpha * A @ B)` had to materialize a pre-scaled copy of A.

- `epilogues.linear_act_mod` has_alpha: pins Scalar("alpha") and prefixes the generated body with `x = acc * alpha`, so the scale applies to the accumulator BEFORE C / rowvec / colvec / activation (same math order as the default epilogue).
- `gemm_act` / `run_gemm_act_plan` take `alpha (float | Tensor);` the neutral 1.0 folds to the alpha-free epilogue.
- `gemm_interface`: `gemm_act_tuned` / `gemm_gated_tuned` / `_gemm_act_execute` pass it through; the public `gemm_act` keys the eager plan on `scalar_mode(alpha)`. gemm_act_out / gemm_gated_out grows the `alpha`/`alpha_tensor` schema split used by `gemm_out`; `gemm_act_ref` forwards alpha to `gemm_ref`/`gemm_add_ref`.

Tested on GB200 (SM100): new `test_gemm_act_alpha` covers float and tensor alpha x {tanh, relu} x bias on/off against the alpha-carrying reference.