### PR TITLE
Relax nvidia-cutlass-dsl pin to >=4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quack-kernels"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "nvidia-cutlass-dsl==4.7.0",
+    "nvidia-cutlass-dsl>=4.7",
     "torch",
     "apache-tvm-ffi>=0.1.6,<0.2",
     "torch-c-dlpack-ext",
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.7.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.7"]
 heuristics = ["nvidia-matmul-heuristics"]
 jax = ["jax", "jax-tvm-ffi"]
 bench = ["pandas", "tyro"]


### PR DESCRIPTION
## Human Note

Trying to get FA moved up and current depdency is quack on 4.6.2 I think we can make this a little looser and then cut a quack release

## Agent note

The published quack-kernels 0.6.4 wheel exact-pins nvidia-cutlass-dsl==4.6.2, which makes quack (and
anything depending on it, e.g. flash-attn-4) unresolvable alongside cutlass-dsl 4.7.x. Main already
requires 4.7 semantically — d079eef migrated to the new Arch enum / prims APIs, so 4.6.2 fails at
import (`cutlass.base_dsl.enums` does not exist there). This change loosens the exact pin to the
honest floor `>=4.7` so downstream consumers can track new DSL releases without waiting on a quack
metadata bump.

Validated on GB200 in a fresh venv at each end of the range: 4.7.0 (648 passed), 4.7.1 (1464 passed),
and 4.8.0.dev0 (1464 passed, 0 compile failures) across test_rmsnorm, test_softmax,
test_cross_entropy, test_gemm_functional, and test_gemm_epilogue. Note `>=4.7` never auto-resolves to
4.8.0.dev0 — pip/uv skip pre-releases unless the user opts in — so default installs stay on stable
4.7.x while opt-in 4.8.dev users are no longer blocked.

## Test Plan

```bash
uv venv venv --python 3.13 && uv pip install -e ".[dev]"   # resolves nvidia-cutlass-dsl==4.7.1
pytest tests/test_rmsnorm.py tests/test_softmax.py tests/test_cross_entropy.py \
    tests/test_gemm_functional.py tests/test_gemm_epilogue.py -q --async-compile=32
# 1464 passed, 14 skipped
uv pip install "nvidia-cutlass-dsl==4.7.0" && pytest tests/test_rmsnorm.py tests/test_gemm_functional.py -q
# 648 passed, 6 skipped
uv pip install --prerelease=allow "nvidia-cutlass-dsl==4.8.0.dev0" && pytest <same 5 files> -q
# 1464 passed, 14 skipped
```

