### PR TITLE
[Gemm, SM90] Add optional decoupled seqused_k (real per-batch K-length) for varlen_k GEMM

### DIFF
--- a/quack/gemm.py
+++ b/quack/gemm.py
@@ -89,6 +89,7 @@ def _compile_gemm(
     a_mma_dtype=None,  # blockscaled: MMA element types when they differ from the
     b_mma_dtype=None,  # storage dtypes (packed fp6 crosses the boundary as bytes)
     has_ag=False,
+    has_seqused_k=False,
 ):
     sm_to_cls = {
         8: GemmDefaultSm80,
@@ -180,7 +181,9 @@ def _compile_gemm(
         has_ag=has_ag,
     )
     aidx_len = m if varlen_m else (k if varlen_k else None)
-    varlen_args = make_fake_varlen_args(varlen_m, varlen_k, gather_A, aidx_len)
+    varlen_args = make_fake_varlen_args(
+        varlen_m, varlen_k, gather_A, aidx_len, seqused_k=has_seqused_k
+    )
     if sf_dtype is not None:
         # Padded SF buffers have a static batch dim of exactly 1 (not l): SFA for
         # varlen_m (M-padded) and varlen_k (K-padded); SFB is K-padded too for
@@ -400,6 +403,7 @@ def gemm(
     beta: float | Tensor = 1.0,
     cu_seqlens_m: Optional[Tensor] = None,  # (l+1,) cumulative sum of m values for variable length
     cu_seqlens_k: Optional[Tensor] = None,  # (l+1,) cumulative sum of k values for variable length
+    seqused_k: Optional[Tensor] = None,  # (l,) real K-length, decoupled from cu_seqlens_k
     A_idx: Optional[Tensor] = None,  # (total_m,) or (total_k,) indices for gather_A when varlen
     batch_idx_permute: Optional[Tensor] = None,  # (l,) permutation of batch indices for scheduler
     add_to_output: bool = False,
@@ -467,6 +471,7 @@ def gemm(
         tensor_key(colvec_bias),
         tensor_key(cu_seqlens_m),
         tensor_key(cu_seqlens_k),
+        seqused_k is not None,
         A_idx is not None,
         batch_idx_permute is not None,
         tile_count_semaphore is not None,
@@ -521,6 +526,7 @@ def gemm(
             colvec_bias=colvec_bias,
             cu_seqlens_m=cu_seqlens_m,
             cu_seqlens_k=cu_seqlens_k,
+            seqused_k=seqused_k,
             A_idx=A_idx,
             batch_idx_permute=batch_idx_permute,
             add_to_output=add_to_output,
@@ -558,6 +564,7 @@ def gemm(
         sr_seed=sr_seed,
         cu_seqlens_m=cu_seqlens_m,
         cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
         A_idx=A_idx,
         batch_idx_permute=batch_idx_permute,
         SFA=SFA,
@@ -585,6 +592,7 @@ def run_gemm_plan(
     sr_seed: int | Tensor = 0,
     cu_seqlens_m: Optional[Tensor] = None,
     cu_seqlens_k: Optional[Tensor] = None,
+    seqused_k: Optional[Tensor] = None,
     A_idx: Optional[Tensor] = None,
     batch_idx_permute: Optional[Tensor] = None,
     SFA: Optional[Tensor] = None,
@@ -650,7 +658,7 @@ def run_gemm_plan(
     scheduler_args = plan_scheduler_args(
         plan, tile_count_semaphore, batch_idx_permute, ag_args, A=A
     )
-    varlen_args = make_varlen_args(cu_seqlens_m, cu_seqlens_k, A_idx)
+    varlen_args = make_varlen_args(cu_seqlens_m, cu_seqlens_k, A_idx, seqused_k=seqused_k)
 
     launch_gemm(plan, A, B, D_gemm, C_gemm, epi_args, scheduler_args, varlen_args, SFA, SFB)
 
@@ -689,6 +697,7 @@ def _build_gemm_plan(
     colvec_bias,
     cu_seqlens_m,
     cu_seqlens_k,
+    seqused_k,
     A_idx,
     batch_idx_permute,
     add_to_output,
@@ -715,8 +724,10 @@ def _build_gemm_plan(
     varlen_k = cu_seqlens_k is not None
     varlen = varlen_m or varlen_k
     gather_A = A_idx is not None
+    has_seqused_k = seqused_k is not None
     blockscaled = SFA is not None
     assert not (varlen_m and varlen_k), "Only one of cu_seqlens_m and cu_seqlens_k"
+    assert not has_seqused_k or varlen_k, "seqused_k requires cu_seqlens_k (varlen_k)"
     if gather_A:
         assert varlen, "gather_A requires varlen"
         assert cluster_N == 1, "gather_A requires cluster_N=1"
@@ -955,6 +966,7 @@ def _build_gemm_plan(
         a_mma_dtype,
         b_mma_dtype,
         has_ag,
+        has_seqused_k,
     )
 
     cluster_size = cluster_M * cluster_N * cluster_K

--- a/quack/gemm_tvm_ffi_utils.py
+++ b/quack/gemm_tvm_ffi_utils.py
@@ -308,7 +308,7 @@ def make_fake_scheduler_args(has_semaphore, has_batch_idx_permute, l_sym, has_ag
     )
 
 
-def make_varlen_args(cu_seqlens_m, cu_seqlens_k, A_idx, cu_tiles_m=None):
+def make_varlen_args(cu_seqlens_m, cu_seqlens_k, A_idx, cu_tiles_m=None, seqused_k=None):
     if cu_seqlens_m is None and cu_seqlens_k is None:
         return None
     return VarlenArguments(
@@ -316,6 +316,7 @@ def make_varlen_args(cu_seqlens_m, cu_seqlens_k, A_idx, cu_tiles_m=None):
         mCuSeqlensK=cu_seqlens_k,
         mAIdx=A_idx,
         mCuTilesM=cu_tiles_m,
+        mSequsedK=seqused_k,
     )
 
 
@@ -331,7 +332,9 @@ def compute_cu_tiles_m(cu_seqlens_m, tile_m_cta):
     return torch.cat([tiles.new_zeros(1), tiles.cumsum(0, dtype=torch.int32)])
 
 
-def make_fake_varlen_args(varlen_m, varlen_k, gather_A, aidx_len, has_cu_tiles_m=False):
+def make_fake_varlen_args(
+    varlen_m, varlen_k, gather_A, aidx_len, has_cu_tiles_m=False, seqused_k=False
+):
     if not varlen_m and not varlen_k:
         return None
     num_seqlens = cute.sym_int()
@@ -349,6 +352,11 @@ def make_fake_varlen_args(varlen_m, varlen_k, gather_A, aidx_len, has_cu_tiles_m
         mCuTilesM=(
             fake_tensor(Int32, (num_seqlens,), leading_dim=0, divisibility=4)
             if has_cu_tiles_m
+            else None
+        ),
+        mSequsedK=(
+            fake_tensor(Int32, (cute.sym_int(),), leading_dim=0, divisibility=4)
+            if seqused_k
             else None
         ),
     )

--- a/quack/varlen_utils.py
+++ b/quack/varlen_utils.py
@@ -23,6 +23,7 @@ class VarlenArguments(NamedTuple):
     # sinks); the tile scheduler's m index is sequence-local, so a batchless
     # per-M-tile buffer needs this offset to keep sequences' rows disjoint.
     mCuTilesM: Optional[cute.Tensor] = None
+    mSequsedK: Optional[cute.Tensor] = None
 
 
 class VarlenManager:
@@ -32,6 +33,7 @@ class VarlenManager:
         cu_seqlens_k: Optional[cute.Tensor] = None
         mAIdx: Optional[cute.Tensor] = None
         cu_tiles_m: Optional[cute.Tensor] = None
+        seqused_k: Optional[cute.Tensor] = None
 
         @staticmethod
         @cute.jit
@@ -41,6 +43,7 @@ class VarlenManager:
                 cu_seqlens_k=args.mCuSeqlensK,
                 mAIdx=args.mAIdx,
                 cu_tiles_m=args.mCuTilesM,
+                seqused_k=args.mSequsedK,
             )
 
     def __init__(
@@ -64,6 +67,7 @@ class VarlenManager:
         self.varlen_m = const_expr(params.cu_seqlens_m is not None)
         self.varlen_k = const_expr(params.cu_seqlens_k is not None)
         self.gather_A = const_expr(params.mAIdx is not None)
+        self.has_seqused_k = const_expr(params.seqused_k is not None)
         self._loc = loc
         self._ip = ip
 
@@ -71,6 +75,9 @@ class VarlenManager:
     def to_underlying_arguments(args: VarlenArguments, *, loc=None, ip=None) -> Params:
         assert not (args.mCuSeqlensM is not None and args.mCuSeqlensK is not None), (
             "Only support either varlen_m or varlen_k"
+        )
+        assert args.mSequsedK is None or args.mCuSeqlensK is not None, (
+            "seqused_k requires cu_seqlens_k"
         )
         return VarlenManager.Params.create(args, loc=loc, ip=ip)
 
@@ -99,7 +106,9 @@ class VarlenManager:
             return self._len_m_static
 
     def len_k(self, batch_idx: Int32) -> Int32:
-        if const_expr(self.varlen_k):
+        if const_expr(self.has_seqused_k):
+            return self.params.seqused_k[batch_idx]
+        elif const_expr(self.varlen_k):
             return self.params.cu_seqlens_k[batch_idx + 1] - self.params.cu_seqlens_k[batch_idx]
         else:
             return self._len_k_static
@@ -142,7 +151,10 @@ class VarlenManager:
             if const_expr(ragged_rank == 2):  # Didn't create ragged tensor
                 mA_mk = cute.domain_offset((None, offset), mA_mkl)
             else:
-                length = params.cu_seqlens_k[batch_idx + 1] - offset
+                if const_expr(self.has_seqused_k):
+                    length = params.seqused_k[batch_idx]
+                else:
+                    length = params.cu_seqlens_k[batch_idx + 1] - offset
                 # rank 3 = 1-extra-dim (ptr_shift), rank 4 = 2-extra-dim
                 ptr_shift = const_expr(ragged_rank == 3)
                 mA_mk = copy_utils.offset_ragged_tensor(
@@ -211,7 +223,10 @@ class VarlenManager:
             if const_expr(ragged_rank == 2):  # Didn't create ragged tensor
                 mB_nk = cute.domain_offset((None, offset), mB_nkl)
             else:
-                length = params.cu_seqlens_k[batch_idx + 1] - offset
+                if const_expr(self.has_seqused_k):
+                    length = params.seqused_k[batch_idx]
+                else:
+                    length = params.cu_seqlens_k[batch_idx + 1] - offset
                 ptr_shift = const_expr(ragged_rank == 3)
                 mB_nk = copy_utils.offset_ragged_tensor(
                     mB_nkl,

--- a/tests/test_gemm_seqused_k.py
+++ b/tests/test_gemm_seqused_k.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2025, Tri Dao.
+"""Tests for the optional decoupled real-K-length `seqused_k` on varlen_k GEMM.
+
+The strong test poisons every padded row with NaN and asserts the output is
+both finite and equal to a real-rows-only reference — so it fails unless BOTH
+mechanisms work: the reduced per-batch K-tile count (`len_k` -> seqused_k[b])
+AND the TMA OOB-fill bound (`offset_batch_A/B` length -> seqused_k[b]) that
+zero-fills the straddling last K-tile.
+"""
+
+import math
+import pytest
+import torch
+
+from quack.cute_dsl_utils import get_device_capacity
+from quack.gemm import gemm as quack_gemm
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or get_device_capacity(torch.device("cuda"))[0] != 9,
+    reason="seqused_k varlen_k GEMM test targets SM90",
+)
+
+# Proven SM90 varlen_k config (see run_lowlevel_varlen_k_gemm in
+# test_linear_varlen_k.py). tile_K auto-derives to 64 for bf16.
+TILE_M, TILE_N = 256, 256
+CLUSTER_M, CLUSTER_N = 2, 1
+DTYPE = torch.bfloat16
+ATOL, RTOL = 3e-2, 1e-3
+K_PAD = 128
+
+
+def _run_gemm(A, B, D, **kwargs):
+    quack_gemm(
+        A,
+        B,
+        D,
+        C=None,
+        tile_count_semaphore=None,
+        tile_M=TILE_M,
+        tile_N=TILE_N,
+        cluster_M=CLUSTER_M,
+        cluster_N=CLUSTER_N,
+        persistent=True,
+        **kwargs,
+    )
+
+
+def _make_padded_operands(m, n, real_k, pad_fill):
+    """Build m-major A (m, total_pad_k) and n-major B (n, total_pad_k) whose
+    per-group padded columns [cu[i] + real_k[i] : cu[i+1]) are set to `pad_fill`.
+
+    Returns A, B, cu_seqlens_k (int32, padded offsets), real_k_t (int32).
+    """
+    device = "cuda"
+    pad_k = [((rk + K_PAD - 1) // K_PAD) * K_PAD for rk in real_k]  # tile-aligned slot
+    cu = [0]
+    for p in pad_k:
+        cu.append(cu[-1] + p)
+    total_pad_k = cu[-1]
+    avg_k = total_pad_k / len(real_k)
+
+    # m-major A: contiguous (total_pad_k, m) then .T => stride(-2)==1.
+    A = (torch.randn(total_pad_k, m, device=device, dtype=DTYPE) / math.sqrt(avg_k)).T
+    # n-major B: contiguous (total_pad_k, n) then .T => stride(-2)==1.
+    B = (torch.randn(total_pad_k, n, device=device, dtype=DTYPE) / math.sqrt(avg_k)).T
+    for i, rk in enumerate(real_k):
+        pad_cols = slice(cu[i] + rk, cu[i + 1])
+        A[:, pad_cols] = pad_fill
+        B[:, pad_cols] = pad_fill
+    cu_seqlens_k = torch.tensor(cu, dtype=torch.int32, device=device)
+    real_k_t = torch.tensor(real_k, dtype=torch.int32, device=device)
+    return A, B, cu_seqlens_k, real_k_t
+
+
+def _real_rows_ref(A, B, cu_seqlens_k, real_k):
+    """Reference: per group, contract only over the real rows of each slot."""
+    cu = cu_seqlens_k.tolist()
+    return torch.stack(
+        [
+            A[:, cu[i] : cu[i] + rk].float() @ B[:, cu[i] : cu[i] + rk].float().T
+            for i, rk in enumerate(real_k)
+        ]
+    ).to(DTYPE)
+
+
+# real_k deliberately not tile_K(64)-aligned so the last real K-tile straddles
+# real/pad. Mix: group 0 keeps the same tile count as the padded slot (only the
+# OOB-fill length differs); groups 1,2 drop whole K-tiles (seqused reduces the
+# count). pad slots become [256, 256, 384].
+REAL_K = [200, 137, 264]
+
+
+@pytest.mark.parametrize("n", [512])
+@pytest.mark.parametrize("m", [1024])
+def test_seqused_k_excludes_nan_padding(m, n):
+    """NaN-poisoned padded rows + seqused_k => finite output matching real-only ref."""
+    torch.manual_seed(0)
+    A, B, cu_seqlens_k, real_k = _make_padded_operands(m, n, REAL_K, pad_fill=float("nan"))
+    D = torch.empty(len(REAL_K), m, n, dtype=DTYPE, device="cuda")
+
+    _run_gemm(A, B, D, cu_seqlens_k=cu_seqlens_k, seqused_k=real_k)
+
+    assert torch.isfinite(D).all(), "NaN leaked from padded rows -> seqused_k OOB-fill broken"
+    ref = _real_rows_ref(A, B, cu_seqlens_k, REAL_K)
+    torch.testing.assert_close(D, ref, atol=ATOL, rtol=RTOL)
+
+
+@pytest.mark.parametrize("n", [512])
+@pytest.mark.parametrize("m", [1024])
+def test_seqused_k_none_zero_pad_matches(m, n):
+    """Backward-compat: seqused_k=None over zero-padded slots contracts the full
+    slot but the zero pads contribute nothing, so it equals the real-only ref.
+    Confirms the existing coupled-varlen_k path is unchanged."""
+    torch.manual_seed(0)
+    A, B, cu_seqlens_k, _ = _make_padded_operands(m, n, REAL_K, pad_fill=0.0)
+    D = torch.empty(len(REAL_K), m, n, dtype=DTYPE, device="cuda")
+
+    _run_gemm(A, B, D, cu_seqlens_k=cu_seqlens_k)  # no seqused_k
+
+    ref = _real_rows_ref(A, B, cu_seqlens_k, REAL_K)
+    torch.testing.assert_close(D, ref, atol=ATOL, rtol=RTOL)

--- a/tests/test_namedtuple_tvm_ffi.py
+++ b/tests/test_namedtuple_tvm_ffi.py
@@ -100,8 +100,9 @@ def test_varlen_construction():
     assert args.mCuSeqlensK is None
     assert args.mAIdx is None
     assert args.mCuTilesM is None
+    assert args.mSequsedK is None
     assert hasattr(args, "_fields")
-    assert args._fields == ("mCuSeqlensM", "mCuSeqlensK", "mAIdx", "mCuTilesM")
+    assert args._fields == ("mCuSeqlensM", "mCuSeqlensK", "mAIdx", "mCuTilesM", "mSequsedK")
 
     # Keyword construction
     t = torch.zeros(4, dtype=torch.int32, device="cuda")


### PR DESCRIPTION
## Summary

Adds an optional `seqused_k` tensor to the varlen_k `gemm()` that decouples each batch's real contraction length from its `cu_seqlens_k` storage layout. `seqused_k=None` is the existing behavior, so the change is backward compatible.

## Motivation

varlen_k currently couples a batch's storage *offset* to its contraction *length*: `length[b] = cu_seqlens_k[b+1] - cu_seqlens_k[b]`. That holds only when every stored row participates in the contraction.

My use case is an MoE workload where tokens are routed to experts with variable per-expert counts, and each expert's token slab is stored in a **padded, tile-aligned slot** (e.g. 128-row padding) so the grouped GEMM gets aligned, well-formed tiles. Only the first `real_count[b]` rows of a slot are real tokens; the padded tail is uninitialized garbage. This PR avoids having to memset the padded positions to 0 to ensure correctness.

`seqused_k` (borrowing flash-attn's naming) fixes this: `cu_seqlens_k` keeps supplying the padded per-batch offset/stride, while `seqused_k[b] ≤ slot_width` gives the real number of rows that participate.

## Change

When supplied, `seqused_k` only affects `VarlenManager`:
- `len_k(b)` returns `seqused_k[b]` → fewer K-tiles per batch (whole padded tiles are skipped).
- `offset_batch_A/B` bounds the TMA OOB-fill to `seqused_k[b]` → a real/pad-straddling last K-tile zero-fills its padded rows on load.

Threaded through the public `gemm()` (signature, cache key, plan build/compile, `make_varlen_args`). No scheduler or mainloop changes — the SM90 mainloop already routes the K-bound through `len_k()` and operand offsets through `offset_batch_A/B`, so the change is confined to `VarlenManager`. Scope: SM90 varlen_k path.

## Tests

`tests/test_gemm_seqused_k.py` (new):
- **Strong test** — NaN-poison every padded row, supply `seqused_k`, assert the output is finite and equal to a real-rows-only reference. Fails unless *both* the reduced K-tile count and the OOB-fill work.
- **Backward-compat** — `seqused_k=None` over zero-padded slots matches the real-only reference, confirming the existing coupled path is unchanged.

**Full suite** — single H100 (SM90), CUDA 13 + torch 2.11: **17,433 passed, 839 skipped, 4 failed**. The 839 skips are the SM100/SM120 and multi-GPU tests, not applicable on one SM90 GPU.

The 4 failures are all `torch.compile` tracing of the `quack.gemm_epi_f` op — `test_epilogue_iface::test_torch_compile_single_op[True]` / `::test_torch_compile_reduce_sinks` and `test_gemm_transform::test_a_transform_torch_compile` / `::test_a_transform_dropout_torch_compile`. They fail in dynamo when `ast.literal_eval`'ing the op's repr'd `meta` string, entirely within `gemm_runtime/torch_op.py` + dynamo — paths this change does not touch. Likely an **environment / torch-version mismatch** but I will test this to confirm.
