### PR TITLE
[PoC] Add optional FlyDSL RMSNorm backend for ROCm

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Install ruff
         run: pip install ruff
       - name: Ruff check
-        run: ruff check quack/ tests/
+        run: ruff check quack/ tests/ benchmarks/benchmark_rmsnorm_flydsl.py
       - name: Ruff format
-        run: ruff format --check quack/ tests/
+        run: ruff format --check quack/ tests/ benchmarks/benchmark_rmsnorm_flydsl.py
 
   changes:
     runs-on: ubuntu-24.04
@@ -50,6 +50,7 @@ jobs:
             code:
               - 'quack/**'
               - 'tests/**'
+              - 'benchmarks/benchmark_rmsnorm_flydsl.py'
               - '.github/**'
               - 'pyproject.toml'
 

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -1,0 +1,118 @@
+name: ROCm FlyDSL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "quack/**"
+      - "tests/test_benchmark_rmsnorm_flydsl.py"
+      - "tests/test_rmsnorm_dispatch.py"
+      - "tests/test_rmsnorm_flydsl.py"
+      - "tests/test_rocm_workflow.py"
+      - "benchmarks/benchmark_rmsnorm_flydsl.py"
+      - "pyproject.toml"
+      - ".github/workflows/rocm.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "quack/**"
+      - "tests/test_benchmark_rmsnorm_flydsl.py"
+      - "tests/test_rmsnorm_dispatch.py"
+      - "tests/test_rmsnorm_flydsl.py"
+      - "tests/test_rocm_workflow.py"
+      - "benchmarks/benchmark_rmsnorm_flydsl.py"
+      - "pyproject.toml"
+      - ".github/workflows/rocm.yml"
+  pull_request_target:
+    branches: [main]
+    paths:
+      - "quack/**"
+      - "tests/test_benchmark_rmsnorm_flydsl.py"
+      - "tests/test_rmsnorm_dispatch.py"
+      - "tests/test_rmsnorm_flydsl.py"
+      - "tests/test_rocm_workflow.py"
+      - "benchmarks/benchmark_rmsnorm_flydsl.py"
+      - "pyproject.toml"
+      - ".github/workflows/rocm.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rocm-flydsl-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  ROCM_PYTORCH_IMAGE: rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
+  EXPECTED_TORCH_VERSION: "2.9.1"
+  EXPECTED_ROCM_VERSION: "7.2"
+  FLYDSL_VERSION: "0.2.3"
+  PYTEST_VERSION: "8.4.2"
+
+jobs:
+  rmsnorm:
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
+    name: rmsnorm (${{ matrix.arch }})
+    environment: gpu-ci
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: linux-flydsl-mi325-1, arch: gfx942 }
+          - { runner: linux-flydsl-mi355-1, arch: gfx950 }
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Run isolated ROCm tests
+        env:
+          EXPECTED_GFX: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          DEVICE_ARGS=(--device /dev/kfd)
+          if [ -f /etc/podinfo/gha-render-devices ]; then
+            read -r -a RENDER_ARGS <<< "$(cat /etc/podinfo/gha-render-devices)"
+            DEVICE_ARGS+=("${RENDER_ARGS[@]}")
+          else
+            DEVICE_ARGS+=(--device /dev/dri)
+          fi
+          docker run --rm --network=host "${DEVICE_ARGS[@]}" \
+            --group-add video --ipc=host --shm-size=8g \
+            --security-opt seccomp=unconfined \
+            -e HIP_VISIBLE_DEVICES=0 \
+            -e QUACK_EXPECTED_GFX="${EXPECTED_GFX}" \
+            -e FLYDSL_GPU_ARCH="${EXPECTED_GFX}" \
+            -e FLYDSL_VERSION -e EXPECTED_TORCH_VERSION \
+            -e EXPECTED_ROCM_VERSION -e PYTEST_VERSION \
+            -v "${GITHUB_WORKSPACE}:/workspace" -w /workspace \
+            "${ROCM_PYTORCH_IMAGE}" bash -lc '
+              set -euo pipefail
+              python3 -m pip install --no-cache-dir \
+                "flydsl==${FLYDSL_VERSION}" "pytest==${PYTEST_VERSION}"
+              python3 -m pip install --no-deps -e .
+              python3 -c "import os; from importlib.metadata import version; import torch; \
+                arch = torch.cuda.get_device_properties(0).gcnArchName.split(\":\", 1)[0]; \
+                assert version(\"flydsl\") == os.environ[\"FLYDSL_VERSION\"]; \
+                assert torch.__version__.startswith(os.environ[\"EXPECTED_TORCH_VERSION\"]); \
+                assert torch.version.hip.startswith(os.environ[\"EXPECTED_ROCM_VERSION\"]); \
+                assert arch == os.environ[\"QUACK_EXPECTED_GFX\"]"
+              PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+                python3 -m pytest --noconftest -q \
+                  tests/test_benchmark_rmsnorm_flydsl.py \
+                  tests/test_rmsnorm_dispatch.py \
+                  tests/test_rmsnorm_flydsl.py \
+                  tests/test_rocm_workflow.py
+              python3 benchmarks/benchmark_rmsnorm_flydsl.py \
+                --M 64 --N 65 --dtype bfloat16 \
+                --warmup 1 --iterations 2 --skip-torch-compile \
+                --output-json /tmp/rmsnorm-flydsl-benchmark.json
+            '

--- a/benchmarks/benchmark_rmsnorm_flydsl.py
+++ b/benchmarks/benchmark_rmsnorm_flydsl.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Same-GPU ROCm benchmark for Quack's explicit FlyDSL RMSNorm backend.
+
+The reported baselines run in this process on the same AMD GPU. They are not
+comparisons against Quack's CUDA/CuTe backend and do not imply CUDA parity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+import torch
+
+from quack.backends.flydsl.rmsnorm_config import get_bwd_workspace_rows
+from quack.rmsnorm_flydsl import _rmsnorm_flydsl_bwd, _rmsnorm_flydsl_fwd, rmsnorm
+
+DTYPES = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
+
+
+def _dispatch_latency_us(fn, warmup, iterations):
+    """Measure batched synchronized wall latency per dispatch.
+
+    This intentionally includes Python/dispatcher overhead and GPU execution.
+    It does not claim to isolate sub-microsecond kernel duration with events.
+    """
+
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - start) * 1e6 / iterations
+
+
+def _wall_ms(fn):
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - start) * 1000.0
+
+
+def _record(results, provider, metric, value, unit):
+    timing = (
+        "batched_synchronized_wall_clock"
+        if metric.endswith("_dispatch_latency")
+        else "synchronized_wall_clock"
+    )
+    results.append(
+        {
+            "provider": provider,
+            "metric": metric,
+            "value": round(value, 4),
+            "unit": unit,
+            "timing": timing,
+        }
+    )
+
+
+def _load_aiter():
+    try:
+        from aiter.ops.triton.rmsnorm import rms_norm
+    except Exception as exc:
+        print(f"AIter unavailable; skipping same-GPU comparison: {type(exc).__name__}: {exc}")
+        return None
+    return rms_norm
+
+
+def run(args):
+    if torch.version.hip is None or not torch.cuda.is_available():
+        raise RuntimeError("this benchmark requires ROCm PyTorch and a GPU")
+    device = torch.device("cuda", torch.cuda.current_device())
+    props = torch.cuda.get_device_properties(device)
+    arch = props.gcnArchName.split(":", 1)[0]
+    if arch not in {"gfx942", "gfx950"}:
+        raise RuntimeError(f"FlyDSL RMSNorm supports gfx942/gfx950, got {arch}")
+
+    dtype = DTYPES[args.dtype]
+    torch.manual_seed(args.seed)
+    x = torch.randn(args.M, args.N, device=device, dtype=dtype)
+    weight = torch.randn(args.N, device=device, dtype=torch.float32)
+    doutput = torch.randn_like(x)
+    output, dx = torch.empty_like(x), torch.empty_like(x)
+    rstd = torch.empty(args.M, device=device, dtype=torch.float32)
+    dweight = torch.zeros_like(weight)
+    workspace = torch.empty(
+        get_bwd_workspace_rows(args.M, args.N, dtype) * args.N,
+        device=device,
+        dtype=torch.float32,
+    )
+    results = []
+
+    _record(
+        results,
+        "flydsl",
+        "first_forward_compile_and_launch",
+        _wall_ms(lambda: rmsnorm(x, weight, eps=args.eps)),
+        "ms",
+    )
+    _rmsnorm_flydsl_fwd(x, weight, output, rstd, args.eps)
+
+    def direct_backward():
+        dweight.zero_()
+        _rmsnorm_flydsl_bwd(x, weight, doutput, rstd, dx, dweight, workspace)
+
+    _record(
+        results,
+        "flydsl",
+        "first_backward_compile_and_launch",
+        _wall_ms(direct_backward),
+        "ms",
+    )
+    _record(
+        results,
+        "flydsl",
+        "hot_cache_forward_dispatch_latency",
+        _dispatch_latency_us(
+            lambda: _rmsnorm_flydsl_fwd(x, weight, output, rstd, args.eps),
+            args.warmup,
+            args.iterations,
+        ),
+        "us",
+    )
+    _record(
+        results,
+        "flydsl",
+        "direct_backward_dispatch_latency",
+        _dispatch_latency_us(direct_backward, args.warmup, args.iterations),
+        "us",
+    )
+
+    x_train = x.detach().clone().requires_grad_()
+    weight_train = weight.detach().clone().requires_grad_()
+
+    def e2e(fn):
+        y = fn(x_train, weight_train, eps=args.eps)
+        return torch.autograd.grad(y, (x_train, weight_train), doutput)
+
+    _record(
+        results,
+        "flydsl",
+        "public_autograd_e2e_dispatch_latency",
+        _dispatch_latency_us(lambda: e2e(rmsnorm), args.warmup, args.iterations),
+        "us",
+    )
+    if not args.skip_torch_compile:
+        compiled = torch.compile(rmsnorm, fullgraph=True)
+        e2e(compiled)
+        _record(
+            results,
+            "flydsl_torch_compile",
+            "public_autograd_e2e_dispatch_latency",
+            _dispatch_latency_us(lambda: e2e(compiled), args.warmup, args.iterations),
+            "us",
+        )
+
+    def torch_forward(input, scale):
+        return torch.nn.functional.rms_norm(input, (args.N,), scale, args.eps)
+
+    _record(
+        results,
+        "pytorch_eager",
+        "hot_cache_forward_dispatch_latency",
+        _dispatch_latency_us(
+            lambda: torch_forward(x, weight),
+            args.warmup,
+            args.iterations,
+        ),
+        "us",
+    )
+
+    rstd_ref = torch.rsqrt(x.float().square().mean(dim=-1) + args.eps)
+
+    def torch_direct_backward(input, scale, grad, inv_rms):
+        x_hat = input.float() * inv_rms[:, None]
+        weighted_grad = grad.float() * scale
+        coefficient = (x_hat * weighted_grad).mean(dim=-1, keepdim=True)
+        dx_ref = ((weighted_grad - x_hat * coefficient) * inv_rms[:, None]).to(input.dtype)
+        dweight_ref = (grad.float() * x_hat).sum(dim=0)
+        return dx_ref, dweight_ref
+
+    _record(
+        results,
+        "pytorch_eager_math",
+        "direct_backward_dispatch_latency",
+        _dispatch_latency_us(
+            lambda: torch_direct_backward(x, weight, doutput, rstd_ref),
+            args.warmup,
+            args.iterations,
+        ),
+        "us",
+    )
+
+    x_ref = x.detach().clone().requires_grad_()
+    weight_ref = weight.detach().clone().requires_grad_()
+
+    def torch_e2e():
+        y = torch_forward(x_ref, weight_ref)
+        return torch.autograd.grad(y, (x_ref, weight_ref), doutput)
+
+    _record(
+        results,
+        "pytorch_eager",
+        "public_autograd_e2e_dispatch_latency",
+        _dispatch_latency_us(torch_e2e, args.warmup, args.iterations),
+        "us",
+    )
+    if not args.skip_torch_compile:
+        compiled_torch_forward = torch.compile(torch_forward, fullgraph=True)
+        compiled_torch_backward = torch.compile(torch_direct_backward, fullgraph=True)
+        compiled_torch_forward(x, weight)
+        compiled_torch_backward(x, weight, doutput, rstd_ref)
+        _record(
+            results,
+            "pytorch_fullgraph",
+            "hot_cache_forward_dispatch_latency",
+            _dispatch_latency_us(
+                lambda: compiled_torch_forward(x, weight),
+                args.warmup,
+                args.iterations,
+            ),
+            "us",
+        )
+        _record(
+            results,
+            "pytorch_fullgraph_math",
+            "direct_backward_dispatch_latency",
+            _dispatch_latency_us(
+                lambda: compiled_torch_backward(x, weight, doutput, rstd_ref),
+                args.warmup,
+                args.iterations,
+            ),
+            "us",
+        )
+
+        def compiled_torch_e2e():
+            y = compiled_torch_forward(x_ref, weight_ref)
+            return torch.autograd.grad(y, (x_ref, weight_ref), doutput)
+
+        _record(
+            results,
+            "pytorch_fullgraph",
+            "public_autograd_e2e_dispatch_latency",
+            _dispatch_latency_us(compiled_torch_e2e, args.warmup, args.iterations),
+            "us",
+        )
+    if args.aiter and (aiter_rmsnorm := _load_aiter()) is not None:
+        _record(
+            results,
+            "aiter",
+            "hot_cache_forward_dispatch_latency",
+            _dispatch_latency_us(
+                lambda: aiter_rmsnorm(x, weight, args.eps),
+                args.warmup,
+                args.iterations,
+            ),
+            "us",
+        )
+
+    print(f"GPU={props.name} arch={arch} shape=({args.M}, {args.N}) dtype={args.dtype}")
+    print("Baselines are same-machine ROCm measurements; CUDA Quack parity is not implied.")
+    print(
+        "Dispatch-latency rows use batched synchronized wall time and include "
+        "Python/dispatcher overhead plus GPU execution."
+    )
+    print(f"{'provider':24s} {'metric':44s} {'value':>12s} {'unit':>5s}")
+    for row in results:
+        print(f"{row['provider']:24s} {row['metric']:44s} {row['value']:12.4f} {row['unit']:>5s}")
+    if args.output_json:
+        payload = {
+            "device": props.name,
+            "arch": arch,
+            "shape": [args.M, args.N],
+            "dtype": args.dtype,
+            "eps": args.eps,
+            "torch_version": torch.__version__,
+            "hip_version": torch.version.hip,
+            "scope": (
+                "same-machine ROCm baselines; dispatch rows are batched synchronized "
+                "wall-clock latency; no CUDA Quack parity claim"
+            ),
+            "results": results,
+        }
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(payload, indent=2) + "\n")
+    return results
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--M", type=int, default=4096)
+    parser.add_argument("--N", type=int, default=4096)
+    parser.add_argument("--dtype", choices=DTYPES, default="bfloat16")
+    parser.add_argument("--eps", type=float, default=1e-6)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--aiter", action="store_true")
+    parser.add_argument("--skip-torch-compile", action="store_true")
+    parser.add_argument("--enable-disk-cache", action="store_true")
+    parser.add_argument("--output-json", type=Path)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    cli_args = parse_args()
+    if not cli_args.enable_disk_cache:
+        os.environ["FLYDSL_RUNTIME_ENABLE_CACHE"] = "0"
+    run(cli_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 
 [project.optional-dependencies]
 cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.1"]
+flydsl = ["flydsl>=0.2.3"]
+rocm = ["flydsl>=0.2.3"]
 heuristics = ["nvidia-matmul-heuristics"]
 jax = ["jax", "jax-tvm-ffi"]
 bench = ["pandas", "tyro"]

--- a/quack/__init__.py
+++ b/quack/__init__.py
@@ -1,29 +1,82 @@
-__version__ = "0.6.1"
+"""Quack's backend-aware public package surface.
+
+CUDA builds preserve the original eager CuTe initialization. ROCm builds keep
+both compiler backends unloaded until a public operator is requested.
+"""
+
+from __future__ import annotations
 
 import os
+from importlib import import_module
 
-import quack.dsl as _quack_dsl  # noqa: F401
+__version__ = "0.6.1"
 
-if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
-    from quack.dsl import cute_dsl_ptxas as _cute_dsl_ptxas
+__all__ = ["rmsnorm", "softmax", "cross_entropy", "RoundingMode"]
 
-    # Patch before importing any modules that instantiate CuTeDSL. The patch
-    # forces PTX dumping so the CUDA library loader can replace CUTLASS DSL's
-    # embedded ptxas-library cubin with one assembled by system ptxas.
-    _cute_dsl_ptxas.patch()
-
-# Pythonic CuTe tensor indexing (`:` / `...` sugar) is installed as a side effect
-# of importing `quack.dsl`, which imports `quack.dsl.cute_tensor_indexing` and
-# monkey-patches CuTe's tensor classes process-wide.
-from quack.rmsnorm import rmsnorm  # noqa: E402
-from quack.softmax import softmax  # noqa: E402
-from quack.cross_entropy import cross_entropy  # noqa: E402
-from quack.rounding import RoundingMode  # noqa: E402
+_LAZY_EXPORTS = {
+    "softmax": ("quack.softmax", "softmax"),
+    "cross_entropy": ("quack.cross_entropy", "cross_entropy"),
+    "RoundingMode": ("quack.rounding", "RoundingMode"),
+}
 
 
-__all__ = [
-    "rmsnorm",
-    "softmax",
-    "cross_entropy",
-    "RoundingMode",
-]
+def __getattr__(name: str):
+    if name == "rmsnorm":
+        import torch
+
+        if torch.compiler.is_compiling():
+            raise RuntimeError("resolve `from quack import rmsnorm` before entering torch.compile")
+        from quack.backends.registry import REGISTRY
+        from quack.backends.target import vendor_from_torch_build
+
+        vendor = vendor_from_torch_build()
+        if vendor not in {"amd", "nvidia"}:
+            raise RuntimeError("quack.rmsnorm requires a CUDA or ROCm PyTorch build")
+        value = REGISTRY.load_provider("rmsnorm", vendor).load_op()
+        globals()[name] = value
+        return value
+    try:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))
+
+
+def _initialize_backend_exports() -> None:
+    """Restore pre-existing CUDA initialization and callable exports.
+
+    CUDA builds install CuTe tensor helpers and bind callable package exports
+    during ``import quack``. ROCm builds leave exports lazy so importing Quack
+    never requires CuTe or FlyDSL.
+    """
+
+    import torch
+
+    if torch.version.hip is not None:
+        return
+    if torch.version.cuda is None:
+        return
+
+    import_module("quack.dsl")
+    if os.environ.get("CUTE_DSL_PTXAS_PATH") is not None:
+        from quack.dsl import cute_dsl_ptxas as _cute_dsl_ptxas
+
+        _cute_dsl_ptxas.patch()
+
+    exports = {
+        "rmsnorm": ("quack.rmsnorm", "rmsnorm"),
+        "softmax": ("quack.softmax", "softmax"),
+        "cross_entropy": ("quack.cross_entropy", "cross_entropy"),
+        "RoundingMode": ("quack.rounding", "RoundingMode"),
+    }
+    for name, (module_name, attr_name) in exports.items():
+        globals()[name] = getattr(import_module(module_name), attr_name)
+
+
+_initialize_backend_exports()

--- a/quack/_torch_library_op.py
+++ b/quack/_torch_library_op.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+"""Backend-neutral opaque ``torch.library.custom_op`` helper.
+
+The decorated operation mutates caller-allocated tensors. Its fake
+implementation is therefore a no-op, which prevents Dynamo and AOTAutograd
+from tracing into backend compilers or launchers. Eager calls bypass the
+dispatcher to avoid its fixed overhead; compiled calls retain the opaque op.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, Iterable, Optional, Union
+
+import torch
+
+__all__ = ["torch_library_op"]
+
+
+def torch_library_op(
+    name: str,
+    *,
+    mutates_args: Union[str, Iterable[str]],
+    schema: Optional[str] = None,
+    device_types: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
+    """Register a mutating backend operation with an opaque fake implementation."""
+
+    def dec(fn: Callable) -> Any:
+        kwargs: dict[str, Any] = {"mutates_args": mutates_args}
+        if schema is not None:
+            kwargs["schema"] = schema
+        if device_types is not None:
+            kwargs["device_types"] = device_types
+        op = torch.library.custom_op(name, fn, **kwargs)
+
+        @op.register_fake
+        def _fake(*args, **kwargs):
+            return None
+
+        return _make_eager_bypass(op, fn)
+
+    return dec
+
+
+def _make_eager_bypass(op, fn):
+    """Return a Dynamo-inlineable eager bypass for ``op``.
+
+    A callable object works for direct compiled calls, but Dynamo cannot wrap
+    that object when it is referenced from inside ``autograd.Function``. A
+    plain function is inlineable in both cases, so Dynamo can constant-fold
+    ``is_compiling()`` and retain the custom-op node.
+    """
+
+    op_overload = op._opoverload
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if torch.compiler.is_compiling():
+            # Dynamo natively understands OpOverload, including when this
+            # wrapper is inlined inside autograd.Function. Capturing the
+            # higher-level CustomOpDef here triggers SourcelessBuilder errors.
+            return op_overload(*args, **kwargs)
+        return fn(*args, **kwargs)
+
+    wrapper._custom_op = op
+    wrapper._init_fn = fn
+    # Preserve post-registration hooks used by existing CuTe operators
+    # (register_effect/register_autograd/_opoverload) and introspection tests.
+    for attribute_name in dir(op):
+        if attribute_name.startswith("__") or attribute_name in wrapper.__dict__:
+            continue
+        try:
+            setattr(wrapper, attribute_name, getattr(op, attribute_name))
+        except (AttributeError, TypeError):
+            pass
+    return wrapper

--- a/quack/backends/__init__.py
+++ b/quack/backends/__init__.py
@@ -1,0 +1,18 @@
+"""Lazy operator-backend selection primitives."""
+
+from quack.backends.protocol import BackendProvider, Support
+from quack.backends.registry import REGISTRY, BackendRegistry
+from quack.backends.rmsnorm_spec import RMSNormSpec, normalize_rmsnorm_spec
+from quack.backends.target import Target, target_from_tensor, vendor_from_torch_build
+
+__all__ = [
+    "BackendProvider",
+    "BackendRegistry",
+    "REGISTRY",
+    "RMSNormSpec",
+    "Support",
+    "Target",
+    "normalize_rmsnorm_spec",
+    "target_from_tensor",
+    "vendor_from_torch_build",
+]

--- a/quack/backends/cute/__init__.py
+++ b/quack/backends/cute/__init__.py
@@ -1,0 +1,1 @@
+"""Lazy adapters for Quack's existing CuTe implementations."""

--- a/quack/backends/cute/rmsnorm_provider.py
+++ b/quack/backends/cute/rmsnorm_provider.py
@@ -1,0 +1,21 @@
+"""Lazy adapter for the existing CuTe RMSNorm implementation."""
+
+from importlib.util import find_spec
+
+from quack.backends.protocol import Support
+
+
+def is_available() -> bool:
+    return find_spec("cutlass") is not None and find_spec("cuda") is not None
+
+
+def supports(spec, target) -> Support:
+    if target.vendor != "nvidia":
+        return Support.no(f"CuTe RMSNorm requires an NVIDIA target, got {target.vendor!r}")
+    return Support.yes()
+
+
+def load_op():
+    from quack.rmsnorm import rmsnorm
+
+    return rmsnorm

--- a/quack/backends/flydsl/__init__.py
+++ b/quack/backends/flydsl/__init__.py
@@ -1,0 +1,8 @@
+"""Quack-owned FlyDSL backend implementations."""
+
+FLYDSL_INSTALL_HINT = (
+    "FlyDSL is required for quack.rmsnorm_flydsl; "
+    "install Quack with `pip install 'quack-kernels[rocm]'`."
+)
+
+__all__ = ["FLYDSL_INSTALL_HINT"]

--- a/quack/backends/flydsl/rmsnorm_bwd_kernel.py
+++ b/quack/backends/flydsl/rmsnorm_bwd_kernel.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Copyright (c) 2026 Dao-AILab
+"""Quack-owned FlyDSL RMSNorm backward kernels.
+
+Small row counts use direct FP32 atomic dweight accumulation. Large row
+counts use a persistent first stage plus a deterministic workspace reduction.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+import torch
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+
+from quack.backends.flydsl.rmsnorm_common import (
+    WARP_SIZE,
+    atomic_add_f32,
+    dtype_to_elem_type,
+    load_scalar,
+    make_reduction_storage,
+    store_scalar,
+    torch_dtype_to_str,
+)
+from quack.backends.flydsl.rmsnorm_config import (
+    ATOMIC,
+    TWO_STAGE,
+    RMSNormBwdConfig,
+    cache_target_identity,
+)
+
+_BWD_CACHE: dict[tuple, flyc.CompiledFunction] = {}
+_BWD_CACHE_LOCK = threading.Lock()
+
+
+def _validate_builder_dtypes(weight_dtype_str: str) -> None:
+    if weight_dtype_str != "f32":
+        raise ValueError("the FlyDSL RMSNorm backward kernel requires FP32 weight")
+
+
+def build_rmsnorm_bwd_atomic_module(
+    n: int,
+    input_dtype_str: str,
+    weight_dtype_str: str,
+    config: RMSNormBwdConfig,
+):
+    """Build one-block-per-row backward with FP32 dweight atomics."""
+
+    _validate_builder_dtypes(weight_dtype_str)
+    block_threads = config.block_threads
+    red_slots = max(1, math.ceil(block_threads / WARP_SIZE))
+    elem_bits = 32 if input_dtype_str == "f32" else 16
+    SharedStorage = make_reduction_storage(red_slots)
+
+    @flyc.kernel
+    def rmsnorm_bwd_atomic_kernel(
+        Input: fx.Tensor,
+        Weight: fx.Tensor,
+        DOutput: fx.Tensor,
+        Rstd: fx.Tensor,
+        DInput: fx.Tensor,
+        DWeight: fx.Tensor,
+    ):
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+        input_dtype = dtype_to_elem_type(input_dtype_str)
+        fastmath = arith.FastMathFlags.fast
+
+        shared = fx.SharedAllocator().allocate(SharedStorage).peek()
+        reduction = shared.values.view(fx.make_layout(red_slots, 1))
+
+        def wave_reduce_add(value):
+            result = value
+            for shift_exp in range_constexpr(int(math.log2(WARP_SIZE))):
+                offset = WARP_SIZE // (2 << shift_exp)
+                result = result.addf(
+                    result.shuffle_xor(offset, WARP_SIZE),
+                    fastmath=fastmath,
+                )
+            return result
+
+        def block_reduce_add(value):
+            if const_expr(red_slots == 1):
+                return wave_reduce_add(value)
+            lane = tid % WARP_SIZE
+            wave = tid // WARP_SIZE
+            wave_sum = wave_reduce_add(value)
+            if lane == 0:
+                fx.memref_store(wave_sum, reduction, wave)
+            gpu.barrier()
+            if wave == 0:
+                in_range = lane < red_slots
+                safe_lane = in_range.select(lane, 0)
+                partial = fx.memref_load(reduction, safe_lane)
+                total = wave_reduce_add(in_range.select(partial, fx.Float32(0.0)))
+                if lane == 0:
+                    fx.memref_store(total, reduction, 0)
+            gpu.barrier()
+            return fx.memref_load(reduction, 0)
+
+        input_buffer = fx.rocdl.make_buffer_tensor(Input)
+        weight_buffer = fx.rocdl.make_buffer_tensor(Weight)
+        doutput_buffer = fx.rocdl.make_buffer_tensor(DOutput)
+        rstd_buffer = fx.rocdl.make_buffer_tensor(Rstd)
+        dinput_buffer = fx.rocdl.make_buffer_tensor(DInput)
+        dweight_div = fx.logical_divide(DWeight, fx.make_layout(1, 1))
+
+        input_div = fx.logical_divide(
+            fx.slice(input_buffer, (row, None)),
+            fx.make_layout(1, 1),
+        )
+        doutput_div = fx.logical_divide(
+            fx.slice(doutput_buffer, (row, None)),
+            fx.make_layout(1, 1),
+        )
+        dinput_div = fx.logical_divide(
+            fx.slice(dinput_buffer, (row, None)),
+            fx.make_layout(1, 1),
+        )
+        weight_div = fx.logical_divide(weight_buffer, fx.make_layout(1, 1))
+        rstd_div = fx.logical_divide(rstd_buffer, fx.make_layout(1, 1))
+
+        input_copy = fx.make_copy_atom(
+            fx.rocdl.BufferCopy32b() if elem_bits == 32 else fx.rocdl.BufferCopy16b(),
+            elem_bits,
+        )
+        f32_copy = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
+        f32_atomic_add = fx.make_copy_atom(
+            fx.UniversalAtomicAdd(
+                fx.Float32,
+                syncscope=fx.rocdl.SyncScope.Agent,
+            ),
+            fx.Float32,
+        )
+        rstd = load_scalar(f32_copy, fx.Float32, rstd_div, row)
+
+        thread_sum = fx.Float32(0.0)
+        for base in range_constexpr(0, n, block_threads):
+            index = tid + base
+            valid = index < n
+            safe_index = valid.select(index, 0)
+            x_elem = load_scalar(input_copy, input_dtype, input_div, safe_index)
+            dy_elem = load_scalar(input_copy, input_dtype, doutput_div, safe_index)
+            x = x_elem if input_dtype_str == "f32" else x_elem.to(fx.Float32)
+            dy = dy_elem if input_dtype_str == "f32" else dy_elem.to(fx.Float32)
+            weight = load_scalar(f32_copy, fx.Float32, weight_div, safe_index)
+            x_hat = x * rstd
+            thread_sum = thread_sum + valid.select(x_hat * dy * weight, fx.Float32(0.0))
+
+        coefficient = block_reduce_add(thread_sum) / float(n)
+        for base in range_constexpr(0, n, block_threads):
+            index = tid + base
+            if index < n:
+                x_elem = load_scalar(input_copy, input_dtype, input_div, index)
+                dy_elem = load_scalar(input_copy, input_dtype, doutput_div, index)
+                x = x_elem if input_dtype_str == "f32" else x_elem.to(fx.Float32)
+                dy = dy_elem if input_dtype_str == "f32" else dy_elem.to(fx.Float32)
+                weight = load_scalar(f32_copy, fx.Float32, weight_div, index)
+                x_hat = x * rstd
+                dx = (dy * weight - x_hat * coefficient) * rstd
+                dx_elem = dx if input_dtype_str == "f32" else dx.to(input_dtype)
+                store_scalar(input_copy, input_dtype, dinput_div, index, dx_elem)
+                atomic_add_f32(
+                    f32_atomic_add,
+                    dweight_div,
+                    index,
+                    dy * x_hat,
+                )
+
+    @flyc.jit
+    def launch_rmsnorm_bwd_atomic(
+        Input: fx.Tensor,
+        Weight: fx.Tensor,
+        DOutput: fx.Tensor,
+        Rstd: fx.Tensor,
+        DInput: fx.Tensor,
+        DWeight: fx.Tensor,
+        M: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        rmsnorm_bwd_atomic_kernel(
+            Input,
+            Weight,
+            DOutput,
+            Rstd,
+            DInput,
+            DWeight,
+        ).launch(
+            grid=(M, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_rmsnorm_bwd_atomic
+
+
+def build_rmsnorm_bwd_two_stage_module(
+    n: int,
+    input_dtype_str: str,
+    weight_dtype_str: str,
+    config: RMSNormBwdConfig,
+):
+    """Build persistent dx/dweight-partial and dweight-finalizer kernels."""
+
+    _validate_builder_dtypes(weight_dtype_str)
+    if config.num_programs <= 0:
+        raise ValueError("two-stage backward requires a positive program count")
+    block_threads = config.block_threads
+    num_programs = config.num_programs
+    values_per_thread = math.ceil(n / block_threads)
+    red_slots = max(1, math.ceil(block_threads / WARP_SIZE))
+    elem_bits = 32 if input_dtype_str == "f32" else 16
+    SharedStorage = make_reduction_storage(red_slots)
+
+    @flyc.kernel
+    def rmsnorm_bwd_partial_kernel(
+        Input: fx.Tensor,
+        Weight: fx.Tensor,
+        DOutput: fx.Tensor,
+        Rstd: fx.Tensor,
+        DInput: fx.Tensor,
+        DWeightPartial: fx.Tensor,
+        M: fx.Int32,
+    ):
+        program = fx.block_idx.x
+        tid = fx.thread_idx.x
+        input_dtype = dtype_to_elem_type(input_dtype_str)
+        fastmath = arith.FastMathFlags.fast
+
+        shared = fx.SharedAllocator().allocate(SharedStorage).peek()
+        reduction = shared.values.view(fx.make_layout(red_slots, 1))
+
+        def wave_reduce_add(value):
+            result = value
+            for shift_exp in range_constexpr(int(math.log2(WARP_SIZE))):
+                offset = WARP_SIZE // (2 << shift_exp)
+                result = result.addf(
+                    result.shuffle_xor(offset, WARP_SIZE),
+                    fastmath=fastmath,
+                )
+            return result
+
+        def block_reduce_add(value):
+            if const_expr(red_slots == 1):
+                return wave_reduce_add(value)
+            lane = tid % WARP_SIZE
+            wave = tid // WARP_SIZE
+            wave_sum = wave_reduce_add(value)
+            if lane == 0:
+                fx.memref_store(wave_sum, reduction, wave)
+            gpu.barrier()
+            if wave == 0:
+                in_range = lane < red_slots
+                safe_lane = in_range.select(lane, 0)
+                partial = fx.memref_load(reduction, safe_lane)
+                total = wave_reduce_add(in_range.select(partial, fx.Float32(0.0)))
+                if lane == 0:
+                    fx.memref_store(total, reduction, 0)
+            gpu.barrier()
+            return fx.memref_load(reduction, 0)
+
+        input_buffer = fx.rocdl.make_buffer_tensor(Input)
+        weight_buffer = fx.rocdl.make_buffer_tensor(Weight)
+        doutput_buffer = fx.rocdl.make_buffer_tensor(DOutput)
+        rstd_buffer = fx.rocdl.make_buffer_tensor(Rstd)
+        dinput_buffer = fx.rocdl.make_buffer_tensor(DInput)
+        partial_buffer = fx.rocdl.make_buffer_tensor(DWeightPartial)
+        weight_div = fx.logical_divide(weight_buffer, fx.make_layout(1, 1))
+        rstd_div = fx.logical_divide(rstd_buffer, fx.make_layout(1, 1))
+        partial_div = fx.logical_divide(partial_buffer, fx.make_layout(1, 1))
+
+        input_copy = fx.make_copy_atom(
+            fx.rocdl.BufferCopy32b() if elem_bits == 32 else fx.rocdl.BufferCopy16b(),
+            elem_bits,
+        )
+        f32_copy = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
+        initial_partial = fx.Vector.filled(values_per_thread, 0.0, fx.Float32)
+
+        for row, state in range(
+            fx.Int32(program),
+            M,
+            fx.Int32(num_programs),
+            init=[initial_partial],
+        ):
+            partial_acc = state[0]
+            input_div = fx.logical_divide(
+                fx.slice(input_buffer, (row, None)),
+                fx.make_layout(1, 1),
+            )
+            doutput_div = fx.logical_divide(
+                fx.slice(doutput_buffer, (row, None)),
+                fx.make_layout(1, 1),
+            )
+            dinput_div = fx.logical_divide(
+                fx.slice(dinput_buffer, (row, None)),
+                fx.make_layout(1, 1),
+            )
+            rstd = load_scalar(f32_copy, fx.Float32, rstd_div, row)
+
+            thread_sum = fx.Float32(0.0)
+            for tile in range_constexpr(values_per_thread):
+                index = tid + tile * block_threads
+                valid = index < n
+                safe_index = valid.select(index, 0)
+                x_elem = load_scalar(input_copy, input_dtype, input_div, safe_index)
+                dy_elem = load_scalar(input_copy, input_dtype, doutput_div, safe_index)
+                x = x_elem if input_dtype_str == "f32" else x_elem.to(fx.Float32)
+                dy = dy_elem if input_dtype_str == "f32" else dy_elem.to(fx.Float32)
+                weight = load_scalar(f32_copy, fx.Float32, weight_div, safe_index)
+                x_hat = x * rstd
+                thread_sum = thread_sum + valid.select(
+                    x_hat * dy * weight,
+                    fx.Float32(0.0),
+                )
+
+            coefficient = block_reduce_add(thread_sum) / float(n)
+            row_dweight = []
+            for tile in range_constexpr(values_per_thread):
+                index = tid + tile * block_threads
+                valid = index < n
+                safe_index = valid.select(index, 0)
+                x_elem = load_scalar(input_copy, input_dtype, input_div, safe_index)
+                dy_elem = load_scalar(input_copy, input_dtype, doutput_div, safe_index)
+                x = x_elem if input_dtype_str == "f32" else x_elem.to(fx.Float32)
+                dy = dy_elem if input_dtype_str == "f32" else dy_elem.to(fx.Float32)
+                weight = load_scalar(f32_copy, fx.Float32, weight_div, safe_index)
+                x_hat = x * rstd
+                dx = (dy * weight - x_hat * coefficient) * rstd
+                if index < n:
+                    dx_elem = dx if input_dtype_str == "f32" else dx.to(input_dtype)
+                    store_scalar(input_copy, input_dtype, dinput_div, index, dx_elem)
+                row_dweight.append(valid.select(dy * x_hat, fx.Float32(0.0)))
+
+            updated_partial = partial_acc + fx.Vector.from_elements(
+                row_dweight,
+                fx.Float32,
+            )
+            gpu.barrier()
+            results = yield [updated_partial]
+
+        final_partial = results
+        for tile in range_constexpr(values_per_thread):
+            index = tid + tile * block_threads
+            if index < n:
+                partial_index = program * n + index
+                store_scalar(
+                    f32_copy,
+                    fx.Float32,
+                    partial_div,
+                    partial_index,
+                    final_partial[tile],
+                )
+
+    @flyc.kernel
+    def rmsnorm_bwd_reduce_kernel(
+        DWeightPartial: fx.Tensor,
+        DWeight: fx.Tensor,
+    ):
+        block = fx.block_idx.x
+        tid = fx.thread_idx.x
+        index = fx.Int32(block * block_threads + tid)
+        partial_buffer = fx.rocdl.make_buffer_tensor(DWeightPartial)
+        dweight_buffer = fx.rocdl.make_buffer_tensor(DWeight)
+        partial_div = fx.logical_divide(partial_buffer, fx.make_layout(1, 1))
+        dweight_div = fx.logical_divide(dweight_buffer, fx.make_layout(1, 1))
+        f32_copy = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
+
+        valid = index < n
+        safe_index = valid.select(index, 0)
+        for partial_row, state in range(
+            fx.Int32(0),
+            fx.Int32(num_programs),
+            fx.Int32(1),
+            init=[fx.Float32(0.0)],
+        ):
+            partial_index = fx.Int32(partial_row) * fx.Int32(n) + safe_index
+            value = load_scalar(
+                f32_copy,
+                fx.Float32,
+                partial_div,
+                partial_index,
+            )
+            results = yield [state[0] + value]
+        if index < n:
+            store_scalar(
+                f32_copy,
+                fx.Float32,
+                dweight_div,
+                index,
+                results,
+            )
+
+    reduce_grid = math.ceil(n / block_threads)
+
+    @flyc.jit
+    def launch_rmsnorm_bwd_two_stage(
+        Input: fx.Tensor,
+        Weight: fx.Tensor,
+        DOutput: fx.Tensor,
+        Rstd: fx.Tensor,
+        DInput: fx.Tensor,
+        DWeight: fx.Tensor,
+        DWeightPartial: fx.Tensor,
+        M: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        rmsnorm_bwd_partial_kernel(
+            Input,
+            Weight,
+            DOutput,
+            Rstd,
+            DInput,
+            DWeightPartial,
+            M,
+        ).launch(
+            grid=(num_programs, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+        rmsnorm_bwd_reduce_kernel(DWeightPartial, DWeight).launch(
+            grid=(reduce_grid, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_rmsnorm_bwd_two_stage
+
+
+def run_rmsnorm_bwd(
+    x,
+    weight,
+    doutput,
+    rstd,
+    dinput,
+    dweight,
+    workspace,
+    target,
+    config,
+) -> None:
+    """Compile/cache/launch the selected backward path on the current stream."""
+
+    m, n = x.shape
+    input_dtype_str = torch_dtype_to_str(x.dtype)
+    weight_dtype_str = torch_dtype_to_str(weight.dtype)
+    with torch.cuda.device(target.device_index):
+        stream = torch.cuda.current_stream(target.device_index)
+        key = (
+            *cache_target_identity(target),
+            n,
+            input_dtype_str,
+            weight_dtype_str,
+            "backward",
+            config.path,
+            config.block_threads,
+            config.num_programs,
+        )
+        compiled = _BWD_CACHE.get(key)
+        if config.path == ATOMIC:
+            args = (x, weight, doutput, rstd, dinput, dweight, m, stream)
+            builder = build_rmsnorm_bwd_atomic_module
+        elif config.path == TWO_STAGE:
+            required_workspace = config.num_programs * n
+            if workspace.numel() < required_workspace:
+                raise RuntimeError(
+                    "FlyDSL RMSNorm backward workspace is too small: "
+                    f"need {required_workspace} FP32 elements, got {workspace.numel()}"
+                )
+            args = (
+                x,
+                weight,
+                doutput,
+                rstd,
+                dinput,
+                dweight,
+                workspace,
+                m,
+                stream,
+            )
+            builder = build_rmsnorm_bwd_two_stage_module
+        else:
+            raise ValueError(f"unknown FlyDSL RMSNorm backward path {config.path!r}")
+
+        if compiled is not None:
+            compiled(*args)
+            return
+        with _BWD_CACHE_LOCK:
+            compiled = _BWD_CACHE.get(key)
+            if compiled is None:
+                launcher = builder(
+                    n,
+                    input_dtype_str,
+                    weight_dtype_str,
+                    config,
+                )
+                # flyc.compile compiles and performs the first launch.
+                compiled = flyc.compile(launcher, *args)
+                _BWD_CACHE[key] = compiled
+                return
+        compiled(*args)
+
+
+__all__ = [
+    "build_rmsnorm_bwd_atomic_module",
+    "build_rmsnorm_bwd_two_stage_module",
+    "run_rmsnorm_bwd",
+]

--- a/quack/backends/flydsl/rmsnorm_common.py
+++ b/quack/backends/flydsl/rmsnorm_common.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Copyright (c) 2026 Dao-AILab
+"""Shared FlyDSL primitives for Quack-owned RMSNorm kernels."""
+
+import flydsl.expr as fx
+from flydsl.expr.vector import full
+
+WARP_SIZE = 64
+
+
+def dtype_to_elem_type(dtype_str: str):
+    if dtype_str == "f32":
+        return fx.Float32
+    if dtype_str == "f16":
+        return fx.Float16
+    if dtype_str == "bf16":
+        return fx.BFloat16
+    raise ValueError(f"unsupported dtype {dtype_str!r}")
+
+
+def torch_dtype_to_str(dtype) -> str:
+    import torch
+
+    if dtype == torch.float32:
+        return "f32"
+    if dtype == torch.float16:
+        return "f16"
+    if dtype == torch.bfloat16:
+        return "bf16"
+    raise ValueError(f"unsupported torch dtype {dtype}")
+
+
+def make_reduction_storage(red_slots: int):
+    @fx.struct
+    class SharedStorage:
+        values: fx.Array[fx.Float32, red_slots, 16]
+
+    return SharedStorage
+
+
+def load_scalar(copy_atom, elem_dtype, divided_tensor, index):
+    registers = fx.make_rmem_tensor(1, elem_dtype)
+    fx.copy_atom_call(copy_atom, fx.slice(divided_tensor, (None, index)), registers)
+    return fx.memref_load_vec(registers)[0]
+
+
+def store_scalar(copy_atom, elem_dtype, divided_tensor, index, value):
+    registers = fx.make_rmem_tensor(1, elem_dtype)
+    fx.memref_store_vec(full(1, elem_dtype(value), elem_dtype), registers)
+    fx.copy_atom_call(copy_atom, registers, fx.slice(divided_tensor, (None, index)))
+
+
+def atomic_add_f32(copy_atom, divided_tensor, index, value):
+    """Atomically add one FP32 register value through FlyDSL's public atom API."""
+
+    registers = fx.make_rmem_tensor(1, fx.Float32)
+    fx.memref_store_vec(full(1, fx.Float32(value), fx.Float32), registers)
+    fx.copy_atom_call(
+        copy_atom,
+        registers,
+        fx.slice(divided_tensor, (None, index)),
+    )

--- a/quack/backends/flydsl/rmsnorm_config.py
+++ b/quack/backends/flydsl/rmsnorm_config.py
@@ -1,0 +1,133 @@
+"""gfx942/gfx950 RMSNorm launch and reduction selection."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+from quack.backends.target import Target
+
+ATOMIC = "atomic"
+TWO_STAGE = "two_stage"
+MAX_BWD_PROGRAMS = 512
+TWO_STAGE_MIN_ROWS = 512
+TWO_STAGE_MAX_N = 8192
+
+
+@dataclass(frozen=True, slots=True)
+class RMSNormFwdConfig:
+    block_threads: int
+
+
+@dataclass(frozen=True, slots=True)
+class RMSNormBwdConfig:
+    path: Literal["atomic", "two_stage"]
+    block_threads: int
+    num_programs: int = 0
+
+
+def get_bwd_workspace_rows(
+    m: int,
+    n: int,
+    input_dtype: torch.dtype,
+) -> int:
+    """Return a safe workspace-row bound for runtime backward selection."""
+
+    min_rows = TWO_STAGE_MIN_ROWS * (2 if input_dtype == torch.float32 else 1)
+    if m < min_rows or n > TWO_STAGE_MAX_N:
+        return 0
+    return min(m, MAX_BWD_PROGRAMS)
+
+
+def select_fwd_config(
+    m: int,
+    n: int,
+    input_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    target: Target,
+    cu_count: int,
+) -> RMSNormFwdConfig:
+    if weight_dtype != torch.float32:
+        raise ValueError(f"FlyDSL RMSNorm requires FP32 weight, got {weight_dtype}")
+    if n <= 256:
+        return RMSNormFwdConfig(block_threads=64)
+    if n <= 1024 and (
+        input_dtype == torch.float32 or target.arch == "gfx942" or m < max(1, 2 * cu_count)
+    ):
+        return RMSNormFwdConfig(block_threads=128)
+    return RMSNormFwdConfig(block_threads=256)
+
+
+def select_bwd_config(
+    m: int,
+    n: int,
+    input_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    target: Target,
+    cu_count: int,
+) -> RMSNormBwdConfig:
+    if weight_dtype != torch.float32:
+        raise ValueError(f"FlyDSL RMSNorm requires FP32 weight, got {weight_dtype}")
+    block_threads = 64 if n <= 256 else 128 if n <= 1024 else 256
+    workspace_rows = get_bwd_workspace_rows(m, n, input_dtype)
+    if workspace_rows == 0:
+        return RMSNormBwdConfig(path=ATOMIC, block_threads=block_threads)
+    large_m_threshold = 2048 if target.arch == "gfx950" else 4096
+    occupancy_multiplier = 1 if m < large_m_threshold else 2
+    num_programs = min(workspace_rows, max(1, occupancy_multiplier * cu_count))
+    return RMSNormBwdConfig(
+        path=TWO_STAGE,
+        block_threads=block_threads,
+        num_programs=num_programs,
+    )
+
+
+_HIP_LIB = None
+_HIP_LIB_TRIED = False
+
+
+def _hip_context_identity() -> int:
+    """Return the current HIP context handle for Quack's compiled-cache key."""
+
+    global _HIP_LIB, _HIP_LIB_TRIED
+    if not _HIP_LIB_TRIED:
+        _HIP_LIB_TRIED = True
+        for soname in ("libamdhip64.so", "libamdhip64.so.6", "libamdhip64.so.5"):
+            try:
+                lib = ctypes.CDLL(soname)
+                lib.hipCtxGetCurrent.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+                lib.hipCtxGetCurrent.restype = ctypes.c_int
+                _HIP_LIB = lib
+                break
+            except (AttributeError, OSError):
+                continue
+    if _HIP_LIB is None:
+        return 0
+    context = ctypes.c_void_p()
+    if _HIP_LIB.hipCtxGetCurrent(ctypes.byref(context)) != 0:
+        return 0
+    return int(context.value or 0)
+
+
+def cache_target_identity(target: Target) -> tuple[str, int, int]:
+    """Architecture, device, and active context identity for compiled caches."""
+
+    # Materialize the target device's primary context before asking HIP for it.
+    torch.cuda.current_stream(target.device_index)
+    return target.arch, target.device_index, _hip_context_identity()
+
+
+__all__ = [
+    "ATOMIC",
+    "MAX_BWD_PROGRAMS",
+    "RMSNormBwdConfig",
+    "RMSNormFwdConfig",
+    "TWO_STAGE",
+    "TWO_STAGE_MAX_N",
+    "get_bwd_workspace_rows",
+    "select_bwd_config",
+    "select_fwd_config",
+]

--- a/quack/backends/flydsl/rmsnorm_kernel.py
+++ b/quack/backends/flydsl/rmsnorm_kernel.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Copyright (c) 2026 Dao-AILab
+"""Quack-owned FlyDSL RMSNorm forward kernel and compiled cache."""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+import torch
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+
+from quack.backends.flydsl.rmsnorm_common import (
+    WARP_SIZE,
+    dtype_to_elem_type,
+    load_scalar,
+    make_reduction_storage,
+    store_scalar,
+    torch_dtype_to_str,
+)
+from quack.backends.flydsl.rmsnorm_config import (
+    RMSNormFwdConfig,
+    cache_target_identity,
+)
+
+_FWD_CACHE: dict[tuple, flyc.CompiledFunction] = {}
+_FWD_CACHE_LOCK = threading.Lock()
+
+
+def build_rmsnorm_fwd_module(
+    n: int,
+    input_dtype_str: str,
+    weight_dtype_str: str,
+    config: RMSNormFwdConfig,
+):
+    """Build a scalar-tail-safe RMSNorm forward launcher.
+
+    ``eps`` and the row count are runtime values; hidden size, dtypes, and
+    launch geometry are structural specializations.
+    """
+
+    if weight_dtype_str != "f32":
+        raise ValueError("the FlyDSL RMSNorm forward kernel requires FP32 weight")
+    block_threads = config.block_threads
+    red_slots = max(1, math.ceil(block_threads / WARP_SIZE))
+    elem_bits = 32 if input_dtype_str == "f32" else 16
+    SharedStorage = make_reduction_storage(red_slots)
+
+    @flyc.kernel
+    def rmsnorm_fwd_kernel(
+        Input: fx.Tensor,
+        Weight: fx.Tensor,
+        Output: fx.Tensor,
+        Rstd: fx.Tensor,
+        Eps: fx.Float32,
+    ):
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+        input_dtype = dtype_to_elem_type(input_dtype_str)
+        fastmath = arith.FastMathFlags.fast
+
+        shared = fx.SharedAllocator().allocate(SharedStorage).peek()
+        reduction = shared.values.view(fx.make_layout(red_slots, 1))
+
+        def wave_reduce_add(value):
+            result = value
+            for shift_exp in range_constexpr(int(math.log2(WARP_SIZE))):
+                offset = WARP_SIZE // (2 << shift_exp)
+                result = result.addf(
+                    result.shuffle_xor(offset, WARP_SIZE),
+                    fastmath=fastmath,
+                )
+            return result
+
+        def block_reduce_add(value):
+            if const_expr(red_slots == 1):
+                return wave_reduce_add(value)
+            lane = tid % WARP_SIZE
+            wave = tid // WARP_SIZE
+            wave_sum = wave_reduce_add(value)
+            if lane == 0:
+                fx.memref_store(wave_sum, reduction, wave)
+            gpu.barrier()
+            if wave == 0:
+                in_range = lane < red_slots
+                safe_lane = in_range.select(lane, 0)
+                partial = fx.memref_load(reduction, safe_lane)
+                total = wave_reduce_add(in_range.select(partial, fx.Float32(0.0)))
+                if lane == 0:
+                    fx.memref_store(total, reduction, 0)
+            gpu.barrier()
+            return fx.memref_load(reduction, 0)
+
+        input_buffer = fx.rocdl.make_buffer_tensor(Input)
+        weight_buffer = fx.rocdl.make_buffer_tensor(Weight)
+        output_buffer = fx.rocdl.make_buffer_tensor(Output)
+        rstd_buffer = fx.rocdl.make_buffer_tensor(Rstd)
+
+        input_row = fx.slice(input_buffer, (row, None))
+        output_row = fx.slice(output_buffer, (row, None))
+        input_div = fx.logical_divide(input_row, fx.make_layout(1, 1))
+        weight_div = fx.logical_divide(weight_buffer, fx.make_layout(1, 1))
+        output_div = fx.logical_divide(output_row, fx.make_layout(1, 1))
+        rstd_div = fx.logical_divide(rstd_buffer, fx.make_layout(1, 1))
+
+        input_copy = fx.make_copy_atom(
+            fx.rocdl.BufferCopy32b() if elem_bits == 32 else fx.rocdl.BufferCopy16b(),
+            elem_bits,
+        )
+        f32_copy = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 32)
+
+        thread_sum = fx.Float32(0.0)
+        for base in range_constexpr(0, n, block_threads):
+            index = tid + base
+            valid = index < n
+            safe_index = valid.select(index, 0)
+            x_elem = load_scalar(input_copy, input_dtype, input_div, safe_index)
+            x = x_elem if input_dtype_str == "f32" else x_elem.to(fx.Float32)
+            thread_sum = thread_sum + valid.select(x * x, fx.Float32(0.0))
+
+        row_sum = block_reduce_add(thread_sum)
+        rstd = fmath.rsqrt(row_sum / float(n) + Eps, fastmath=fastmath)
+        if tid == 0:
+            store_scalar(f32_copy, fx.Float32, rstd_div, row, rstd)
+
+        for base in range_constexpr(0, n, block_threads):
+            index = tid + base
+            if index < n:
+                x_elem = load_scalar(input_copy, input_dtype, input_div, index)
+                x = x_elem if input_dtype_str == "f32" else x_elem.to(fx.Float32)
+                weight = load_scalar(f32_copy, fx.Float32, weight_div, index)
+                output = x * rstd * weight
+                output_elem = output if input_dtype_str == "f32" else output.to(input_dtype)
+                store_scalar(input_copy, input_dtype, output_div, index, output_elem)
+
+    @flyc.jit
+    def launch_rmsnorm_fwd(
+        Input: fx.Tensor,
+        Weight: fx.Tensor,
+        Output: fx.Tensor,
+        Rstd: fx.Tensor,
+        M: fx.Int32,
+        Eps: fx.Float32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        rmsnorm_fwd_kernel(Input, Weight, Output, Rstd, Eps).launch(
+            grid=(M, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_rmsnorm_fwd
+
+
+def run_rmsnorm_fwd(x, weight, out, rstd, eps: float, target, config) -> None:
+    """Compile/cache/launch on the input tensor's device and current stream."""
+
+    m, n = x.shape
+    input_dtype_str = torch_dtype_to_str(x.dtype)
+    weight_dtype_str = torch_dtype_to_str(weight.dtype)
+    with torch.cuda.device(target.device_index):
+        stream = torch.cuda.current_stream(target.device_index)
+        key = (
+            *cache_target_identity(target),
+            n,
+            input_dtype_str,
+            weight_dtype_str,
+            "forward",
+            config.block_threads,
+        )
+        compiled = _FWD_CACHE.get(key)
+        if compiled is not None:
+            compiled(x, weight, out, rstd, m, eps, stream)
+            return
+        with _FWD_CACHE_LOCK:
+            compiled = _FWD_CACHE.get(key)
+            if compiled is None:
+                launcher = build_rmsnorm_fwd_module(
+                    n,
+                    input_dtype_str,
+                    weight_dtype_str,
+                    config,
+                )
+                # flyc.compile compiles and performs the first launch.
+                compiled = flyc.compile(launcher, x, weight, out, rstd, m, eps, stream)
+                _FWD_CACHE[key] = compiled
+                return
+        compiled(x, weight, out, rstd, m, eps, stream)
+
+
+__all__ = ["build_rmsnorm_fwd_module", "run_rmsnorm_fwd"]

--- a/quack/backends/flydsl/rmsnorm_provider.py
+++ b/quack/backends/flydsl/rmsnorm_provider.py
@@ -1,0 +1,60 @@
+"""Provider metadata for Quack's experimental FlyDSL RMSNorm."""
+
+from importlib.util import find_spec
+
+import torch
+
+from quack.backends.protocol import Support
+
+_SUPPORTED_ARCHES = frozenset({"gfx942", "gfx950"})
+_SUPPORTED_INPUT_DTYPES = frozenset({torch.float16, torch.bfloat16, torch.float32})
+
+
+def is_available() -> bool:
+    return find_spec("flydsl") is not None
+
+
+def supports(spec, target) -> Support:
+    if target.vendor != "amd":
+        return Support.no(f"FlyDSL RMSNorm requires an AMD target, got {target.vendor!r}")
+    if target.arch != "unknown" and target.arch not in _SUPPORTED_ARCHES:
+        return Support.no(
+            "FlyDSL RMSNorm currently supports gfx942 and gfx950; "
+            f"the input tensor targets {target.arch!r}"
+        )
+    if not spec.has_weight:
+        return Support.no("FlyDSL RMSNorm requires an explicit weight")
+    if spec.has_bias:
+        return Support.no("FlyDSL RMSNorm does not yet support bias")
+    if spec.has_residual:
+        return Support.no("FlyDSL RMSNorm does not yet support residual fusion")
+    if spec.prenorm:
+        return Support.no("FlyDSL RMSNorm does not yet support prenorm outputs")
+    if spec.per_head:
+        return Support.no("FlyDSL RMSNorm does not yet support per-head weights")
+    if spec.out_dtype is not None:
+        return Support.no("FlyDSL RMSNorm does not yet support out_dtype")
+    if spec.residual_dtype is not None:
+        return Support.no("FlyDSL RMSNorm does not yet support residual_dtype")
+    if spec.weight_offset != 0.0:
+        return Support.no("FlyDSL RMSNorm does not yet support weight_offset")
+    if spec.input_dtype not in _SUPPORTED_INPUT_DTYPES:
+        return Support.no(
+            "FlyDSL RMSNorm input dtype must be float16, bfloat16, or float32; "
+            f"got {spec.input_dtype}"
+        )
+    if spec.weight_dtype != torch.float32:
+        return Support.no(
+            "FlyDSL RMSNorm requires an FP32 weight for FP16/BF16/FP32 inputs; "
+            f"got {spec.weight_dtype}"
+        )
+    return Support.yes()
+
+
+def load_op():
+    from quack.rmsnorm_flydsl import rmsnorm
+
+    return rmsnorm
+
+
+__all__ = ["is_available", "load_op", "supports"]

--- a/quack/backends/protocol.py
+++ b/quack/backends/protocol.py
@@ -1,0 +1,44 @@
+"""Provider protocol for Quack operator backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from quack.backends.target import Target
+
+
+@dataclass(frozen=True, slots=True)
+class Support:
+    """A provider support decision with an actionable rejection reason."""
+
+    supported: bool
+    reason: str = ""
+
+    @classmethod
+    def yes(cls) -> "Support":
+        return cls(True)
+
+    @classmethod
+    def no(cls, reason: str) -> "Support":
+        if not reason:
+            raise ValueError("an unsupported decision requires a reason")
+        return cls(False, reason)
+
+    def __bool__(self) -> bool:
+        return self.supported
+
+
+@runtime_checkable
+class BackendProvider(Protocol):
+    """Operator-level provider contract.
+
+    Providers are modules with these callables; they remain unloaded until the
+    registry selects their operator/vendor pair.
+    """
+
+    def is_available(self) -> bool: ...
+
+    def supports(self, spec: Any, target: Target) -> Support: ...
+
+    def load_op(self) -> Callable: ...

--- a/quack/backends/registry.py
+++ b/quack/backends/registry.py
@@ -1,0 +1,60 @@
+"""Lazy, in-tree registry for operator backend providers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib import import_module
+from types import ModuleType
+from typing import Any, Mapping
+
+from quack.backends.target import Target
+
+_STATIC_PROVIDERS = {
+    ("rmsnorm", "nvidia"): "quack.backends.cute.rmsnorm_provider",
+    ("rmsnorm", "amd"): "quack.backends.flydsl.rmsnorm_provider",
+}
+
+
+class BackendRegistry:
+    """Map ``(operator, vendor)`` to a lazily imported provider module."""
+
+    def __init__(self, providers: Mapping[tuple[str, str], str]):
+        self._providers = dict(providers)
+
+    def provider_path(self, operator: str, vendor: str) -> str:
+        try:
+            return self._providers[(operator, vendor)]
+        except KeyError:
+            raise LookupError(
+                f"no Quack provider is registered for operator={operator!r}, vendor={vendor!r}"
+            ) from None
+
+    @lru_cache(maxsize=None)
+    def load_provider(self, operator: str, vendor: str) -> ModuleType:
+        module = import_module(self.provider_path(operator, vendor))
+        missing = [
+            name
+            for name in ("is_available", "supports", "load_op")
+            if not callable(getattr(module, name, None))
+        ]
+        if missing:
+            raise TypeError(
+                f"backend provider {module.__name__!r} is missing callables: {', '.join(missing)}"
+            )
+        return module
+
+    def resolve(self, operator: str, spec: Any, target: Target):
+        """Load and validate only the provider selected by ``target.vendor``."""
+
+        provider = self.load_provider(operator, target.vendor)
+        if not provider.is_available():
+            raise RuntimeError(f"provider {provider.__name__!r} is unavailable for {operator!r}")
+        support = provider.supports(spec, target)
+        if not support:
+            raise NotImplementedError(support.reason)
+        return provider.load_op()
+
+
+REGISTRY = BackendRegistry(_STATIC_PROVIDERS)
+
+__all__ = ["BackendRegistry", "REGISTRY"]

--- a/quack/backends/rmsnorm_spec.py
+++ b/quack/backends/rmsnorm_spec.py
@@ -1,0 +1,58 @@
+"""Backend-neutral RMSNorm call specification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True, slots=True)
+class RMSNormSpec:
+    input_dtype: Any
+    weight_dtype: Any
+    out_dtype: Any
+    residual_dtype: Any
+    has_weight: bool
+    has_bias: bool
+    has_residual: bool
+    per_head: bool
+    prenorm: bool
+    weight_offset: float
+    eps: float
+    normalized_size: Any
+
+
+def normalize_rmsnorm_spec(
+    x,
+    weight=None,
+    bias=None,
+    residual=None,
+    out_dtype=None,
+    residual_dtype=None,
+    eps: float = 1e-6,
+    prenorm: bool = False,
+    weight_offset: float = 0.0,
+) -> RMSNormSpec:
+    """Normalize Quack's complete RMSNorm signature without selecting a backend."""
+
+    weight_rank: Optional[int] = weight.dim() if weight is not None else None
+    bias_rank: Optional[int] = bias.dim() if bias is not None else None
+    per_head = weight_rank == 2 or bias_rank == 2
+    normalized_size = x.shape[-1] if x.dim() else 0
+    return RMSNormSpec(
+        input_dtype=x.dtype,
+        weight_dtype=weight.dtype if weight is not None else None,
+        out_dtype=out_dtype,
+        residual_dtype=residual_dtype,
+        has_weight=weight is not None,
+        has_bias=bias is not None,
+        has_residual=residual is not None,
+        per_head=per_head,
+        prenorm=bool(prenorm),
+        weight_offset=float(weight_offset),
+        eps=float(eps),
+        normalized_size=normalized_size,
+    )
+
+
+__all__ = ["RMSNormSpec", "normalize_rmsnorm_spec"]

--- a/quack/backends/target.py
+++ b/quack/backends/target.py
@@ -1,0 +1,65 @@
+"""Backend target identification.
+
+Build-vendor detection is safe to bind before Dynamo tracing. Exact device and
+architecture detection must be called from an opaque backend-op body.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class Target:
+    """An exact device target used for provider support and cache selection."""
+
+    vendor: str
+    arch: str
+    device_index: int
+
+
+def vendor_from_torch_build() -> str:
+    """Return ``"amd"``, ``"nvidia"``, or ``"cpu"`` for this PyTorch build."""
+
+    import torch
+
+    if torch.version.hip is not None:
+        return "amd"
+    if torch.version.cuda is not None:
+        return "nvidia"
+    return "cpu"
+
+
+def target_from_tensor(tensor: Any) -> Target:
+    """Resolve an exact target from a real tensor.
+
+    This performs a device-property query and must not run inside a Dynamo
+    graph. Backend custom-op bodies are the intended call site.
+    """
+
+    import torch
+
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"target_from_tensor expects a torch.Tensor, got {type(tensor)!r}")
+    if tensor.device.type != "cuda":
+        raise ValueError(f"Quack GPU backends require a CUDA/HIP tensor, got {tensor.device}")
+
+    device_index = tensor.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device_index)
+    vendor = vendor_from_torch_build()
+    if vendor == "amd":
+        arch = (getattr(props, "gcnArchName", "") or "").split(":", 1)[0]
+        if not arch:
+            raise RuntimeError(f"could not determine AMD gfx architecture for cuda:{device_index}")
+    elif vendor == "nvidia":
+        major = getattr(props, "major", None)
+        minor = getattr(props, "minor", None)
+        if major is None or minor is None:
+            major, minor = torch.cuda.get_device_capability(device_index)
+        arch = f"sm_{major}{minor}"
+    else:
+        raise RuntimeError("this PyTorch build has neither CUDA nor ROCm support")
+    return Target(vendor=vendor, arch=arch, device_index=device_index)

--- a/quack/dsl/__init__.py
+++ b/quack/dsl/__init__.py
@@ -2,9 +2,16 @@
 
 """CuTe DSL helpers and integration hooks."""
 
-import quack.dsl.cute_tensor_indexing  # noqa: F401
-import quack.dsl.cute_tensor  # noqa: F401
-import quack.dsl.mixed_constexpr_if  # noqa: F401
+import torch
+
+# CuTe helpers are a CUDA-only process-wide initialization. Keeping them out
+# of ROCm imports lets the backend-neutral torch_library_op compatibility path
+# work without NVIDIA dependencies.
+if torch.version.hip is None:
+    import quack.dsl.cute_tensor_indexing  # noqa: F401
+    import quack.dsl.cute_tensor  # noqa: F401
+    import quack.dsl.mixed_constexpr_if  # noqa: F401
+
 from quack.dsl.torch_library_op import cute_op
 
 __all__ = ["cute_op"]

--- a/quack/dsl/torch_library_op.py
+++ b/quack/dsl/torch_library_op.py
@@ -1,99 +1,10 @@
 # Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
-"""``cute_op``: ``torch.library.custom_op`` for CuTe DSL kernels.
+"""Compatibility export for CuTe callers.
 
-Same trick as ``torch.library.triton_op`` (register the impl as the fake/meta
-kernel too), specialized for our setup: the fake is a pure no-op. Our ops
-only mutate their inputs, so Dynamo / AOT autograd need no shape effect from
-the fake, and kernel compilation is owned entirely by ``jit_cache`` (plus
-the async compile pool) at real execution time.
-
-This removes the need for hand-written ``_*_fake`` twins on each op.
-
-Note: we deliberately do NOT gate on ``torch.compiler.is_compiling()`` —
-that flag's underlying ``_is_compiling_flag`` is only set during
-``torch.export``, never during ``torch.compile``. Dynamo's
-``_get_fake_value_impl`` would otherwise run the body and surface
-any ``_compile_*`` ``ValueError`` as a ``TorchRuntimeError`` graph break.
+The implementation is backend-neutral and lives in
+``quack._torch_library_op`` so optional backends do not import ``quack.dsl``.
 """
 
-from __future__ import annotations
-
-import functools
-from typing import Any, Callable, Iterable, Optional, Union
-
-import torch
+from quack._torch_library_op import torch_library_op as cute_op
 
 __all__ = ["cute_op"]
-
-
-def cute_op(
-    name: str,
-    *,
-    mutates_args: Union[str, Iterable[str]],
-    schema: Optional[str] = None,
-    device_types: Optional[Union[str, Iterable[str]]] = None,
-) -> Callable:
-    """Like ``torch.library.triton_op``, but for CuTe DSL kernels.
-
-    Args:
-        name: ``"namespace::op_name"``.
-        mutates_args: Names of mutated tensor args.
-        schema: Optional explicit schema. Required when mutating an
-            ``Optional[Tensor]`` arg (PyTorch can't infer those).
-        device_types: Optional device-type restriction.
-    """
-
-    def dec(fn: Callable) -> Any:
-        kwargs: dict[str, Any] = {"mutates_args": mutates_args}
-        if schema is not None:
-            kwargs["schema"] = schema
-        if device_types is not None:
-            kwargs["device_types"] = device_types
-        op = torch.library.custom_op(name, fn, **kwargs)
-
-        @op.register_fake
-        def _fake(*args, **kw):
-            # Pure no-op: our ops only mutate their input tensors, so under
-            # torch.compile / AOT autograd tracing there is no fake output to
-            # produce, and running the body would pay compile latency at
-            # dynamo trace time (or crash for shape/dtype combos the kernel
-            # intentionally rejects). Kernel compilation is handled by
-            # jit_cache + the async compile pool at real execution time.
-            return
-
-        return _EagerBypassOp(op, fn)
-
-    return dec
-
-
-class _EagerBypassOp:
-    """Callable returned by :func:`cute_op`.
-
-    Eager fast path: the torch.library dispatch + functionalization boundary
-    costs ~60us/call (measured on rmsnorm_fwd, H100) — for these small
-    memory-bound kernels that is often larger than the kernel itself (e.g.
-    rmsnorm 1024x4096: ~10us kernel vs ~125us through the boundary). In eager we
-    call the raw body directly to skip it; under ``torch.compile`` we route to
-    the real op so Dynamo captures it as a graph node (with the no-op fake).
-    ``torch.compiler.is_compiling()`` is constant-folded to True by Dynamo at
-    trace time (torch/_dynamo/variables/torch.py), so the gate is correct under
-    both compile and export. Same trick as ``_launch()`` in gemm_interface.py.
-
-    Attribute access falls through to the underlying ``CustomOpDef`` so
-    post-registration hooks keep working (e.g. ``register_effect``,
-    ``register_autograd``, ``_opoverload``).
-    """
-
-    def __init__(self, op, fn):
-        self._custom_op = op
-        self._init_fn = fn
-        functools.update_wrapper(self, fn)
-
-    def __call__(self, *args, **kwargs):
-        if torch.compiler.is_compiling():
-            return self._custom_op(*args, **kwargs)
-        return self._init_fn(*args, **kwargs)
-
-    def __getattr__(self, name):
-        # Only reached for attrs not set on the instance -> forward to the op.
-        return getattr(self.__dict__["_custom_op"], name)

--- a/quack/rmsnorm_flydsl.py
+++ b/quack/rmsnorm_flydsl.py
@@ -1,0 +1,293 @@
+"""Experimental FlyDSL RMSNorm entry point.
+
+This module intentionally does not import FlyDSL at import time. The compiler
+and Quack-owned kernels are loaded only inside opaque custom-op bodies.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from quack._torch_library_op import torch_library_op
+from quack.backends.flydsl import FLYDSL_INSTALL_HINT
+from quack.backends.flydsl.rmsnorm_config import (
+    get_bwd_workspace_rows,
+    select_bwd_config,
+    select_fwd_config,
+)
+from quack.backends.registry import REGISTRY
+from quack.backends.rmsnorm_spec import normalize_rmsnorm_spec
+from quack.backends.target import Target, target_from_tensor, vendor_from_torch_build
+
+_BUILD_VENDOR = vendor_from_torch_build()
+_PROVIDER = REGISTRY.load_provider("rmsnorm", "amd")
+_FLYDSL_AVAILABLE = _PROVIDER.is_available()
+
+
+def _raise_if_flydsl_unavailable() -> None:
+    if not _FLYDSL_AVAILABLE:
+        raise ModuleNotFoundError(FLYDSL_INSTALL_HINT)
+
+
+def _raise_if_unsupported(spec, target: Target) -> None:
+    support = _PROVIDER.supports(spec, target)
+    if not support:
+        raise NotImplementedError(support.reason)
+
+
+def _runtime_spec(x: Tensor, weight: Tensor, eps: float):
+    return normalize_rmsnorm_spec(x, weight=weight, eps=eps)
+
+
+def _validate_eps(eps: float) -> None:
+    if not math.isfinite(eps) or eps < 0.0:
+        raise ValueError(f"eps must be finite and nonnegative, got {eps}")
+
+
+def _flydsl_compile_target() -> tuple[str, str]:
+    try:
+        from flydsl.compiler.backends import get_backend
+    except ModuleNotFoundError as exc:
+        if exc.name == "flydsl":
+            raise ModuleNotFoundError(FLYDSL_INSTALL_HINT) from None
+        raise
+    target = get_backend().target
+    return target.backend, target.arch.split(":", 1)[0]
+
+
+def _raise_if_compile_target_mismatch(invocation_target: Target) -> None:
+    backend, compile_arch = _flydsl_compile_target()
+    if backend != "rocm":
+        raise RuntimeError(
+            "quack.rmsnorm_flydsl requires FlyDSL's ROCm compile backend; "
+            f"the active backend is {backend!r}"
+        )
+    if compile_arch != invocation_target.arch:
+        raise RuntimeError(
+            "FlyDSL compile target does not match the invocation tensor: "
+            f"FlyDSL will compile for {compile_arch!r}, but the tensor is on "
+            f"{invocation_target.arch!r}. Set ARCH or FLYDSL_GPU_ARCH to the tensor "
+            "architecture. Mixed-architecture execution is disabled until FlyDSL #878 lands."
+        )
+
+
+def _import_fwd_backend():
+    try:
+        from quack.backends.flydsl.rmsnorm_kernel import run_rmsnorm_fwd
+    except ModuleNotFoundError as exc:
+        if exc.name == "flydsl":
+            raise ModuleNotFoundError(FLYDSL_INSTALL_HINT) from None
+        raise
+    return run_rmsnorm_fwd
+
+
+def _import_bwd_backend():
+    try:
+        from quack.backends.flydsl.rmsnorm_bwd_kernel import run_rmsnorm_bwd
+    except ModuleNotFoundError as exc:
+        if exc.name == "flydsl":
+            raise ModuleNotFoundError(FLYDSL_INSTALL_HINT) from None
+        raise
+    return run_rmsnorm_bwd
+
+
+@torch_library_op(
+    "quack::_rmsnorm_flydsl_fwd",
+    mutates_args={"out", "rstd"},
+    device_types="cuda",
+    schema=("(Tensor x, Tensor weight, Tensor(a2!) out, Tensor(a3!) rstd, float eps) -> ()"),
+)
+def _rmsnorm_flydsl_fwd(
+    x: Tensor,
+    weight: Tensor,
+    out: Tensor,
+    rstd: Tensor,
+    eps: float,
+) -> None:
+    """Real custom-op body; device discovery and FlyDSL compilation stay here."""
+
+    _validate_eps(eps)
+    target = target_from_tensor(x)
+    _raise_if_unsupported(_runtime_spec(x, weight, eps), target)
+    _raise_if_compile_target_mismatch(target)
+    if x.numel() == 0:
+        return
+    props = torch.cuda.get_device_properties(target.device_index)
+    config = select_fwd_config(
+        x.shape[0],
+        x.shape[1],
+        x.dtype,
+        weight.dtype,
+        target,
+        props.multi_processor_count,
+    )
+    _import_fwd_backend()(x, weight, out, rstd, eps, target, config)
+
+
+@torch_library_op(
+    "quack::_rmsnorm_flydsl_bwd",
+    mutates_args={"dx", "dweight", "workspace"},
+    device_types="cuda",
+    schema=(
+        "(Tensor x, Tensor weight, Tensor doutput, Tensor rstd, "
+        "Tensor(a4!) dx, Tensor(a5!) dweight, Tensor(a6!) workspace) -> ()"
+    ),
+)
+def _rmsnorm_flydsl_bwd(
+    x: Tensor,
+    weight: Tensor,
+    doutput: Tensor,
+    rstd: Tensor,
+    dx: Tensor,
+    dweight: Tensor,
+    workspace: Tensor,
+) -> None:
+    """Real backward body with runtime atomic/two-stage path selection."""
+
+    target = target_from_tensor(x)
+    _raise_if_unsupported(_runtime_spec(x, weight, 0.0), target)
+    _raise_if_compile_target_mismatch(target)
+    if x.numel() == 0:
+        return
+    props = torch.cuda.get_device_properties(target.device_index)
+    config = select_bwd_config(
+        x.shape[0],
+        x.shape[1],
+        x.dtype,
+        weight.dtype,
+        target,
+        props.multi_processor_count,
+    )
+    _import_bwd_backend()(
+        x,
+        weight,
+        doutput,
+        rstd,
+        dx,
+        dweight,
+        workspace,
+        target,
+        config,
+    )
+
+
+class RMSNormFunction(torch.autograd.Function):
+    """Autograd boundary for already-flattened contiguous tensors."""
+
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor, eps: float):
+        out = torch.empty_like(x)
+        rstd = torch.empty(x.shape[0], device=x.device, dtype=torch.float32)
+        _rmsnorm_flydsl_fwd(x, weight, out, rstd, eps)
+        ctx.save_for_backward(x, weight, rstd)
+        return out
+
+    @staticmethod
+    def backward(ctx, doutput: Tensor):
+        x, weight, rstd = ctx.saved_tensors
+        doutput = doutput.contiguous()
+        dx = torch.empty_like(x)
+        dweight = torch.zeros_like(weight, dtype=torch.float32)
+        m, n = x.shape
+        workspace_rows = get_bwd_workspace_rows(m, n, x.dtype)
+        workspace = torch.empty(
+            workspace_rows * n,
+            device=x.device,
+            dtype=torch.float32,
+        )
+        _rmsnorm_flydsl_bwd(
+            x,
+            weight,
+            doutput,
+            rstd,
+            dx,
+            dweight,
+            workspace,
+        )
+        return dx, dweight, None
+
+
+def _contiguous_for_backend(tensor: Tensor, name: str) -> Tensor:
+    if torch.compiler.is_compiling():
+        return tensor.contiguous()
+    if not tensor.is_contiguous():
+        raise ValueError(f"FlyDSL RMSNorm requires contiguous {name}")
+    return tensor
+
+
+def rmsnorm(
+    x: Tensor,
+    weight: Optional[Tensor] = None,
+    bias: Optional[Tensor] = None,
+    residual: Optional[Tensor] = None,
+    out_dtype: Optional[torch.dtype] = None,
+    residual_dtype: Optional[torch.dtype] = None,
+    eps: float = 1e-6,
+    prenorm: bool = False,
+    weight_offset: float = 0.0,
+) -> Tensor:
+    """Plain weighted RMSNorm on gfx942/gfx950 through FlyDSL.
+
+    This explicit entry remains available alongside the public
+    ``quack.rmsnorm`` backend dispatch.
+    """
+
+    if _BUILD_VENDOR != "amd":
+        raise RuntimeError(
+            "quack.rmsnorm_flydsl requires a ROCm PyTorch build; "
+            f"detected build vendor {_BUILD_VENDOR!r}"
+        )
+    _raise_if_flydsl_unavailable()
+    if not isinstance(x, Tensor):
+        raise TypeError(f"x must be a torch.Tensor, got {type(x)!r}")
+    if x.device.type != "cuda":
+        raise ValueError(f"FlyDSL RMSNorm requires a HIP tensor, got {x.device}")
+    if x.dim() == 0:
+        raise ValueError("FlyDSL RMSNorm input must have at least one dimension")
+    if x.shape[-1] == 0:
+        raise ValueError("FlyDSL RMSNorm normalized dimension must be nonzero")
+
+    spec = normalize_rmsnorm_spec(
+        x,
+        weight=weight,
+        bias=bias,
+        residual=residual,
+        out_dtype=out_dtype,
+        residual_dtype=residual_dtype,
+        eps=eps,
+        prenorm=prenorm,
+        weight_offset=weight_offset,
+    )
+    _raise_if_unsupported(
+        spec,
+        Target(vendor=_BUILD_VENDOR, arch="unknown", device_index=-1),
+    )
+    if weight.dim() != 1:
+        raise ValueError(f"FlyDSL RMSNorm weight must be 1D, got shape {tuple(weight.shape)}")
+    if weight.shape[0] != x.shape[-1]:
+        raise ValueError(
+            f"x last dimension ({x.shape[-1]}) must match weight length ({weight.shape[0]})"
+        )
+    if weight.device != x.device:
+        raise ValueError(f"x and weight must share a device, got {x.device} and {weight.device}")
+    # Dynamo can represent a non-default scalar argument as SymFloat, but
+    # ``math.isfinite(SymFloat)`` returns a Python bool that cannot enter an FX
+    # graph. The eager check still provides the public diagnostic; compiled
+    # execution passes the runtime epsilon through the opaque custom op.
+    if not torch.compiler.is_compiling():
+        _validate_eps(spec.eps)
+
+    original_shape = x.shape
+    n = original_shape[-1]
+    x = _contiguous_for_backend(x, "input")
+    weight = _contiguous_for_backend(weight, "weight")
+    x_flat = x.reshape(-1, n)
+    out_flat = RMSNormFunction.apply(x_flat, weight, spec.eps)
+    return out_flat.reshape(original_shape)
+
+
+__all__ = ["RMSNormFunction", "rmsnorm"]

--- a/tests/test_benchmark_rmsnorm_flydsl.py
+++ b/tests/test_benchmark_rmsnorm_flydsl.py
@@ -1,0 +1,48 @@
+"""Non-GPU contracts for FlyDSL RMSNorm benchmark timing."""
+
+import pytest
+
+from benchmarks import benchmark_rmsnorm_flydsl as benchmark
+
+
+def test_dispatch_latency_is_batched_synchronized_wall_time(monkeypatch):
+    calls = []
+    synchronizations = []
+    timestamps = iter((10.0, 10.004))
+
+    monkeypatch.setattr(
+        benchmark.torch.cuda,
+        "synchronize",
+        lambda: synchronizations.append("sync"),
+    )
+    monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(timestamps))
+
+    latency_us = benchmark._dispatch_latency_us(
+        lambda: calls.append("call"),
+        warmup=2,
+        iterations=4,
+    )
+
+    assert latency_us == pytest.approx(1000.0)
+    assert calls == ["call"] * 6
+    assert synchronizations == ["sync", "sync"]
+
+
+def test_dispatch_metrics_are_explicitly_labeled():
+    results = []
+    benchmark._record(
+        results,
+        "flydsl",
+        "hot_cache_forward_dispatch_latency",
+        1.25,
+        "us",
+    )
+    assert results == [
+        {
+            "provider": "flydsl",
+            "metric": "hot_cache_forward_dispatch_latency",
+            "value": 1.25,
+            "unit": "us",
+            "timing": "batched_synchronized_wall_clock",
+        }
+    ]

--- a/tests/test_rmsnorm_dispatch.py
+++ b/tests/test_rmsnorm_dispatch.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, Dao-AILab.
+"""Focused tests for public CUDA/ROCm RMSNorm binding."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def test_public_rocm_binding_is_import_isolated():
+    repo_root = Path(__file__).resolve().parents[1]
+    code = """
+import sys
+import torch
+if torch.version.hip is None:
+    raise SystemExit(0)
+def unexpected_device_query(*args, **kwargs):
+    raise AssertionError("exact target discovery ran while binding the provider")
+torch.cuda.get_device_properties = unexpected_device_query
+import quack
+public_rmsnorm = quack.rmsnorm
+assert public_rmsnorm.__module__ == "quack.rmsnorm_flydsl"
+assert "quack.backends.flydsl.rmsnorm_provider" in sys.modules
+assert "quack.backends.cute.rmsnorm_provider" not in sys.modules
+assert "quack.dsl" not in sys.modules
+assert "cutlass" not in sys.modules
+assert "flydsl" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], cwd=repo_root, check=True)
+
+
+def test_cuda_initialization_exports_and_direct_imports():
+    repo_root = Path(__file__).resolve().parents[1]
+    code = """
+import importlib
+import os
+import sys
+import types
+import torch
+
+torch.version.hip = None
+torch.version.cuda = "13.0"
+
+patch_calls = []
+dsl = types.ModuleType("quack.dsl")
+dsl.__path__ = []
+ptxas = types.ModuleType("quack.dsl.cute_dsl_ptxas")
+ptxas.patch = lambda: patch_calls.append("patched")
+dsl.cute_dsl_ptxas = ptxas
+sys.modules["quack.dsl"] = dsl
+sys.modules["quack.dsl.cute_dsl_ptxas"] = ptxas
+
+rmsnorm = lambda *args, **kwargs: "rmsnorm"
+softmax = lambda *args, **kwargs: "softmax"
+cross_entropy = lambda *args, **kwargs: "cross_entropy"
+class RoundingMode:
+    pass
+
+legacy_rmsnorm = types.ModuleType("quack.rmsnorm")
+legacy_rmsnorm.rmsnorm = rmsnorm
+legacy_rmsnorm.rmsnorm_fwd = object()
+sys.modules["quack.rmsnorm"] = legacy_rmsnorm
+
+for module_name, attr_name, value in (
+    ("quack.softmax", "softmax", softmax),
+    ("quack.cross_entropy", "cross_entropy", cross_entropy),
+    ("quack.rounding", "RoundingMode", RoundingMode),
+):
+    module = types.ModuleType(module_name)
+    setattr(module, attr_name, value)
+    sys.modules[module_name] = module
+
+os.environ["CUTE_DSL_PTXAS_PATH"] = "/tmp/fake-ptxas"
+import quack
+assert patch_calls == ["patched"]
+assert quack.rmsnorm is rmsnorm and callable(quack.rmsnorm)
+assert quack.softmax is softmax and callable(quack.softmax)
+assert quack.cross_entropy is cross_entropy and callable(quack.cross_entropy)
+assert quack.RoundingMode is RoundingMode
+
+# Direct submodule imports must not replace callable package exports.
+for module_name in ("quack.rmsnorm", "quack.softmax", "quack.cross_entropy"):
+    importlib.import_module(module_name)
+from quack.rmsnorm import rmsnorm_fwd
+from quack import cross_entropy as public_cross_entropy
+from quack import rmsnorm as public_rmsnorm
+from quack import softmax as public_softmax
+assert public_rmsnorm is rmsnorm
+assert not isinstance(public_rmsnorm, types.ModuleType)
+assert rmsnorm_fwd is legacy_rmsnorm.rmsnorm_fwd
+assert public_softmax is softmax
+assert public_cross_entropy is cross_entropy
+assert "flydsl" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], cwd=repo_root, check=True)
+
+
+def test_provider_binding_failures_are_not_swallowed():
+    repo_root = Path(__file__).resolve().parents[1]
+    code = """
+import sys
+import types
+import torch
+torch.version.hip = "7.2"
+torch.version.cuda = None
+class ProviderLoadFailure(RuntimeError):
+    pass
+provider = types.ModuleType("quack.backends.flydsl.rmsnorm_provider")
+provider.is_available = lambda: True
+provider.supports = lambda spec, target: True
+def fail():
+    raise ProviderLoadFailure("provider load failed")
+provider.load_op = fail
+sys.modules["quack.backends.flydsl.rmsnorm_provider"] = provider
+import quack
+try:
+    quack.rmsnorm
+except ProviderLoadFailure as exc:
+    assert str(exc) == "provider load failed"
+else:
+    raise AssertionError("provider load failure was swallowed")
+"""
+    subprocess.run([sys.executable, "-c", code], cwd=repo_root, check=True)
+
+
+@pytest.fixture
+def rocm_device():
+    available = (
+        torch.version.hip is not None
+        and torch.cuda.is_available()
+        and importlib.util.find_spec("flydsl") is not None
+    )
+    if not available:
+        pytest.skip("requires ROCm PyTorch and FlyDSL")
+    device = torch.device("cuda", torch.cuda.current_device())
+    arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+    if arch not in {"gfx942", "gfx950"}:
+        pytest.skip(f"unsupported FlyDSL RMSNorm architecture: {arch}")
+    return device
+
+
+def test_public_rocm_fullgraph_and_diagnostics(rocm_device):
+    from quack import rmsnorm as public_rmsnorm
+    from quack.rmsnorm_flydsl import rmsnorm as explicit_rmsnorm
+
+    assert public_rmsnorm is explicit_rmsnorm
+
+    x = torch.randn(3, 65, device=rocm_device, dtype=torch.float16, requires_grad=True)
+    weight = torch.randn(
+        65,
+        device=rocm_device,
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+    out = torch.compile(public_rmsnorm, fullgraph=True)(x, weight, eps=3e-5)
+    grad = torch.randn_like(out)
+    dx, dweight = torch.autograd.grad(out, (x, weight), grad)
+    x_ref = x.detach().clone().requires_grad_()
+    weight_ref = weight.detach().clone().requires_grad_()
+    out_ref = torch.nn.functional.rms_norm(x_ref, (65,), weight_ref, 3e-5)
+    dx_ref, dweight_ref = torch.autograd.grad(out_ref, (x_ref, weight_ref), grad)
+    torch.testing.assert_close(out, out_ref, atol=3e-2, rtol=2e-2)
+    torch.testing.assert_close(dx, dx_ref, atol=3e-2, rtol=2e-2)
+    torch.testing.assert_close(dweight, dweight_ref, atol=6e-2, rtol=3e-2)
+    with pytest.raises(NotImplementedError, match="bias"):
+        public_rmsnorm(x, weight, bias=torch.zeros_like(weight))
+
+
+@pytest.mark.skipif(
+    torch.version.hip is not None or not torch.cuda.is_available(),
+    reason="requires CUDA PyTorch",
+)
+def test_public_cuda_preserves_legacy_behavior():
+    from quack.rmsnorm import rmsnorm as direct_rmsnorm
+    from quack import rmsnorm as public_rmsnorm
+
+    assert "flydsl" not in sys.modules
+    assert public_rmsnorm is direct_rmsnorm
+    x = torch.randn(4, 65, device="cuda", dtype=torch.float16)
+    weight = torch.randn(65, device="cuda", dtype=torch.float32)
+    torch.testing.assert_close(
+        public_rmsnorm(x, weight, eps=1e-5),
+        direct_rmsnorm(x, weight, eps=1e-5),
+    )

--- a/tests/test_rmsnorm_flydsl.py
+++ b/tests/test_rmsnorm_flydsl.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2026, Dao-AILab.
+"""Focused boundary and smoke tests for the experimental FlyDSL RMSNorm."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from quack._torch_library_op import torch_library_op
+from quack.backends.flydsl import rmsnorm_provider
+from quack.backends.flydsl.rmsnorm_config import (
+    ATOMIC,
+    TWO_STAGE,
+    get_bwd_workspace_rows,
+    select_bwd_config,
+    select_fwd_config,
+)
+from quack.backends.protocol import Support
+from quack.backends.target import Target
+
+torch._dynamo.config.cache_size_limit = 1024
+torch._dynamo.config.accumulated_cache_size_limit = 1024
+
+
+def test_backend_neutral_custom_op_is_opaque_under_compile():
+    call_log = []
+
+    @torch_library_op(
+        "quack_test_flydsl_boundary::copy",
+        mutates_args={"out"},
+        schema="(Tensor x, Tensor(a1!) out) -> ()",
+    )
+    def copy_impl(x, out):
+        call_log.append(tuple(x.shape))
+        out.copy_(x)
+
+    @torch.compile(fullgraph=True)
+    def compiled_copy(x):
+        out = torch.empty_like(x)
+        copy_impl(x, out)
+        return out
+
+    x = torch.randn(4, 8)
+    torch.testing.assert_close(compiled_copy(x), x)
+    assert call_log == [(4, 8)]
+
+
+def test_opaque_custom_ops_preserve_autograd_under_compile():
+    call_log = []
+
+    @torch_library_op(
+        "quack_test_flydsl_boundary::rmsnorm_fwd",
+        mutates_args={"out", "rstd"},
+        schema=("(Tensor x, Tensor weight, Tensor(a2!) out, Tensor(a3!) rstd, float eps) -> ()"),
+    )
+    def fwd_impl(x, weight, out, rstd, eps):
+        call_log.append("forward")
+        row_rstd = torch.rsqrt(x.float().square().mean(dim=-1) + eps)
+        rstd.copy_(row_rstd)
+        out.copy_((x.float() * row_rstd[:, None] * weight).to(x.dtype))
+
+    @torch_library_op(
+        "quack_test_flydsl_boundary::rmsnorm_bwd",
+        mutates_args={"dx", "dweight"},
+        schema=(
+            "(Tensor x, Tensor weight, Tensor doutput, Tensor rstd, "
+            "Tensor(a4!) dx, Tensor(a5!) dweight) -> ()"
+        ),
+    )
+    def bwd_impl(x, weight, doutput, rstd, dx, dweight):
+        call_log.append("backward")
+        x_hat = x.float() * rstd[:, None]
+        weighted_grad = doutput.float() * weight
+        coefficient = (x_hat * weighted_grad).mean(dim=-1, keepdim=True)
+        dx.copy_(((weighted_grad - x_hat * coefficient) * rstd[:, None]).to(x.dtype))
+        dweight.copy_((doutput.float() * x_hat).sum(dim=0))
+
+    class OpaqueRMSNorm(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, weight, eps):
+            out = torch.empty_like(x)
+            rstd = torch.empty(x.shape[0], dtype=torch.float32)
+            torch.ops.quack_test_flydsl_boundary.rmsnorm_fwd.default(
+                x,
+                weight,
+                out,
+                rstd,
+                eps,
+            )
+            ctx.save_for_backward(x, weight, rstd)
+            return out
+
+        @staticmethod
+        def backward(ctx, doutput):
+            x, weight, rstd = ctx.saved_tensors
+            dx = torch.empty_like(x)
+            dweight = torch.empty_like(weight)
+            torch.ops.quack_test_flydsl_boundary.rmsnorm_bwd.default(
+                x,
+                weight,
+                doutput,
+                rstd,
+                dx,
+                dweight,
+            )
+            return dx, dweight, None
+
+    @torch.compile(fullgraph=True)
+    def compiled_rmsnorm(x, weight):
+        shape = x.shape
+        return OpaqueRMSNorm.apply(x.reshape(-1, shape[-1]), weight, 1e-5).reshape(shape)
+
+    x = torch.randn(2, 3, 17, dtype=torch.float16, requires_grad=True)
+    weight = torch.randn(17, dtype=torch.float32, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_()
+    weight_ref = weight.detach().clone().requires_grad_()
+    grad = torch.randn_like(x)
+
+    out = compiled_rmsnorm(x, weight)
+    dx, dweight = torch.autograd.grad(out, (x, weight), grad)
+    out_ref = torch.nn.functional.rms_norm(x_ref, (17,), weight_ref, 1e-5)
+    dx_ref, dweight_ref = torch.autograd.grad(out_ref, (x_ref, weight_ref), grad)
+
+    torch.testing.assert_close(out, out_ref)
+    torch.testing.assert_close(dx, dx_ref)
+    torch.testing.assert_close(dweight, dweight_ref)
+    assert call_log == ["forward", "backward"]
+
+
+def test_package_and_flydsl_entry_imports_are_isolated():
+    repo_root = Path(__file__).resolve().parents[1]
+    code = """
+import sys
+import torch
+torch.version.hip = "7.2"
+torch.version.cuda = None
+import quack
+assert callable(quack.rmsnorm)
+assert quack.rmsnorm.__module__ == "quack.rmsnorm_flydsl"
+assert "quack.rmsnorm" not in sys.modules
+assert "quack.backends.cute.rmsnorm_provider" not in sys.modules
+assert "quack.dsl" not in sys.modules
+assert "cutlass" not in sys.modules
+assert "flydsl" not in sys.modules
+from quack.rmsnorm_flydsl import rmsnorm as explicit_rmsnorm
+assert explicit_rmsnorm is quack.rmsnorm
+assert "quack.dsl" not in sys.modules
+assert "cutlass" not in sys.modules
+assert "flydsl" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], cwd=repo_root, check=True)
+
+
+def test_cute_op_compatibility_reexport_is_preserved():
+    repo_root = Path(__file__).resolve().parents[1]
+    code = """
+import os
+import sys
+import types
+import torch
+
+os.environ.pop("CUTE_DSL_PTXAS_PATH", None)
+torch.version.hip = "7.2"
+torch.version.cuda = None
+for name in (
+    "quack.dsl.cute_tensor_indexing",
+    "quack.dsl.cute_tensor",
+    "quack.dsl.mixed_constexpr_if",
+):
+    sys.modules[name] = types.ModuleType(name)
+
+from quack._torch_library_op import torch_library_op
+from quack.dsl import cute_op
+from quack.dsl.torch_library_op import cute_op as compatibility_cute_op
+
+assert cute_op is torch_library_op
+assert compatibility_cute_op is torch_library_op
+assert "cutlass" not in sys.modules
+assert "flydsl" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], cwd=repo_root, check=True)
+
+
+def test_registry_loads_only_the_selected_provider():
+    code = """
+import sys
+from quack.backends.protocol import BackendProvider
+from quack.backends.registry import REGISTRY
+provider = REGISTRY.load_provider("rmsnorm", "amd")
+assert provider.__name__ == "quack.backends.flydsl.rmsnorm_provider"
+assert isinstance(provider, BackendProvider)
+assert "quack.backends.cute.rmsnorm_provider" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_missing_flydsl_has_install_hint(monkeypatch):
+    import quack.rmsnorm_flydsl as module
+
+    monkeypatch.setattr(module, "_BUILD_VENDOR", "amd")
+    monkeypatch.setattr(module, "_FLYDSL_AVAILABLE", False)
+    with pytest.raises(ModuleNotFoundError, match=r"quack-kernels\[rocm\]"):
+        module.rmsnorm(torch.empty(1))
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"has_weight": False}, "explicit weight"),
+        ({"has_bias": True}, "support bias"),
+        ({"has_residual": True}, "residual fusion"),
+        ({"prenorm": True}, "prenorm"),
+        ({"per_head": True}, "per-head"),
+        ({"out_dtype": torch.float16}, "out_dtype"),
+        ({"residual_dtype": torch.float32}, "residual_dtype"),
+        ({"weight_offset": 1.0}, "weight_offset"),
+    ],
+)
+def test_flydsl_provider_reports_unsupported_features(override, message):
+    fields = {
+        "has_weight": True,
+        "has_bias": False,
+        "has_residual": False,
+        "prenorm": False,
+        "per_head": False,
+        "out_dtype": None,
+        "residual_dtype": None,
+        "weight_offset": 0.0,
+        "input_dtype": torch.float16,
+        "weight_dtype": torch.float32,
+    }
+    fields.update(override)
+    decision = rmsnorm_provider.supports(
+        SimpleNamespace(**fields),
+        Target(vendor="amd", arch="gfx950", device_index=0),
+    )
+    assert isinstance(decision, Support)
+    assert not decision
+    assert message in decision.reason
+
+
+@pytest.mark.parametrize("arch", ["gfx942", "gfx950"])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [torch.float16, torch.bfloat16, torch.float32],
+)
+def test_fp32_weight_and_supported_arch_contracts_without_hardware(arch, input_dtype):
+    spec = SimpleNamespace(
+        has_weight=True,
+        has_bias=False,
+        has_residual=False,
+        prenorm=False,
+        per_head=False,
+        out_dtype=None,
+        residual_dtype=None,
+        weight_offset=0.0,
+        input_dtype=input_dtype,
+        weight_dtype=torch.float32,
+    )
+    target = Target(vendor="amd", arch=arch, device_index=0)
+    assert rmsnorm_provider.supports(spec, target)
+    assert (
+        select_fwd_config(
+            1024,
+            4096,
+            input_dtype,
+            torch.float32,
+            target,
+            304 if arch == "gfx942" else 256,
+        ).block_threads
+        == 256
+    )
+
+
+def test_non_fp32_weight_has_precise_reason():
+    spec = SimpleNamespace(
+        has_weight=True,
+        has_bias=False,
+        has_residual=False,
+        prenorm=False,
+        per_head=False,
+        out_dtype=None,
+        residual_dtype=None,
+        weight_offset=0.0,
+        input_dtype=torch.float16,
+        weight_dtype=torch.float16,
+    )
+    decision = rmsnorm_provider.supports(
+        spec,
+        Target(vendor="amd", arch="gfx942", device_index=0),
+    )
+    assert not decision
+    assert "FP32 weight" in decision.reason
+
+
+def test_unsupported_arch_has_precise_reason():
+    spec = SimpleNamespace(
+        has_weight=True,
+        has_bias=False,
+        has_residual=False,
+        prenorm=False,
+        per_head=False,
+        out_dtype=None,
+        residual_dtype=None,
+        weight_offset=0.0,
+        input_dtype=torch.float32,
+        weight_dtype=torch.float32,
+    )
+    decision = rmsnorm_provider.supports(
+        spec,
+        Target(vendor="amd", arch="gfx1100", device_index=0),
+    )
+    assert not decision
+    assert "gfx942 and gfx950" in decision.reason
+    assert "gfx1100" in decision.reason
+
+
+@pytest.mark.parametrize("direction", ["forward", "backward"])
+def test_custom_ops_reject_compile_target_mismatch(monkeypatch, direction):
+    import quack.rmsnorm_flydsl as module
+
+    invocation_target = Target(vendor="amd", arch="gfx950", device_index=0)
+    monkeypatch.setattr(module, "target_from_tensor", lambda tensor: invocation_target)
+    monkeypatch.setattr(module, "_flydsl_compile_target", lambda: ("rocm", "gfx942"))
+
+    x = torch.randn(2, 4)
+    weight = torch.randn(4, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="compile for 'gfx942'.*tensor is on 'gfx950'"):
+        if direction == "forward":
+            module._rmsnorm_flydsl_fwd._init_fn(
+                x,
+                weight,
+                torch.empty_like(x),
+                torch.empty(2, dtype=torch.float32),
+                1e-6,
+            )
+        else:
+            module._rmsnorm_flydsl_bwd._init_fn(
+                x,
+                weight,
+                torch.randn_like(x),
+                torch.ones(2, dtype=torch.float32),
+                torch.empty_like(x),
+                torch.empty_like(weight),
+                torch.empty(0, dtype=torch.float32),
+            )
+
+
+@pytest.mark.parametrize("arch,cu_count", [("gfx942", 304), ("gfx950", 256)])
+def test_backward_selector_contracts_without_hardware(arch, cu_count):
+    target = Target(vendor="amd", arch=arch, device_index=0)
+    atomic = select_bwd_config(
+        32,
+        4096,
+        torch.bfloat16,
+        torch.float32,
+        target,
+        cu_count,
+    )
+    staged = select_bwd_config(
+        4096,
+        4096,
+        torch.bfloat16,
+        torch.float32,
+        target,
+        cu_count,
+    )
+    assert atomic.path == ATOMIC
+    assert atomic.num_programs == 0
+    assert staged.path == TWO_STAGE
+    workspace_rows = get_bwd_workspace_rows(4096, 4096, torch.bfloat16)
+    assert 0 < staged.num_programs <= workspace_rows
+
+
+def test_flydsl_custom_ops_have_noop_fake_implementations():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    import quack.rmsnorm_flydsl as module
+
+    with FakeTensorMode():
+        x = torch.empty(2, 17, device="cuda", dtype=torch.float16)
+        weight = torch.empty(17, device="cuda", dtype=torch.float32)
+        out = torch.empty_like(x)
+        rstd = torch.empty(2, device="cuda", dtype=torch.float32)
+        module._rmsnorm_flydsl_fwd._custom_op(x, weight, out, rstd, 1e-6)
+        doutput = torch.empty_like(x)
+        dx = torch.empty_like(x)
+        dweight = torch.empty_like(weight)
+        workspace = torch.empty(0, device="cuda", dtype=torch.float32)
+        module._rmsnorm_flydsl_bwd._custom_op(
+            x,
+            weight,
+            doutput,
+            rstd,
+            dx,
+            dweight,
+            workspace,
+        )
+
+
+@pytest.mark.parametrize("eps", [-1.0, float("inf"), float("-inf"), float("nan")])
+def test_opaque_forward_rejects_invalid_eps_before_launch(eps):
+    import quack.rmsnorm_flydsl as module
+
+    x = torch.randn(2, 4)
+    weight = torch.randn(4, dtype=torch.float32)
+    with pytest.raises(ValueError, match="eps must be finite and nonnegative"):
+        module._rmsnorm_flydsl_fwd._init_fn(
+            x,
+            weight,
+            torch.empty_like(x),
+            torch.empty(2, dtype=torch.float32),
+            eps,
+        )
+
+
+def _flydsl_rocm_available() -> bool:
+    return (
+        torch.version.hip is not None
+        and torch.cuda.is_available()
+        and importlib.util.find_spec("flydsl") is not None
+    )
+
+
+@pytest.fixture
+def rocm_device():
+    if not _flydsl_rocm_available():
+        pytest.skip("requires ROCm PyTorch and FlyDSL")
+    device = torch.device("cuda", torch.cuda.current_device())
+    arch = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+    if arch not in {"gfx942", "gfx950"}:
+        pytest.skip(f"unsupported FlyDSL RMSNorm architecture: {arch}")
+    expected_arch = os.environ.get("QUACK_EXPECTED_GFX")
+    if expected_arch is not None:
+        assert arch == expected_arch, f"runner exposed {arch}, expected {expected_arch}"
+    return device
+
+
+def _tolerances(dtype, flattened_rows):
+    if dtype == torch.float32:
+        return 8e-4, max(2e-3, 2e-4 * math.sqrt(flattened_rows))
+    if dtype == torch.float16:
+        return 3e-2, max(5e-2, 2e-3 * math.sqrt(flattened_rows))
+    return 1e-1, max(2e-1, 5e-3 * math.sqrt(flattened_rows))
+
+
+def _assert_forward_backward(shape, dtype, eps, use_compile, device):
+    from quack.rmsnorm_flydsl import rmsnorm
+
+    torch.manual_seed(0)
+    n = shape[-1]
+    flattened_rows = math.prod(shape[:-1]) if len(shape) > 1 else 1
+    x = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+    weight = torch.randn(n, device=device, dtype=torch.float32, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_()
+    weight_ref = weight.detach().clone().requires_grad_()
+    fn = torch.compile(rmsnorm, fullgraph=True) if use_compile else rmsnorm
+
+    out = fn(x, weight, eps=eps)
+    out_ref = torch.nn.functional.rms_norm(x_ref, (n,), weight_ref, eps)
+    grad = torch.randn_like(out)
+    out.backward(grad)
+    out_ref.backward(grad)
+
+    tensor_atol, weight_atol = _tolerances(dtype, flattened_rows)
+    assert out.shape == x.shape
+    assert out.dtype == x.dtype
+    torch.testing.assert_close(out, out_ref, atol=tensor_atol, rtol=2e-2)
+    torch.testing.assert_close(x.grad, x_ref.grad, atol=tensor_atol, rtol=2e-2)
+    torch.testing.assert_close(weight.grad, weight_ref.grad, atol=weight_atol, rtol=3e-2)
+
+
+@pytest.mark.parametrize("use_compile", [False, True])
+@pytest.mark.parametrize(
+    "shape,dtype,eps",
+    [
+        ((1, 1), torch.float16, 0.0),
+        ((7, 65), torch.float32, 1e-6),
+        ((2, 3, 257), torch.float16, 3e-5),
+        ((5, 129), torch.bfloat16, 1e-2),
+        ((2048, 1024), torch.bfloat16, 1e-5),
+    ],
+)
+def test_rmsnorm_flydsl_forward_backward(rocm_device, use_compile, shape, dtype, eps):
+    _assert_forward_backward(shape, dtype, eps, use_compile, rocm_device)
+
+
+@pytest.mark.parametrize("use_compile", [False, True])
+@pytest.mark.parametrize("eps", [-1.0, float("inf"), float("-inf"), float("nan")])
+def test_invalid_eps_fails_before_kernel_launch(rocm_device, use_compile, eps):
+    from quack.rmsnorm_flydsl import rmsnorm
+
+    x = torch.randn(2, 17, device=rocm_device, dtype=torch.float16)
+    weight = torch.randn(17, device=rocm_device, dtype=torch.float32)
+    fn = torch.compile(rmsnorm, fullgraph=True) if use_compile else rmsnorm
+    with pytest.raises(ValueError, match="eps must be finite and nonnegative"):
+        fn(x, weight, eps=eps)
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("missing_weight", "explicit weight"),
+        ("bias", "support bias"),
+        ("residual", "residual fusion"),
+        ("prenorm", "prenorm"),
+        ("per_head", "per-head"),
+        ("out_dtype", "out_dtype"),
+        ("residual_dtype", "residual_dtype"),
+        ("weight_offset", "weight_offset"),
+        ("input_dtype", "input dtype"),
+        ("weight_dtype", "FP32 weight"),
+    ],
+)
+def test_public_api_reports_unsupported_features(rocm_device, case, message):
+    from quack.rmsnorm_flydsl import rmsnorm
+
+    x = torch.randn(2, 17, device=rocm_device, dtype=torch.float16)
+    weight = torch.randn(17, device=rocm_device, dtype=torch.float32)
+    kwargs = {"weight": weight}
+    if case == "missing_weight":
+        kwargs["weight"] = None
+    elif case == "bias":
+        kwargs["bias"] = torch.randn_like(weight)
+    elif case == "residual":
+        kwargs["residual"] = torch.randn_like(x)
+    elif case == "prenorm":
+        kwargs["prenorm"] = True
+    elif case == "per_head":
+        kwargs["weight"] = torch.randn(2, 17, device=rocm_device, dtype=torch.float32)
+    elif case == "out_dtype":
+        kwargs["out_dtype"] = torch.float32
+    elif case == "residual_dtype":
+        kwargs["residual_dtype"] = torch.float32
+    elif case == "weight_offset":
+        kwargs["weight_offset"] = 1.0
+    elif case == "input_dtype":
+        x = x.double()
+    elif case == "weight_dtype":
+        kwargs["weight"] = weight.half()
+
+    with pytest.raises(NotImplementedError, match=message):
+        rmsnorm(x, **kwargs)
+
+
+def test_runtime_eps_and_compiled_cache_reuse(rocm_device, monkeypatch):
+    from quack.backends.flydsl import rmsnorm_bwd_kernel, rmsnorm_kernel
+    from quack.rmsnorm_flydsl import rmsnorm
+
+    rmsnorm_kernel._FWD_CACHE.clear()
+    rmsnorm_bwd_kernel._BWD_CACHE.clear()
+    counts = {"forward": 0, "backward": 0}
+    original_fwd = rmsnorm_kernel.build_rmsnorm_fwd_module
+    original_bwd = rmsnorm_bwd_kernel.build_rmsnorm_bwd_atomic_module
+
+    def counted_fwd(*args, **kwargs):
+        counts["forward"] += 1
+        return original_fwd(*args, **kwargs)
+
+    def counted_bwd(*args, **kwargs):
+        counts["backward"] += 1
+        return original_bwd(*args, **kwargs)
+
+    monkeypatch.setattr(rmsnorm_kernel, "build_rmsnorm_fwd_module", counted_fwd)
+    monkeypatch.setattr(rmsnorm_bwd_kernel, "build_rmsnorm_bwd_atomic_module", counted_bwd)
+    compiled = torch.compile(rmsnorm, fullgraph=True)
+    weight = torch.randn(65, device=rocm_device, dtype=torch.float32, requires_grad=True)
+    for m, eps in ((3, 1e-6), (11, 1e-2)):
+        x = torch.randn(
+            m,
+            65,
+            device=rocm_device,
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+        out = compiled(x, weight, eps=eps)
+        expected = torch.nn.functional.rms_norm(x.detach(), (65,), weight.detach(), eps)
+        torch.testing.assert_close(out, expected, atol=8e-4, rtol=2e-2)
+        out.sum().backward()
+        weight.grad = None
+
+    assert counts == {"forward": 1, "backward": 1}
+
+
+def test_non_default_streams_use_per_call_staged_workspaces(rocm_device):
+    from quack.rmsnorm_flydsl import rmsnorm
+
+    torch.manual_seed(0)
+    streams = [torch.cuda.Stream(device=rocm_device) for _ in range(2)]
+    cases = []
+    for seed, stream in enumerate(streams):
+        torch.manual_seed(seed)
+        x = torch.randn(
+            512,
+            257,
+            device=rocm_device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        weight = torch.randn(
+            257,
+            device=rocm_device,
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+        grad = torch.randn_like(x)
+        checks_host = torch.empty(3, dtype=torch.bool, pin_memory=True)
+        cases.append((stream, x, weight, grad, checks_host))
+
+    # Compile both paths and finish all input initialization before deliberately
+    # blocking the default stream.
+    warm_x = cases[0][1].detach().clone().requires_grad_()
+    warm_weight = cases[0][2].detach().clone().requires_grad_()
+    warm_out = rmsnorm(warm_x, warm_weight, eps=1e-5)
+    warm_dx, warm_dweight = torch.autograd.grad(
+        warm_out,
+        (warm_x, warm_weight),
+        cases[0][3],
+    )
+    torch.cuda.synchronize(rocm_device)
+
+    default_stream = torch.cuda.current_stream(rocm_device)
+    default_finished = torch.cuda.Event()
+    torch.cuda._sleep(int(2e9))
+    default_finished.record(default_stream)
+
+    completions = []
+    for stream, x, weight, grad, checks_host in cases:
+        with torch.cuda.stream(stream):
+            out = rmsnorm(x, weight, eps=1e-5)
+            dx, dweight = torch.autograd.grad(out, (x, weight), grad)
+            out_ref = torch.nn.functional.rms_norm(x, (257,), weight, 1e-5)
+            dx_ref, dweight_ref = torch.autograd.grad(out_ref, (x, weight), grad)
+            checks = torch.stack(
+                (
+                    torch.isclose(out, out_ref, atol=1e-1, rtol=2e-2).all(),
+                    torch.isclose(dx, dx_ref, atol=1e-1, rtol=2e-2).all(),
+                    torch.isclose(dweight, dweight_ref, atol=3e-1, rtol=3e-2).all(),
+                )
+            )
+            checks_host.copy_(checks, non_blocking=True)
+            done = torch.cuda.Event()
+            done.record(stream)
+        completions.append(done)
+
+    try:
+        for done in completions:
+            done.synchronize()
+        assert not default_finished.query(), "default-stream blocker ended before validation"
+        for *_, checks_host in cases:
+            assert checks_host.tolist() == [True, True, True]
+    finally:
+        default_finished.synchronize()
+
+    # Keep warmup allocations live until the blocked default stream drains, so
+    # test outputs cannot accidentally reuse already-correct storage.
+    assert warm_dx is not None and warm_dweight is not None

--- a/tests/test_rocm_workflow.py
+++ b/tests/test_rocm_workflow.py
@@ -1,0 +1,16 @@
+"""Concurrency and event-routing invariants for the ROCm workflow."""
+
+from pathlib import Path
+
+_WORKFLOW = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "rocm.yml").read_text()
+
+
+def test_rocm_workflow_separates_event_concurrency():
+    assert "github.event_name" in _WORKFLOW
+    assert "github.event.pull_request.number || github.ref" in _WORKFLOW
+
+
+def test_rocm_workflow_routes_internal_and_fork_prs_once():
+    assert "pull_request_target:" in _WORKFLOW
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in _WORKFLOW
+    assert "github.event.pull_request.head.repo.full_name != github.repository" in _WORKFLOW


### PR DESCRIPTION
## Summary

This draft implements the first end-to-end FlyDSL backend PoC proposed in #178, following the ownership boundary discussed in ROCm/FlyDSL#749:

- FlyDSL owns the DSL, compiler, JIT/runtime, device/stream handling, and generic cache infrastructure.
- Quack owns the production kernel source, PyTorch semantics, feature gating, autograd/custom ops, tuning, tests, benchmarks, packaging, and CI.

This is intentionally a **draft PoC**, not a production-complete backend. The goal is to make the architecture and initial RMSNorm path concrete enough for scope and API review.

## Current progress

Implemented:

- optional FlyDSL/ROCm dependency boundary without adding FlyDSL to existing CUDA installations;
- lazy package imports so ROCm can import Quack without loading CuTe/CUDA modules;
- a lightweight operator-level `Target` / provider / lazy-registry SPI;
- Quack-owned FlyDSL RMSNorm forward and backward kernels;
- atomic and two-stage FP32 `dweight` reduction paths;
- opaque `torch.library.custom_op` forward/backward boundaries;
- `torch.autograd.Function` and `torch.compile(fullgraph=True)` support;
- explicit `quack.rmsnorm_flydsl.rmsnorm` entry point;
- build-bound public dispatch through `from quack import rmsnorm`;
- import-isolation, feature-gate, cache, runtime-epsilon, stream, autograd, and compile tests;
- a same-GPU ROCm benchmark harness;
- an isolated gfx942/gfx950 ROCm CI workflow proposal.

The existing `quack/rmsnorm.py` CuTe implementation remains unchanged.

## MVP contract

The FlyDSL provider currently supports:

- plain weighted RMSNorm forward and backward;
- FP16, BF16, and FP32 inputs;
- FP32 weights;
- runtime `eps`;
- contiguous inputs with flattenable leading dimensions;
- gfx942 and gfx950.

Unsupported features fail with an explicit diagnostic instead of silently selecting an incorrect path.

## Local validation

On an available gfx950 system:

- focused suite: **75 passed, 1 CUDA-only test skipped**;
- eager forward/backward: passed;
- public autograd: passed;
- `torch.compile(fullgraph=True)`: passed;
- runtime `eps` and compiled-cache reuse: passed;
- concurrent non-default streams with per-call workspaces: passed;
- Ruff, formatting, `compileall`, YAML/TOML parsing, and diff checks: passed;
- benchmark smoke test: passed.

The benchmark reports same-machine ROCm baselines only. It does **not** claim performance parity with Quack's CUDA/CuTe implementation.

## Deliberately gated / not implemented yet

- bias;
- residual fusion / prenorm;
- per-head weights;
- optional weight;
- `out_dtype` / `residual_dtype` conversion;
- `weight_offset`;
- quantized RMSNorm paths.

These should be added based on the feature subset Quack wants to expose for the first ROCm release, rather than expanding the PoC unconditionally.

## Known limitations and blockers

1. **Hardware validation**
   - gfx950 has been exercised locally.
   - gfx942 still needs execution on the proposed CI runner.
   - the existing CUDA path has mocked compatibility coverage, but still needs real NVIDIA CI.

2. **Packaging**
   - FlyDSL is optional (`flydsl` / `rocm` extra), so existing users do not install it.
   - Quack's current base dependencies still include NVIDIA/CuTe packages. A clean ROCm wheel therefore needs either a core + CUDA/ROCm metapackage split or a separate adapter package.

3. **Public import surface**
   - `from quack import rmsnorm` selects CuTe on CUDA and FlyDSL on ROCm.
   - direct `from quack.rmsnorm import rmsnorm` remains the legacy CuTe module during this PoC.

4. **Mixed-architecture processes**
   - production-safe target/cache reuse across different AMD GPU architectures depends on ROCm/FlyDSL#878.

5. **CI infrastructure**
   - the workflow assumes gfx942/gfx950 runners and a protected `gpu-ci` environment are available to this repository; runner naming and access still need maintainer confirmation.

## Proposed path to merge

This draft currently carries the complete vertical slice so the design can be evaluated. After agreement, I propose splitting or reviewing it in these stages:

1. package import isolation and optional dependency boundary;
2. backend-neutral Target/provider/registry SPI;
3. Quack-owned FlyDSL kernel plus explicit experimental entry point;
4. PyTorch custom-op, autograd, and `torch.compile` integration;
5. gfx942/gfx950 tests, benchmark harness, and ROCm CI;
6. transparent public dispatch only after the supported API contract is agreed.

Before removing draft status:

- [ ] agree on whether the lightweight provider SPI belongs in Quack;
- [ ] agree on the first supported RMSNorm feature subset;
- [ ] choose ROCm packaging (`[rocm]`, metapackage split, or adapter);
- [ ] run gfx942 CI;
- [ ] run existing CUDA CI on the import/custom-op refactor;
- [ ] confirm ROCm runner/environment availability;
- [ ] collect representative gfx942/gfx950 forward and backward performance results;
- [ ] resolve or explicitly gate mixed-architecture behavior pending ROCm/FlyDSL#878.

## References

- Quack scope discussion: #178
- FlyDSL downstream ownership RFC: https://github.com/ROCm/FlyDSL/issues/749
- FlyDSL invocation-device target blocker: https://github.com/ROCm/FlyDSL/issues/878
- FlyDSL `torch.compile` custom-op findings: https://github.com/ROCm/FlyDSL/issues/596
