### PR TITLE
Support CUDA 12.9 stream capture info

### DIFF
--- a/quack/distributed/all_gather_gemm.py
+++ b/quack/distributed/all_gather_gemm.py
@@ -272,6 +272,20 @@ def _check(err_ret):
     return ret[0] if len(ret) == 1 else tuple(ret)
 
 
+def _capture_dependencies(capture_info):
+    """Extract capture dependencies from CUDA 12.x and 13.x bindings."""
+    if len(capture_info) == 5:
+        _, _, _, deps, num_deps = capture_info
+    elif len(capture_info) == 6:
+        _, _, _, deps, _, num_deps = capture_info
+    else:
+        raise RuntimeError(
+            "cudaStreamGetCaptureInfo returned an unexpected payload with "
+            f"{len(capture_info)} values"
+        )
+    return deps, num_deps
+
+
 class AllGatherRunner:
     """Transport half of overlapped AllGather+GEMM: owns the rotating
     symmetric gather buffers, arrival flags, streams/events, and the
@@ -798,8 +812,8 @@ class AllGatherRunner:
                 #   A/B.
                 compute_stream = torch.cuda.current_stream(self.device)
                 if not self.capture_lockstep:
-                    _, _, _, deps, _, num_deps = _check(
-                        runtime.cudaStreamGetCaptureInfo(compute_stream.cuda_stream)
+                    deps, num_deps = _capture_dependencies(
+                        _check(runtime.cudaStreamGetCaptureInfo(compute_stream.cuda_stream))
                     )
                 self._ev_join.record(self.push_stream)
                 compute_stream.wait_event(self._ev_join)

--- a/tests/test_distributed_gemm.py
+++ b/tests/test_distributed_gemm.py
@@ -18,6 +18,28 @@ import torch
 NUM_ITERS = 6  # exercises epoch monotonicity + double-buffer reuse
 
 
+@pytest.mark.parametrize(
+    "capture_info",
+    [
+        ("status", 1, "graph", "deps", 2),
+        ("status", 1, "graph", "deps", "edge_data", 2),
+    ],
+)
+def test_capture_dependencies_cuda_binding_compatibility(capture_info):
+    """CUDA 12.x and 13.x capture-info payloads must produce the same dependencies."""
+    from quack.distributed.all_gather_gemm import _capture_dependencies
+
+    assert _capture_dependencies(capture_info) == ("deps", 2)
+
+
+def test_capture_dependencies_rejects_unknown_payload():
+    """Unexpected binding signatures must fail with a useful error."""
+    from quack.distributed.all_gather_gemm import _capture_dependencies
+
+    with pytest.raises(RuntimeError, match="unexpected payload with 4 values"):
+        _capture_dependencies(("status", 1, "graph", "deps"))
+
+
 def _ag_gemm(runner, a_shard, b, d=None):
     """Plain AG+GEMM (D = A_full @ B^T) through the gather() context."""
     from quack.gemm import gemm as quack_gemm


### PR DESCRIPTION
## Summary

- accept both the five-value CUDA 12.x and six-value CUDA 13.x `cudaStreamGetCaptureInfo` payloads
- preserve capture dependency restoration for the all-gather CUDA Graph path
- add focused tests for both binding signatures and unexpected payloads

## Root cause

`AllGatherRunner.gather()` assumed the CUDA 13.x binding shape, including `edgeData_out`. `cuda-bindings==12.9.7` omits that field, so the six-value unpack raised `ValueError` and CUDA Graph teardown subsequently reported `cudaErrorStreamCaptureUnjoined`.

## Verification

- `py_compile` passes for the modified source and test files
- focused compatibility assertions pass for five-value, six-value, and invalid payloads
- full pytest execution was not available in the local environment

See https://github.com/Dao-AILab/quack/issues/187