### PR TITLE
[Rounding] Widen the SR stream offset from 16 to 28 bits; rename tid to offset

### DIFF
--- a/quack/copy_utils.py
+++ b/quack/copy_utils.py
@@ -222,13 +222,15 @@ def sr_cvt_copy(
     src: cute.Tensor,
     dst: cute.Tensor,
     seed: Int32,
-    tidx: Int32,
+    offset: Int32,
     *,
     retile: bool = False,
     loc=None,
     ip=None,
 ) -> None:
-    """Like cvt_copy but uses stochastic rounding for FP32 -> BF16/FP16 conversion."""
+    """Like cvt_copy but uses stochastic rounding for FP32 -> BF16/FP16 conversion.
+    ``offset`` (< 2**28) is the caller's linearized rand-stream offset (see
+    quack.rounding.convert_f32_to_bf16_sr)."""
     assert isinstance(src.iterator, cute.Pointer) and src.memspace == cute.AddressSpace.rmem
     from quack.rounding import convert_f32_to_bf16_sr, convert_f32_to_f16_sr
     from cutlass.cute.tensor import TensorSSA
@@ -243,7 +245,7 @@ def sr_cvt_copy(
     )
     src_cvt = cute.make_rmem_tensor_like(src, dst.element_type)
     src_vec = src.load()
-    raw_vec = convert_sr(src_vec, seed, tidx, loc=loc, ip=ip)
+    raw_vec = convert_sr(src_vec, seed, offset, loc=loc, ip=ip)
     src_cvt.store(TensorSSA(raw_vec, src_vec.shape, dst.element_type))
     src = src_cvt
     if const_expr(retile):

--- a/quack/rounding.py
+++ b/quack/rounding.py
@@ -110,6 +110,22 @@ PHILOX_ROUND_B = 0xCD9E8D57
 PHILOX_KEY_A = 0x9E3779B9
 PHILOX_KEY_B = 0xBB67AE85
 
+# Philox counter word shared by every SR converter below: the caller's
+# linearized ``offset`` in the low SR_OFFSET_BITS (distinct (seed, offset) pairs
+# are independent rand streams, so callers can linearize e.g. (tile, thread)
+# straight into it), and the converter's per-call batch index in the top
+# SR_GROUP_BITS (one Philox call yields 4 words = 4 pairs or 4 quads).
+SR_OFFSET_BITS = 28
+SR_GROUP_BITS = 32 - SR_OFFSET_BITS
+SR_MAX_GROUPS = 1 << SR_GROUP_BITS
+
+
+def _sr_counter(group_idx: int, offset) -> Uint32:
+    """``(group_idx << SR_OFFSET_BITS) | offset``. ``offset`` must be below
+    2**SR_OFFSET_BITS; any wider would repeat entropy."""
+    assert 0 <= group_idx < SR_MAX_GROUPS
+    return Uint32(group_idx << SR_OFFSET_BITS) | Uint32(offset)
+
 
 @dsl_user_op
 def epilogue_sr_seed(
@@ -1036,7 +1052,7 @@ def _use_hw_cvt() -> bool:
 def convert_f32_to_f8_sr(
     src_vec,
     seed: Int32,
-    tid: Int32,
+    offset: Int32,
     f8_kind: str,
     *,
     loc=None,
@@ -1067,14 +1083,14 @@ def convert_f32_to_f8_sr(
             hi = pair_fn(v2, v3, Uint32(rand) >> 16, loc=loc, ip=ip)
             return cutlass.Int32(Uint32(lo).to(Uint32) | (Uint32(hi).to(Uint32) << 16))
 
-    return _convert_f32_sr_quad_impl(src_vec, seed, tid, cvt_quad, dst_numeric, loc, ip)
+    return _convert_f32_sr_quad_impl(src_vec, seed, offset, cvt_quad, dst_numeric, loc, ip)
 
 
 @dsl_user_op
 def convert_f32_to_e2m1_sr(
     src_vec,
     seed: Int32,
-    tid: Int32,
+    offset: Int32,
     *,
     loc=None,
     ip=None,
@@ -1096,10 +1112,10 @@ def convert_f32_to_e2m1_sr(
         cvt_fn = cvt_f32x4_e2m1x4_rs_direct
     else:
         cvt_fn = cvt_f32x4_e2m1x4_rs_sw
-    return _convert_f32_sr_quad_impl(src_vec, seed, tid, cvt_fn, cutlass.Float4E2M1FN, loc, ip)
+    return _convert_f32_sr_quad_impl(src_vec, seed, offset, cvt_fn, cutlass.Float4E2M1FN, loc, ip)
 
 
-def _convert_f32_sr_quad_impl(src_vec, seed, tid, cvt_quad_fn, dst_numeric, loc, ip):
+def _convert_f32_sr_quad_impl(src_vec, seed, offset, cvt_quad_fn, dst_numeric, loc, ip):
     """Quad-based sibling of _convert_f32_sr_impl for 8/4-bit outputs: the
     converters are x4-only (hw f8x4/e2m1x4 instructions), each value consumes
     8 rbits, so one Philox word covers a quad and one batch covers 4 quads
@@ -1111,6 +1127,11 @@ def _convert_f32_sr_quad_impl(src_vec, seed, tid, cvt_quad_fn, dst_numeric, loc,
         f"8/4-bit stochastic rounding requires num_elems % 4 == 0, got {num_elems}"
     )
     num_quads = num_elems // 4
+    num_groups = -(-num_quads // 4)
+    assert num_groups <= SR_MAX_GROUPS, (
+        f"stochastic rounding converts at most {SR_MAX_GROUPS * 16} 8/4-bit elements "
+        f"per call ({SR_GROUP_BITS} Philox batch-index bits), got {num_elems}"
+    )
 
     dst_vec_type = ir.VectorType.get([num_elems], dst_numeric.mlir_type, loc=loc)
     word_numeric = Int32 if dst_numeric.width == 8 else cutlass.Uint16
@@ -1133,7 +1154,7 @@ def _convert_f32_sr_quad_impl(src_vec, seed, tid, cvt_quad_fn, dst_numeric, loc,
         group_idx = quad_idx // 4
         intra_idx = quad_idx % 4
         if intra_idx == 0:
-            counter = cutlass.Uint32(group_idx << 16) | cutlass.Uint32(tid)
+            counter = _sr_counter(group_idx, offset)
             rand_batch = philox(counter, cutlass.Uint32(seed))
         entropy = rand_batch[intra_idx]
         packed = cvt_quad_fn(*vals, entropy, loc=loc, ip=ip)
@@ -1153,7 +1174,7 @@ def _convert_f32_sr_quad_impl(src_vec, seed, tid, cvt_quad_fn, dst_numeric, loc,
 def convert_f32_to_bf16_sr(
     src_vec,
     seed: Int32,
-    tid: Int32,
+    offset: Int32,
     *,
     loc=None,
     ip=None,
@@ -1163,16 +1184,21 @@ def convert_f32_to_bf16_sr(
     Processes elements in pairs using Philox PRNG for entropy and the hardware
     cvt.rs.satfinite.bf16x2.f32 instruction when compiling for sm_100a/sm_103a,
     or a bit-exact software emulation on any other sm_80+ target.
+
+    ``offset`` (< 2**SR_OFFSET_BITS = 2**28) selects this call's rand stream
+    within ``seed``: the low 28 bits of the Philox counter, with the top 4 bits
+    reserved for the per-call batch index (see _sr_counter). At most
+    SR_MAX_GROUPS * 8 = 128 elements per call.
     """
     cvt_fn = cvt_f32x2_bf16x2_rs if _use_hw_cvt() else cvt_f32x2_bf16x2_rs_sw
-    return _convert_f32_sr_impl(src_vec, seed, tid, cvt_fn, cutlass.BFloat16, loc, ip)
+    return _convert_f32_sr_impl(src_vec, seed, offset, cvt_fn, cutlass.BFloat16, loc, ip)
 
 
 @dsl_user_op
 def convert_f32_to_f16_sr(
     src_vec,
     seed: Int32,
-    tid: Int32,
+    offset: Int32,
     *,
     loc=None,
     ip=None,
@@ -1184,7 +1210,7 @@ def convert_f32_to_f16_sr(
     the same Philox words.
     """
     cvt_fn = cvt_f32x2_f16x2_rs if _use_hw_cvt() else cvt_f32x2_f16x2_rs_sw
-    return _convert_f32_sr_impl(src_vec, seed, tid, cvt_fn, cutlass.Float16, loc, ip)
+    return _convert_f32_sr_impl(src_vec, seed, offset, cvt_fn, cutlass.Float16, loc, ip)
 
 
 # Storage dtypes the epilogue SR convert supports. bf16/f16/e2m1 run
@@ -1199,38 +1225,45 @@ SR_STORE_DTYPES = (
 )
 
 
-def convert_f32_frag_sr(frag: cute.Tensor, dtype, seed: Int32, tid: Int32) -> cute.Tensor:
+def convert_f32_frag_sr(frag: cute.Tensor, dtype, seed: Int32, offset: Int32) -> cute.Tensor:
     """Convert an f32 rmem fragment to ``dtype`` with stochastic rounding.
 
     Same-layout sibling of ``frag.to(dtype)`` for every dtype in
     SR_STORE_DTYPES; dtype is a trace-time constant. Callers derive ``seed``
     per (tile, subtile) via epilogue_sr_seed so rand streams never repeat
-    across the output.
+    across the output, and pass ``offset`` (< 2**SR_OFFSET_BITS = 2**28) to
+    separate streams within a seed: the thread index, or any wider linearized
+    (tile, thread, ...) offset.
     """
     from cutlass.cute.tensor import TensorSSA
 
     assert dtype in SR_STORE_DTYPES, f"no stochastic-rounding converter for {dtype}"
     src_vec = frag.load()
     if dtype is cutlass.BFloat16:
-        raw_vec = convert_f32_to_bf16_sr(src_vec, seed, tid)
+        raw_vec = convert_f32_to_bf16_sr(src_vec, seed, offset)
     elif dtype is cutlass.Float16:
-        raw_vec = convert_f32_to_f16_sr(src_vec, seed, tid)
+        raw_vec = convert_f32_to_f16_sr(src_vec, seed, offset)
     elif dtype is cutlass.Float8E4M3FN:
-        raw_vec = convert_f32_to_f8_sr(src_vec, seed, tid, "e4m3")
+        raw_vec = convert_f32_to_f8_sr(src_vec, seed, offset, "e4m3")
     elif dtype is cutlass.Float8E5M2:
-        raw_vec = convert_f32_to_f8_sr(src_vec, seed, tid, "e5m2")
+        raw_vec = convert_f32_to_f8_sr(src_vec, seed, offset, "e5m2")
     else:
-        raw_vec = convert_f32_to_e2m1_sr(src_vec, seed, tid)
+        raw_vec = convert_f32_to_e2m1_sr(src_vec, seed, offset)
     out = cute.make_rmem_tensor_like(frag, dtype)
     out.store(TensorSSA(raw_vec, src_vec.shape, dtype))
     return out
 
 
-def _convert_f32_sr_impl(src_vec, seed, tid, cvt_fn, dst_numeric, loc, ip):
+def _convert_f32_sr_impl(src_vec, seed, offset, cvt_fn, dst_numeric, loc, ip):
     src_vec_type = ir.VectorType(src_vec.type)
     num_elems = src_vec_type.shape[0]
     assert num_elems % 2 == 0, f"requires even number of elements, got {num_elems}"
     num_pairs = num_elems // 2
+    num_groups = -(-num_pairs // 4)
+    assert num_groups <= SR_MAX_GROUPS, (
+        f"stochastic rounding converts at most {SR_MAX_GROUPS * 8} 16-bit elements "
+        f"per call ({SR_GROUP_BITS} Philox batch-index bits), got {num_elems}"
+    )
     # No num_pairs % 4 requirement for 16-bit outputs.
     # For 8-bit outputs the QUAD is a hard requirement (the hw
     # instruction is f8x4-only)
@@ -1267,7 +1300,7 @@ def _convert_f32_sr_impl(src_vec, seed, tid, cvt_fn, dst_numeric, loc, ip):
         group_idx = pair_idx // 4
         intra_idx = pair_idx % 4
         if intra_idx == 0:
-            counter = cutlass.Uint32(group_idx << 16) | cutlass.Uint32(tid)
+            counter = _sr_counter(group_idx, offset)
             rand_batch = philox(counter, cutlass.Uint32(seed))
 
         entropy = rand_batch[intra_idx]

--- a/tests/test_rounding.py
+++ b/tests/test_rounding.py
@@ -286,21 +286,44 @@ N_PER_THREAD = 32
 N_THREADS = 128
 
 
+# Stream offsets: the thread index alone, and the top of the 28-bit offset
+# field (past the old 16-bit field, which aliased such offsets into the
+# batch index). The host model spells the layout with literals on purpose.
+OFFSET_BASES = [0, (1 << 28) - N_THREADS]
+
+
 @cute.kernel
-def _frag_kernel(mX: cute.Tensor, mOut: cute.Tensor, seed: Int32):
+def _frag_kernel(mX: cute.Tensor, mOut: cute.Tensor, seed: Int32, offset_base: Int32):
     tidx, _, _ = cute.arch.thread_idx()
     frag = cute.make_rmem_tensor(cute.make_layout(N_PER_THREAD), Float32)
     for j in cutlass.range_constexpr(N_PER_THREAD):
         frag[j] = mX[tidx * N_PER_THREAD + j]
-    out = convert_f32_frag_sr(frag, cutlass.Float4E2M1FN, seed, tidx)
+    out = convert_f32_frag_sr(frag, cutlass.Float4E2M1FN, seed, offset_base + tidx)
     out_i32 = cute.recast_tensor(out, Int32)
     for j in cutlass.range_constexpr(N_PER_THREAD // 8):
         mOut[tidx * (N_PER_THREAD // 8) + j] = out_i32[j]
 
 
 @cute.jit
-def _frag_launch(mX: cute.Tensor, mOut: cute.Tensor, seed: Int32):
-    _frag_kernel(mX, mOut, seed).launch(grid=(1, 1, 1), block=(N_THREADS, 1, 1))
+def _frag_launch(mX: cute.Tensor, mOut: cute.Tensor, seed: Int32, offset_base: Int32):
+    _frag_kernel(mX, mOut, seed, offset_base).launch(grid=(1, 1, 1), block=(N_THREADS, 1, 1))
+
+
+@cute.kernel
+def _frag_kernel_bf16(mX: cute.Tensor, mOut: cute.Tensor, seed: Int32, offset_base: Int32):
+    tidx, _, _ = cute.arch.thread_idx()
+    frag = cute.make_rmem_tensor(cute.make_layout(N_PER_THREAD), Float32)
+    for j in cutlass.range_constexpr(N_PER_THREAD):
+        frag[j] = mX[tidx * N_PER_THREAD + j]
+    out = convert_f32_frag_sr(frag, cutlass.BFloat16, seed, offset_base + tidx)
+    out_i32 = cute.recast_tensor(out, Int32)
+    for j in cutlass.range_constexpr(N_PER_THREAD // 2):
+        mOut[tidx * (N_PER_THREAD // 2) + j] = out_i32[j]
+
+
+@cute.jit
+def _frag_launch_bf16(mX: cute.Tensor, mOut: cute.Tensor, seed: Int32, offset_base: Int32):
+    _frag_kernel_bf16(mX, mOut, seed, offset_base).launch(grid=(1, 1, 1), block=(N_THREADS, 1, 1))
 
 
 def philox4_py(counter: int, key: int, n_rounds: int = PHILOX_N_ROUNDS_DEFAULT):
@@ -319,21 +342,29 @@ def philox4_py(counter: int, key: int, n_rounds: int = PHILOX_N_ROUNDS_DEFAULT):
     return c0, c1, c2, c3
 
 
+def _sr_counter_py(group: int, offset: int) -> int:
+    assert 0 <= group < 16 and 0 <= offset < (1 << 28)
+    return (group << 28) | offset
+
+
 @pytest.mark.skipif(
     IS_HW_CVT_TARGET, reason="convert_f32_frag_sr dispatches to the hw cvt.rs on this target"
 )
+@pytest.mark.parametrize("offset_base", OFFSET_BASES)
 @pytest.mark.parametrize("seed", [0, 12345])
-def test_e2m1_frag_sr_philox_wiring(seed):
+def test_e2m1_frag_sr_philox_wiring(seed, offset_base):
     """convert_f32_frag_sr(Float4E2M1FN) end to end: Philox counter layout
-    (one word per quad, (group<<16)|tid counter, 4 quads per batch), straight
-    byte mapping, and the packed-nibble vector bitcast, vs a host model."""
+    (one word per quad, (group<<SR_OFFSET_BITS)|offset counter, 4 quads per
+    batch), straight byte mapping, and the packed-nibble vector bitcast, vs a
+    host model. offset_base past 2**16 fails under the old 16-bit offset field."""
     gen = torch.Generator(device="cuda").manual_seed(seed)
     n_vals = N_THREADS * N_PER_THREAD
     x = torch.rand(n_vals, generator=gen, device="cuda") * 16 - 8
     x = x.float()
     out = torch.empty(n_vals // 8, dtype=torch.int32, device="cuda")
-    fn = cute.compile(_frag_launch, from_dlpack(x), from_dlpack(out), Int32(seed))
-    fn(from_dlpack(x), from_dlpack(out), Int32(seed))
+    args = (from_dlpack(x), from_dlpack(out), Int32(seed), Int32(offset_base))
+    fn = cute.compile(_frag_launch, *args)
+    fn(*args)
     torch.cuda.synchronize()
     got = out.cpu().numpy().view(np.uint8)  # nibble pairs, little-endian per byte
 
@@ -342,10 +373,47 @@ def test_e2m1_frag_sr_philox_wiring(seed):
     for t in range(N_THREADS):
         for q in range(N_PER_THREAD // 4):
             group, intra = q // 4, q % 4
-            words = philox4_py((group << 16) | t, seed & 0xFFFFFFFF)
+            words = philox4_py(_sr_counter_py(group, offset_base + t), seed & 0xFFFFFFFF)
             word = words[intra]
             for j in range(4):
                 r8 = np.array([(word >> (8 * j)) & 0xFF], dtype=np.uint8)
                 nib_ref[t, 4 * q + j] = ref_e2m1_rs(x_np[t, 4 * q + j : 4 * q + j + 1], r8)[0]
     ref_bytes = (nib_ref[:, 0::2] | (nib_ref[:, 1::2] << 4)).reshape(-1)
     np.testing.assert_array_equal(got, ref_bytes)
+
+
+@pytest.mark.parametrize("hw", [True, False])
+@pytest.mark.parametrize("offset_base", OFFSET_BASES)
+def test_bf16_frag_sr_philox_wiring(monkeypatch, offset_base, hw):
+    """convert_f32_frag_sr(BFloat16) end to end vs a host model: Philox counter
+    (group<<SR_OFFSET_BITS)|offset, one word per PAIR (4 pairs per batch), low
+    rand half to the even element, high half to the odd one, and the cvt.rs
+    rule bits(x) + r16 truncated to bf16 (in-range inputs, so satfinite and
+    NaN handling never engage). bf16 SR is bit-identical on the hw cvt.rs and
+    the sw emulation, so both dispatch paths are checked against the model."""
+    import quack.rounding as rounding
+
+    if hw and not IS_HW_CVT_TARGET:
+        pytest.skip("hw cvt.rs needs an sm_100a/sm_103a compile target")
+    if not hw:
+        monkeypatch.setattr(rounding, "_use_hw_cvt", lambda: False)
+    seed = 0
+    gen = torch.Generator(device="cuda").manual_seed(seed)
+    n_vals = N_THREADS * N_PER_THREAD
+    x = (torch.randn(n_vals, generator=gen, device="cuda") * 3).float()
+    out = torch.empty(n_vals // 2, dtype=torch.int32, device="cuda")
+    args = (from_dlpack(x), from_dlpack(out), Int32(seed), Int32(offset_base))
+    fn = cute.compile(_frag_launch_bf16, *args)
+    fn(*args)
+    torch.cuda.synchronize()
+    got = out.cpu().numpy().view(np.uint16).reshape(N_THREADS, N_PER_THREAD)
+
+    bits = x.cpu().numpy().view(np.uint32).reshape(N_THREADS, N_PER_THREAD)
+    ref = np.zeros((N_THREADS, N_PER_THREAD), dtype=np.uint16)
+    for t in range(N_THREADS):
+        for p in range(N_PER_THREAD // 2):
+            group, intra = p // 4, p % 4
+            r = philox4_py(_sr_counter_py(group, offset_base + t), seed & 0xFFFFFFFF)[intra]
+            ref[t, 2 * p] = ((int(bits[t, 2 * p]) + (r & 0xFFFF)) >> 16) & 0xFFFF
+            ref[t, 2 * p + 1] = ((int(bits[t, 2 * p + 1]) + (r >> 16)) >> 16) & 0xFFFF
+    np.testing.assert_array_equal(got, ref)


### PR DESCRIPTION
The SR converters' Philox counter word is now `(batch << 28) | offset` instead of `(batch << 16) | tid`: 28 bits for the caller's linearized stream offset, 4 for the converter's per-call batch index (<= 16 batches = 128 16-bit or 256 8/4-bit elements per call, asserted at trace time). Still a single u32. Callers pass the thread index positionally and are unchanged; SR bits differ from before only for fragments longer than 8 elements.

Tests: e2m1 and bf16 Philox wiring vs a host model at offsets 0 and 2^28-128 (bf16 on both the hw cvt.rs and sw paths).