### PR TITLE
Bump CuTe-DSL to 4.6.1

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,8 +16,8 @@ on:
 
 env:
   # Bump these when pushing a new image; old SIFs are auto-pruned on the next CI run.
-  IMAGE_CU129: tridao/quack-kernels:cu12.9-26.07.09
-  IMAGE_CU132: tridao/quack-kernels:cu13.2-26.07.09
+  IMAGE_CU129: tridao/quack-kernels:cu12.9-26.07.16
+  IMAGE_CU132: tridao/quack-kernels:cu13.2-26.07.16
 
 jobs:
   lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quack-kernels"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0",
+    "nvidia-cutlass-dsl==4.6.1",
     "torch",
     "apache-tvm-ffi>=0.1.6,<0.2",
     "torch-c-dlpack-ext",
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.1"]
 heuristics = ["nvidia-matmul-heuristics"]
 jax = ["jax", "jax-tvm-ffi"]
 bench = ["pandas", "tyro"]

--- a/quack/fast_math.py
+++ b/quack/fast_math.py
@@ -27,7 +27,16 @@ class FastDivmod:
     exact for all dividends < 2^31, i.e. any non-negative Int32. Same contract and
     algorithm as C++ cutlass::FastDivmod. Negative dividends are OUT of contract
     (they reinterpret through Uint32 to values >= 2^31 and silently divide wrong);
-    use cute.FastDivmodDivisor if signed or full-u32 dividends are ever needed.
+    use cute.FastDivmodDivisorV2 if signed or full-u32 dividends are ever needed.
+
+    Why we keep this instead of cute.FastDivmodDivisorV2 (DSL >= 4.6.1): V2 must be
+    exact for the full u32 dividend range, so it lowers to the two-shift add-back
+    form q = (hi + ((n - hi) >> s1)) >> s2 -- measured on sm_90a with DSL 4.6.1 that
+    is 7 SASS ops per divmod with a 5-op dependency chain to the quotient
+    (IMAD.HI -> IADD3 -> SHF -> IADD3 -> SHF). Ours is 6 ops with a 3-op chain
+    (IMAD.HI -> SHF -> SEL; the ISETP feeding the SEL is off the critical path and
+    amortizes per divisor). Tile schedulers chain divmods back-to-back on the
+    next-work-tile latency path, so we keep the < 2^31 contract and the shorter form.
     """
 
     def __init__(self, divisor: Integer):

--- a/tools/dev/docker/Dockerfile
+++ b/tools/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 #   docker build -f tools/dev/docker/Dockerfile -t kernel-dev:cu133 .
 #
 # Useful build args:
-#   --build-arg CUTLASS_DSL_VERSION=4.6.0
+#   --build-arg CUTLASS_DSL_VERSION=4.6.1
 #   --build-arg TILELANG_VERSION=0.1.12
 #   --build-arg CUDA_APT_SUFFIX=13-3
 #   --build-arg CUDNN_VERSION=9.24.0.43
@@ -49,7 +49,7 @@ ARG MATMUL_HEURISTICS_VERSION=0.1.0.27
 ARG NSIGHT_PYTHON_VERSION=1.0.0
 ARG COMPILEIQ_VERSION=1.0.2
 ARG UV_VERSION=0.11.22
-ARG CUTLASS_DSL_VERSION=4.6.0
+ARG CUTLASS_DSL_VERSION=4.6.1
 ARG TILELANG_VERSION=0.1.12
 ARG GH_VERSION=2.95.0
 


### PR DESCRIPTION
### Summary
Bump nvidia-cutlass-dsl to 4.6.1.

### Changelog
[4.6.1](https://github.com/NVIDIA/cutlass/releases/tag/v4.6.1) (2026-07-13)
- Bug fixing and improvements
  - Fixed following issues:
    - https://github.com/NVIDIA/cutlass/issues/3243
    - https://github.com/NVIDIA/cutlass/issues/3359
    - https://github.com/NVIDIA/cutlass/issues/3365
    - https://github.com/NVIDIA/cutlass/issues/3312
  - Fixed a compilation failure on Thor with 12.9 wheel
  - Fixed a per regression of flash attention v2 on Ampere
  - Allow custom and multiple FFI call registration for Jax

### Maintainer edit
Reduced scope to the version bump only — we're keeping `quack.fast_math.FastDivmod` (see comment below for the SASS comparison), and dropped the ruff reformat commit (main already passes the repo-pinned ruff 0.11.13; the diff came from a newer local ruff).