### PR TITLE
[Blockscaled] Tolerate torch < 2.13 lacking the recompile_limit compile kwarg

### DIFF
--- a/quack/blockscaled/quantize.py
+++ b/quack/blockscaled/quantize.py
@@ -16,6 +16,8 @@ bf16 loss parity — FLOOR clips block maxima in (448, 512)·2^e, which hurts
 especially on gradient tensors. The FP4 quantizers remain FLOOR-only.
 """
 
+import inspect
+
 import torch
 
 F8E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
@@ -454,6 +456,11 @@ def to_nvfp4(x: torch.Tensor, block_size: int = 16, per_tensor_scale=None):
 # on the autograd worker thread, which would still see the default 8.
 # ---------------------------------------------------------------------------
 _COMPILE_KW = dict(dynamic=False, recompile_limit=64)
+if "recompile_limit" not in inspect.signature(torch.compile).parameters:
+    # torch < 2.13: torch.compile has no per-wrapper recompile_limit kwarg. Drop it
+    # to keep the module importable; past 8 distinct shapes dynamo then silently
+    # falls back to eager (slow but correct).
+    del _COMPILE_KW["recompile_limit"]
 
 to_mx_compiled = torch.compile(to_mx, **_COMPILE_KW)
 to_mx_e5m2_compiled = torch.compile(to_mx_e5m2, **_COMPILE_KW)

--- a/quack/blockscaled/utils.py
+++ b/quack/blockscaled/utils.py
@@ -24,6 +24,7 @@ from quack.blockscaled.operand import (
 from quack.blockscaled.quantize import (  # noqa: F401  (pure-torch helpers re-exported)
     FP4_E2M1FN_VALUES,
     QUANTIZERS,
+    _COMPILE_KW,
     _fp4_unpacked_to_value,
     dequant_operand,
     pack_scale_2d_to_blocked_contig,
@@ -254,9 +255,7 @@ BLOCKSCALED_FORMATS = {
 # compiled (static shapes) so the swizzle fuses into a couple of kernels instead
 # of an eager pad/permute/contiguous chain; see the dynamic=False and
 # recompile_limit notes in quantize.py (per-wrapper limit: config is thread-local)
-_pack_scale_compiled = torch.compile(
-    pack_scale_2d_to_blocked_contig, dynamic=False, recompile_limit=64
-)
+_pack_scale_compiled = torch.compile(pack_scale_2d_to_blocked_contig, **_COMPILE_KW)
 
 
 def blockscaled_quantize(


### PR DESCRIPTION
https://github.com/Dao-AILab/quack/issues/182

torch.compile() only grew the per-wrapper recompile_limit kwarg in torch 2.13; on older torch the module-level torch.compile(...) wrappers in blockscaled/quantize.py and blockscaled/utils.py raised 'TypeError: compile() got an unexpected keyword argument recompile_limit' at import time, breaking even test collection.

Drop the kwarg when the running torch does not support it (dynamo then silently falls back to eager past 8 distinct shapes — slow but correct) and reuse _COMPILE_KW for the pack-scale wrapper so both sites share the guard.