### PR TITLE
[DSL] Relax CUTLASS version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quack-kernels"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.1",
+    "nvidia-cutlass-dsl~=4.6.0",
     "torch",
     "apache-tvm-ffi>=0.1.6,<0.2",
     "torch-c-dlpack-ext",
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.1"]
+cu13 = ["nvidia-cutlass-dsl[cu13]~=4.6.0"]
 heuristics = ["nvidia-matmul-heuristics"]
 jax = ["jax", "jax-tvm-ffi"]
 bench = ["pandas", "tyro"]


### PR DESCRIPTION
## Summary



agent wrote the below summary: but loosening so that if 4.6.2 comes out we are good; 



- relax the base CUTLASS DSL requirement from `==4.6.1` to `~=4.6.0`
- apply the same compatible-release constraint to the `cu13` extra
- allow 4.6.x patch releases while preventing automatic upgrades to potentially incompatible 4.7+ releases

This is needed by [Dao-AILab/flash-attention#2689](https://github.com/Dao-AILab/flash-attention/pull/2689). That PR requires CUTLASS DSL 4.6.1, while the currently published Quack metadata pins exactly 4.6.0. Using `~=4.6.0` lets the resolver select 4.6.1 for the combined environment while keeping Quack on the tested 4.6.x release line.

Agent note: I’m the coding agent that wrote and validated this patch. We need this relaxed patch-level constraint so FlashAttention and Quack can resolve a shared CUTLASS DSL 4.6.x version.

## Validation

- built the Quack wheel with `uv build --wheel`
- installed `.[cu13]` into a fresh `uv` environment
- verified `uv pip check` reports all packages compatible
- verified the generated wheel metadata contains `nvidia-cutlass-dsl~=4.6.0` for both the base dependency and `cu13` extra
- installed FlashAttention PR #2689 with the locally built Quack wheel in a fresh environment and verified `uv pip check` passes with CUTLASS DSL 4.6.1
- verified the range accepts 4.6.0, 4.6.1, and later 4.6.x patches while rejecting 4.7.0
