### PR TITLE
[SM100][GEMM]: Support fallback cluster shapes by default and add larger preferred cluster shapes to default autotune list

### DIFF
--- a/quack/copy_utils.py
+++ b/quack/copy_utils.py
@@ -12,7 +12,7 @@ from cutlass.base_dsl.enums import Arch
 from cutlass.cute.nvgpu import cpasync, tcgen05, warp
 from cutlass.cute.nvgpu.tcgen05.mma import CtaGroup  # noqa
 from cutlass.cutlass_dsl import dsl_user_op
-from cutlass.utils import LayoutEnum, block_copy
+from cutlass.utils import LayoutEnum
 import cutlass.pipeline
 from cutlass._mlir import ir
 from cutlass._mlir.dialects import llvm
@@ -1217,72 +1217,6 @@ def tma_get_copy_fn(
         cute.copy(atom, src, dst, **new_kwargs, **kwargs, loc=loc, ip=ip)
 
     return (copy_tma if const_expr(not single_stage) else copy_tma_single_stage), s, g
-
-
-@dsl_user_op
-def tma_get_block_copy_fn(
-    atom: cute.CopyAtom,
-    src_tensor: cute.Tensor,
-    dst_tensor: cute.Tensor,
-    tma_multicast: Optional[dict] = None,
-    single_stage: bool = False,
-    *,
-    loc=None,
-    ip=None,
-    **kwargs,
-) -> Callable:
-    src_is_smem = const_expr(
-        isinstance(src_tensor.iterator, cute.Pointer)
-        and src_tensor.memspace == cute.AddressSpace.smem
-    )
-    if const_expr(tma_multicast is not None and "use_2cta_mma_inst" not in tma_multicast):
-        op = atom.op if const_expr(hasattr(atom, "op")) else atom
-        tma_multicast = {
-            **tma_multicast,
-            "use_2cta_mma_inst": getattr(op, "cta_group", None) == tcgen05.CtaGroup.TWO,
-        }
-    smem_tensor, gmem_tensor = (src_tensor, dst_tensor) if src_is_smem else (dst_tensor, src_tensor)
-    group_rank_smem = const_expr(cute.rank(smem_tensor) - (1 if not single_stage else 0))
-    group_rank_gmem = const_expr(cute.rank(gmem_tensor) - (1 if not single_stage else 0))
-    s = cute.group_modes(smem_tensor, 0, group_rank_smem)
-    g = cute.group_modes(gmem_tensor, 0, group_rank_gmem)
-    src, dst = (s, g) if src_is_smem else (g, s)
-
-    @dsl_user_op
-    def copy_tma(src_idx, dst_idx, *, loc=None, ip=None, **new_kwargs):
-        src_cur = src[None, src_idx]
-        dst_cur = dst[None, dst_idx]
-        if const_expr(tma_multicast is None):
-            block_copy(atom, src_cur, dst_cur, **new_kwargs, **kwargs, loc=loc, ip=ip)
-        else:
-            block_copy(
-                atom,
-                src_cur,
-                dst_cur,
-                tma_multicast=tma_multicast,
-                **new_kwargs,
-                **kwargs,
-                loc=loc,
-                ip=ip,
-            )
-
-    @dsl_user_op
-    def copy_tma_single_stage(*, loc=None, ip=None, **new_kwargs):
-        if const_expr(tma_multicast is None):
-            block_copy(atom, src, dst, **new_kwargs, **kwargs, loc=loc, ip=ip)
-        else:
-            block_copy(
-                atom,
-                src,
-                dst,
-                tma_multicast=tma_multicast,
-                **new_kwargs,
-                **kwargs,
-                loc=loc,
-                ip=ip,
-            )
-
-    return copy_tma if const_expr(not single_stage) else copy_tma_single_stage
 
 
 def s2t_get_copy_fn(

--- a/quack/gemm_base.py
+++ b/quack/gemm_base.py
@@ -1179,7 +1179,7 @@ class GemmTmaBase(GemmBase):
             (sD, tDgD_for_tma_partition) if is_s2g else (tDgD_for_tma_partition, sD)
         )
         # NOTE(l2-hints, tried July 2026): a cache_policy kwarg (PTX
-        # createpolicy Int64) flows through tma_get_copy_fn -> block_copy ->
+        # createpolicy Int64) flows through tma_get_copy_fn ->
         # cute.copy if ever needed — we wired D stores as evict_first here and
         # B loads as evict_last in the mainloop and measured a net REGRESSION
         # (-0.9% plain / -3.5% AG at TP4 16384x4096x8192 settled). Don't
@@ -1317,10 +1317,17 @@ class GemmTmaBase(GemmBase):
         16U4_ALIGN8B tensormap (SM120 mixed fp4 x fp8): each 16-element group
         lands as 8 packed-nibble bytes + 8 pad bytes of smem footprint, ready
         for the ldsm.b4x16_p64 unpacking ldmatrix."""
-        # block_copy takes compiler-driven multicast metadata at the copy site,
-        # so the TMA atom itself must stay the non-multicast variant here.
-        op = cpasync.CopyBulkTensorTileG2SOp()
+        op = (
+            cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
         tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
-            op, tensor, smem_layout, smem_tile, internal_type=internal_type
+            op,
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=mcast_dim,
+            internal_type=internal_type,
         )
         return tma_atom, tma_tensor

--- a/quack/gemm_config.py
+++ b/quack/gemm_config.py
@@ -206,14 +206,20 @@ def _get_sm100_configs(
         + [(256, tile_n, (2, 2)) for tile_n in tile_n_vals]
         + [(256, 512, (2, 1))]
     )
+    # Larger cluster shapes for 2SM MMA + CLC only to avoid excessive CGA quant
+    tile_mn_cluster_vals_clc_only = [(256, tile_n, (4, 2)) for tile_n in tile_n_vals] + [
+        (256, tile_n, (2, 4)) for tile_n in tile_n_vals
+    ]
     swap_ab_vals = [False, True]
     if epilogue in ["lse", "gated"]:
         swap_ab_vals = [False]
     GemmConfigCls = partial(
         GemmConfig, pingpong=False, device_capacity=10
     )  # There's no pingpong on Sm100
-    use_clc_vals = [True, False]
     use_tma_gather_vals = [True, False]
+    tile_mn_cluster_clc_vals = [
+        (tmc, use_clc) for tmc in tile_mn_cluster_vals for use_clc in (True, False)
+    ] + [(tmc, True) for tmc in tile_mn_cluster_vals_clc_only]
     return [
         GemmConfigCls(
             tile_m=m,
@@ -225,8 +231,8 @@ def _get_sm100_configs(
             is_dynamic_persistent=use_clc,
             use_tma_gather=use_tma_gather,
         )
-        for (m, n, (cm, cn)), sab, use_clc, use_tma_gather in itertools.product(
-            tile_mn_cluster_vals, swap_ab_vals, use_clc_vals, use_tma_gather_vals
+        for ((m, n, (cm, cn)), use_clc), sab, use_tma_gather in itertools.product(
+            tile_mn_cluster_clc_vals, swap_ab_vals, use_tma_gather_vals
         )
     ]
 

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -813,12 +813,8 @@ class GemmSm100(GemmTmaBase):
         a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
         b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
         tma_atom_a, tma_tensor_a = None, None
-        a_op = (
-            cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
-            if const_expr(not self.gather_A)
-            else sm100_utils.cluster_shape_to_tma_atom_A(
-                self.cluster_shape_mnk, self.tiled_mma.thr_id
-            )
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mnk, self.tiled_mma.thr_id
         )
         if const_expr(not self.gather_A):
             # varlen_m + an active M-fold reduce sink: rag A (2-extra-dim
@@ -862,9 +858,9 @@ class GemmSm100(GemmTmaBase):
                 tma_smem_layout.shape,
                 internal_type=(cutlass.TFloat32 if mA.element_type is Float32 else None),
             )
-        # block_copy takes compiler-driven multicast metadata at the copy site,
-        # so the TMA atom itself must stay the non-multicast variant here.
-        b_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mnk, self.tiled_mma.thr_id
+        )
         tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
             b_op,
             copy_utils.create_ragged_tensor_for_tma(mB, ragged_dim=1) if varlen_k else mB,
@@ -882,8 +878,10 @@ class GemmSm100(GemmTmaBase):
         tma_atom_sfa, tma_tensor_sfa = None, None
         tma_atom_sfb, tma_tensor_sfb = None, None
         if const_expr(self.blockscaled):
-            # Setup TMA load for SFA
-            sfa_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+            # Setup TMA load for SFA (same M-semantics as A: mcast across N)
+            sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+                self.cluster_shape_mnk, self.tiled_mma.thr_id
+            )
             sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
             tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
                 sfa_op,
@@ -911,14 +909,16 @@ class GemmSm100(GemmTmaBase):
             # overlapped-window remap presented atoms in groups of 4 and
             # zero-filled past the *presented* extent instead, silently zeroing
             # the last valid columns (see the N=448 regression test).
-            # SFB is multicast across all cluster-M CTAs (compiler-driven at the
-            # copy site, like B); the op carries cta_group so 2-CTA kernels use
-            # cta_group::2 multicast, whose transaction bytes aggregate at the
-            # pair leader's barrier as num_tma_load_bytes expects. The atom
-            # stays the non-multicast variant with num_multicast=1 (same as
-            # A/B): block_copy's lowering derives the mask and slicing from the
-            # tma_multicast dict.
-            sfb_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+            # SFB is duplicated (not V-split like B) across the 2-CTA MMA
+            # pair, so its multicast group spans every cluster-M CTA including
+            # the pair peer (halving SFB gmem traffic within a pair):
+            # num_multicast = cluster_m, and the box splits across that group.
+            # The op carries cta_group so 2-CTA kernels use cta_group::2
+            # multicast, whose transaction bytes aggregate at the pair
+            # leader's barrier as num_tma_load_bytes expects.
+            sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+                self.cluster_shape_mnk, self.tiled_mma.thr_id
+            )
             sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
             # Compact column-major: (chunk, k-chunks, window atoms).
             sfb_window_layout = cute.make_layout(
@@ -936,6 +936,7 @@ class GemmSm100(GemmTmaBase):
                 mSFB,
                 sfb_window_layout,
                 sfb_window_layout.shape,
+                num_multicast=self.cluster_shape_mnk[0],
             )
 
         # Transaction bytes are counted with the GMEM dtype: for unpack operands
@@ -1290,6 +1291,36 @@ class GemmSm100(GemmTmaBase):
                 cute.arch.griddepcontrol_wait()
             if const_expr(self.gather_A):
                 cute.arch.setmaxregister_decrease(self.num_regs_other)
+            # Multicast masks + partition coords for the A/B(/SFA/SFB) TMA
+            # loads: A/SFA are same-M across N peers, B same-N across M peers,
+            # and SFB spans every cluster-M CTA including the 2-CTA MMA pair
+            # peer (duplicated, not V-split — halves SFB gmem traffic within a
+            # pair).
+            block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+            cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk = None, None
+            if const_expr(self.blockscaled):
+                cluster_layout_sfb_vmnk = cute.tiled_divide(
+                    cute.make_layout(self.cluster_shape_mnk), ((1,),)
+                )
+                block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+                    cta_rank_in_cluster
+                )
+            a_mcast_mask, b_mcast_mask = None, None
+            sfa_mcast_mask, sfb_mcast_mask = None, None
+            if const_expr(self.is_a_mcast or self.is_b_mcast or self.use_2cta_instrs):
+                a_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+                b_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+                )
+                if const_expr(self.blockscaled):
+                    sfa_mcast_mask = a_mcast_mask
+                    sfb_mcast_mask = cpasync.create_tma_multicast_mask(
+                        cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+                    )
+            a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+            b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
             # Persistent tile scheduling loop
             tile_scheduler = TileSchedulerCls()
             work_tile = tile_scheduler.initial_work_tile_info()
@@ -1381,35 +1412,17 @@ class GemmSm100(GemmTmaBase):
                 # Partition global tensor for TiledMMA_A/B/D
                 # Then partition global/shared tensor for TMA load A/B
                 len_k = varlen_manager.len_k(batch_idx)
-                # block_copy's lowering wants the coordinate held fixed by the
-                # multicast mask: A/SFA are same-M across N peers, while B/SFB
-                # are same-N across M peers. Degenerate cluster dimensions are
-                # left for the compiler lowering to simplify.
-                a_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "M",
-                }
-                b_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "N",
-                }
-                # SFB is duplicated (not V-split like B) across the 2-CTA MMA
-                # pair, so unlike B its multicast group spans every cluster-M
-                # CTA including the pair peer: use_2cta_mma_inst=False makes
-                # the lowering slice/multicast across all of them (halving SFB
-                # gmem traffic within a pair), while the op's cta_group still
-                # aggregates transaction bytes at the pair leader's barrier.
-                sfb_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "N",
-                    "use_2cta_mma_inst": False,
-                }
                 copy_A, prefetch_A = None, None
                 if const_expr(not self.gather_A):
                     # (MMA, MMA_M, MMA_K, RestK)
                     tCgA = thr_mma.partition_A(gA_mk)
-                    copy_A = copy_utils.tma_get_block_copy_fn(
-                        tma_atom_a, src_tensor=tCgA, dst_tensor=sA, tma_multicast=a_tma_multicast
+                    copy_A, _, _ = copy_utils.tma_get_copy_fn(
+                        tma_atom_a,
+                        cta_coord=block_in_cluster_coord_vmnk[2],
+                        cta_layout=a_cta_layout,
+                        src_tensor=tCgA,
+                        dst_tensor=sA,
+                        mcast_mask=a_mcast_mask,
                     )
                 else:
                     # For varlen_m paths (TMA or cp.async): consume indices from
@@ -1439,25 +1452,39 @@ class GemmSm100(GemmTmaBase):
                     # (MMA, MMA_M, MMA_K)
                     tCgSFA = thr_mma.partition_A(gSFA_mkl)
                 # TMA load B partition_S/D
-                copy_B = copy_utils.tma_get_block_copy_fn(
-                    tma_atom_b, src_tensor=tCgB, dst_tensor=sB, tma_multicast=b_tma_multicast
+                copy_B, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_b,
+                    cta_coord=block_in_cluster_coord_vmnk[1],
+                    cta_layout=b_cta_layout,
+                    src_tensor=tCgB,
+                    dst_tensor=sB,
+                    mcast_mask=b_mcast_mask,
                 )
                 copy_SFA, copy_SFB = None, None
                 if const_expr(self.blockscaled):
                     #  TMA load SFA partition_S/D
-                    copy_SFA = copy_utils.tma_get_block_copy_fn(
+                    copy_SFA, _, _ = copy_utils.tma_get_copy_fn(
                         tma_atom_sfa,
+                        cta_coord=block_in_cluster_coord_vmnk[2],
+                        cta_layout=a_cta_layout,
                         src_tensor=tCgSFA,
                         dst_tensor=sSFA,
-                        tma_multicast=a_tma_multicast,
+                        filter_zeros=True,
+                        mcast_mask=sfa_mcast_mask,
                     )
-                    # SFB multicast: same-N across all cluster-M CTAs (see
-                    # sfb_tma_multicast above).
-                    copy_SFB = copy_utils.tma_get_block_copy_fn(
+                    # SFB multicast: same-N across all cluster-M CTAs (the
+                    # atom's num_multicast = cluster_m splits the chunk window
+                    # across the group).
+                    sfb_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+                    )
+                    copy_SFB, _, _ = copy_utils.tma_get_copy_fn(
                         tma_atom_sfb,
+                        cta_coord=block_in_cluster_coord_sfb_vmnk[1],
+                        cta_layout=sfb_cta_layout,
                         src_tensor=gSFB_chunks,
                         dst_tensor=sSFB_chunks,
-                        tma_multicast=sfb_tma_multicast,
+                        mcast_mask=sfb_mcast_mask,
                     )
                 k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
                 k_tile_start, k_tile_cnt = tile_scheduler.get_split_k_tile_range(

--- a/quack/gemm_sm100.py
+++ b/quack/gemm_sm100.py
@@ -3,6 +3,7 @@
 # https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py
 
 from typing import Optional, Type, Tuple, Union, Callable, Literal
+from dataclasses import dataclass
 from functools import partial
 import math
 
@@ -22,8 +23,10 @@ from cutlass.cute.nvgpu.warp import (
     StMatrix16x8x8bOp,
 )
 from cutlass import Int32, Float32, Boolean, const_expr
+from cutlass.cutlass_dsl import if_generate, select_
 from cutlass.utils import LayoutEnum
 from cutlass.cute.experimental import iket
+from cutlass.cute.experimental import is_preferred_cluster
 
 
 from quack.pipeline import (
@@ -89,6 +92,10 @@ This GEMM kernel supports the following features:
     - Implements TMA multicast with cluster to reduce L2 memory traffic
     - Support persistent tile scheduling to better overlap memory load/store with mma between tiles
     - Support warp specialization to avoid explicit pipelining between mainloop load and mma
+    - Mixed preferred/fallback cluster launches under CLC persistence: when the driver cannot
+      co-schedule a full preferred cluster it launches fallback-shaped clusters ((2, 1) for 2-CTA
+      MMA, (1, 1) otherwise) instead of serializing; one kernel body selects the shape-specific
+      load TMA atoms, multicast masks and barrier arrive counts at runtime
 
 This GEMM works as follows:
 1. DMA warp: Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
@@ -120,6 +127,44 @@ Constraints:
 
 # canonical home moved to gemm_base (shared with the SM120 blockscaled path)
 from quack.gemm_base import reinterpret_packed_fp6 as _reinterpret_packed_fp6  # noqa: E402
+
+
+@dataclass(frozen=True)
+class _LoadMcastGeometry:
+    """TMA load geometry of ONE cluster shape: this CTA's coordinate in the cluster
+    layout, the CTA layouts the loads partition over, and the multicast masks."""
+
+    coord_vmnk: tuple
+    a_cta_layout: cute.Layout
+    b_cta_layout: cute.Layout
+    a_mcast_mask: Optional[cutlass.Int16]
+    b_mcast_mask: Optional[cutlass.Int16]
+    sfa_mcast_mask: Optional[cutlass.Int16]
+    sfb_mcast_mask: Optional[cutlass.Int16]
+    sfb_coord_vmnk: Optional[tuple]
+    sfb_cta_layout: Optional[cute.Layout]
+
+
+def _select_copy_fn(
+    is_pref: Boolean, copy_pref: Optional[Callable], copy_fallback: Optional[Callable]
+):
+    """Copy fn that issues the preferred or the fallback atom's copy per the runtime
+    cluster shape. None fallback = the atoms are equivalent, use the preferred one."""
+    if copy_fallback is None:
+        return copy_pref
+
+    def copy_selected(*args, **kwargs):
+        if_generate(
+            is_pref,
+            lambda: copy_pref(*args, **kwargs),
+            lambda: copy_fallback(*args, **kwargs),
+        )
+
+    return copy_selected
+
+
+def _select_i32(pred: Boolean, if_value: int, else_value: int) -> Int32:
+    return Int32(select_(pred, Int32(if_value), Int32(else_value)))
 
 
 class GemmSm100(GemmTmaBase):
@@ -266,6 +311,30 @@ class GemmSm100(GemmTmaBase):
             self.mma_tiler = (*mma_tiler_mnk, 0)
         self.is_persistent = True
         self.use_clc_persistence = use_clc_persistence
+        # Mixed preferred/fallback cluster launch (CLC persistence only): when the
+        # hardware cannot co-schedule a full preferred cluster (SM count not a
+        # multiple of the cluster size, co-tenant kernels, wave tails), the driver
+        # launches fallback-shaped clusters instead of serializing; the kernel
+        # selects per-shape atoms/masks/arrive counts at runtime. The fallback keeps the 2-CTA
+        # MMA pair intact: (2,1) with cta_group=2, else (1,1). No-op when the
+        # preferred cluster already is the fallback shape. The tile scheduler
+        # decode stays in preferred-cluster units for both shapes (CTA-remainder
+        # decode, see tile_scheduler._cluster_id_to_cta_id).
+        fallback_mnk = (2 if self.use_2cta_instrs else 1, 1, 1)
+        self.fallback_cluster_shape_mnk = (
+            fallback_mnk
+            if use_clc_persistence and tuple(cluster_shape_mnk) != fallback_mnk
+            else None
+        )
+        # The driver rejects mixed launches unless the fallback divides the
+        # preferred shape per-dim (CUDA_ERROR_INVALID_CLUSTER_SIZE, opaque); the
+        # derivation guarantees it (fallback_m is 2 only for an even cluster_m).
+        # Test hook: launch the (unchanged) mixed kernel with the preferred launch
+        # shape shrunk to the fallback shape, so every cluster launches
+        # fallback-shaped and the runtime predicate selects the fallback atoms,
+        # masks and arrive counts — the only deterministic way to execute that
+        # path (the driver only falls back under resource pressure).
+        self._force_fallback_branch = False
         self.epi_m_major = True
         self.gather_A = gather_A
         self.concat_layout = concat_layout or ()
@@ -475,6 +544,12 @@ class GemmSm100(GemmTmaBase):
             cute.make_layout(self.cluster_shape_mnk),
             (self.tiled_mma.thr_id.shape,),
         )
+        self.fallback_cluster_layout_vmnk = None
+        if const_expr(self.fallback_cluster_shape_mnk is not None):
+            self.fallback_cluster_layout_vmnk = cute.tiled_divide(
+                cute.make_layout(self.fallback_cluster_shape_mnk),
+                (self.tiled_mma.thr_id.shape,),
+            )
 
         # Compute number of multicast CTAs for A/B
         self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
@@ -656,6 +731,158 @@ class GemmSm100(GemmTmaBase):
         else:
             self.iter_acc_early_release = -1
 
+    def _make_load_tma_atoms_and_tensors(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mSFA: Optional[cute.Tensor],
+        mSFB: Optional[cute.Tensor],
+        a_smem_layout,
+        b_smem_layout,
+        sfb_smem_layout,
+        epilogue_args,
+        varlen_m: bool,
+        varlen_k: bool,
+        cluster_shape_mnk,
+        cluster_layout_vmnk,
+    ):
+        """One set of G2S TMA atoms + coordinate tensors for A/B (and SFA/SFB
+        when blockscaled), built for ONE cluster shape: the multicast op choice
+        and the box split (num_multicast) are baked into each atom, so a mixed
+        preferred/fallback launch needs one set per shape (the kernel picks per
+        copy at runtime where they differ)."""
+        tma_atom_a, tma_tensor_a = None, None
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(cluster_shape_mnk, self.tiled_mma.thr_id)
+        if const_expr(not self.gather_A):
+            # varlen_m + an active M-fold reduce sink: rag A (2-extra-dim
+            # wraparound; loads can't ptr_shift) so rows past the sequence end
+            # zero-fill instead of reading the next sequence — restores the
+            # "OOB accumulator lanes are zero" invariant that the unpredicated
+            # M-fold relies on. Without such a sink, garbage rows are masked at
+            # every store, so plain domain_offset keeps the descriptor 2-D.
+            if const_expr(varlen_m and self.epilogue_zero_fill_varlen_m(epilogue_args)):
+                mA_tma = copy_utils.create_ragged_tensor_for_tma(mA, ragged_dim=0, ptr_shift=False)
+            elif const_expr(varlen_k):
+                mA_tma = copy_utils.create_ragged_tensor_for_tma(mA, ragged_dim=1, ptr_shift=False)
+            else:
+                mA_tma = mA
+            tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+                a_op,
+                mA_tma,
+                a_smem_layout,
+                self.mma_tiler,
+                self.tiled_mma,
+                cluster_layout_vmnk.shape,
+                # Uint8 internal type + sub-byte gmem element selects the
+                # U4/U6_UNPACK_U8 tensormap (packed gmem -> byte-container smem).
+                internal_type=(
+                    cutlass.Uint8
+                    if const_expr(self.a_unpack)
+                    else (cutlass.TFloat32 if mA.element_type is Float32 else None)
+                ),
+            )
+        elif const_expr(self.use_tma_gather):
+            # gather4 descriptor: box has 1 in the gathered dim, tile size in the contiguous dim.
+            # varlen_m (K-major): box (1, tile_K), gather M rows at K offset
+            # varlen_k (M-major): box (64, 1), gather K cols at M offset
+            tma_smem_layout = quack_sm100_utils.make_smem_layout_atom_tma_gather_a(
+                self.tiled_mma, self.mma_tiler, self.a_dtype, gather_size=1
+            )
+            tma_atom_a, tma_tensor_a = cpasync.make_tiled_tma_atom(
+                a_op,
+                mA,
+                tma_smem_layout,
+                tma_smem_layout.shape,
+                internal_type=(cutlass.TFloat32 if mA.element_type is Float32 else None),
+            )
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(cluster_shape_mnk, self.tiled_mma.thr_id)
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            copy_utils.create_ragged_tensor_for_tma(mB, ragged_dim=1) if varlen_k else mB,
+            b_smem_layout,
+            self.mma_tiler,
+            self.tiled_mma,
+            cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.Uint8
+                if const_expr(self.b_unpack)
+                else (cutlass.TFloat32 if mB.element_type is Float32 else None)
+            ),
+        )
+
+        tma_atom_sfa, tma_tensor_sfa = None, None
+        tma_atom_sfb, tma_tensor_sfb = None, None
+        if const_expr(self.blockscaled):
+            # Setup TMA load for SFA (same M-semantics as A: mcast across N)
+            sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+                cluster_shape_mnk, self.tiled_mma.thr_id
+            )
+            sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+            tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+                sfa_op,
+                mSFA,
+                sfa_smem_layout,
+                self.mma_tiler,
+                self.tiled_mma,
+                cluster_layout_vmnk.shape,
+                internal_type=cutlass.Int16,
+            )
+            # Setup TMA load for SFB.
+            # One box per stage covering the tile's SF window at chunk
+            # granularity: (256 Int16 = one 512-B atom-chunk, chunks-per-k-tile,
+            # window atoms). Because the box coordinates are free-form (not
+            # tiler multiples), a tile whose window starts mid-way into the
+            # atom sequence (tile_n=192 advances 1.5 atoms per tile) needs no
+            # layout tricks: the kernel computes first_atom = j*tile_n//128 and
+            # slices there. Tiles start (j*tile_n) % 128 into their first atom;
+            # the mma warp corrects for that via an SFB tmem column offset.
+            # The atom-n dim's extent is the allocated atom count, so a last
+            # tile whose window straddles past it (tile_n=192 with e.g. N=448:
+            # window atoms {3,4}, only 4 allocated) gets the out-of-range atom
+            # hardware-zero-filled — its columns are beyond N, where B is
+            # zero-filled too. This invariant is load-bearing: the previous
+            # overlapped-window remap presented atoms in groups of 4 and
+            # zero-filled past the *presented* extent instead, silently zeroing
+            # the last valid columns (see the N=448 regression test).
+            # SFB is duplicated (not V-split like B) across the 2-CTA MMA
+            # pair, so its multicast group spans every cluster-M CTA including
+            # the pair peer (halving SFB gmem traffic within a pair):
+            # num_multicast = cluster_m, and the box splits across that group.
+            # The op carries cta_group so 2-CTA kernels use cta_group::2
+            # multicast, whose transaction bytes aggregate at the pair
+            # leader's barrier as num_tma_load_bytes expects.
+            sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+                cluster_shape_mnk, self.tiled_mma.thr_id
+            )
+            # Compact column-major: (chunk, k-chunks, window atoms).
+            sfb_window_layout = cute.make_layout(
+                (256, self.sfb_chunks_per_ktile, self.sfb_window_atoms)
+            )
+            # The chunk view must tile the actual SFB smem stage bytes exactly
+            # (atom-major, k-chunks inner — the order make_smem_layout_sfb
+            # produces).
+            assert cute.cosize(sfb_smem_layout) == 2 * cute.cosize(sfb_window_layout)
+            assert cute.cosize(self.sfb_smem_layout_staged) == (
+                2 * cute.cosize(sfb_window_layout) * self.ab_stage
+            )
+            tma_atom_sfb, tma_tensor_sfb = cpasync.make_tiled_tma_atom(
+                sfb_op,
+                mSFB,
+                sfb_window_layout,
+                sfb_window_layout.shape,
+                num_multicast=cluster_shape_mnk[0],
+            )
+        return (
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+        )
+
     @cute.jit
     def __call__(
         self,
@@ -812,133 +1039,53 @@ class GemmSm100(GemmTmaBase):
         # Setup TMA load for A & B
         a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
         b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
-        tma_atom_a, tma_tensor_a = None, None
-        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
-            self.cluster_shape_mnk, self.tiled_mma.thr_id
-        )
-        if const_expr(not self.gather_A):
-            # varlen_m + an active M-fold reduce sink: rag A (2-extra-dim
-            # wraparound; loads can't ptr_shift) so rows past the sequence end
-            # zero-fill instead of reading the next sequence — restores the
-            # "OOB accumulator lanes are zero" invariant that the unpredicated
-            # M-fold relies on. Without such a sink, garbage rows are masked at
-            # every store, so plain domain_offset keeps the descriptor 2-D.
-            if const_expr(varlen_m and self.epilogue_zero_fill_varlen_m(epilogue_args)):
-                mA_tma = copy_utils.create_ragged_tensor_for_tma(mA, ragged_dim=0, ptr_shift=False)
-            elif const_expr(varlen_k):
-                mA_tma = copy_utils.create_ragged_tensor_for_tma(mA, ragged_dim=1, ptr_shift=False)
-            else:
-                mA_tma = mA
-            tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
-                a_op,
-                mA_tma,
-                a_smem_layout,
-                self.mma_tiler,
-                self.tiled_mma,
-                self.cluster_layout_vmnk.shape,
-                # Uint8 internal type + sub-byte gmem element selects the
-                # U4/U6_UNPACK_U8 tensormap (packed gmem -> byte-container smem).
-                internal_type=(
-                    cutlass.Uint8
-                    if const_expr(self.a_unpack)
-                    else (cutlass.TFloat32 if mA.element_type is Float32 else None)
-                ),
-            )
-        elif const_expr(self.use_tma_gather):
-            # gather4 descriptor: box has 1 in the gathered dim, tile size in the contiguous dim.
-            # varlen_m (K-major): box (1, tile_K), gather M rows at K offset
-            # varlen_k (M-major): box (64, 1), gather K cols at M offset
-            tma_smem_layout = quack_sm100_utils.make_smem_layout_atom_tma_gather_a(
-                self.tiled_mma, self.mma_tiler, self.a_dtype, gather_size=1
-            )
-            tma_atom_a, tma_tensor_a = cpasync.make_tiled_tma_atom(
-                a_op,
-                mA,
-                tma_smem_layout,
-                tma_smem_layout.shape,
-                internal_type=(cutlass.TFloat32 if mA.element_type is Float32 else None),
-            )
-        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
-            self.cluster_shape_mnk, self.tiled_mma.thr_id
-        )
-        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
-            b_op,
-            copy_utils.create_ragged_tensor_for_tma(mB, ragged_dim=1) if varlen_k else mB,
-            b_smem_layout,
-            self.mma_tiler,
-            self.tiled_mma,
-            self.cluster_layout_vmnk.shape,
-            internal_type=(
-                cutlass.Uint8
-                if const_expr(self.b_unpack)
-                else (cutlass.TFloat32 if mB.element_type is Float32 else None)
-            ),
-        )
-
-        tma_atom_sfa, tma_tensor_sfa = None, None
-        tma_atom_sfb, tma_tensor_sfb = None, None
+        sfa_smem_layout, sfb_smem_layout = None, None
         if const_expr(self.blockscaled):
-            # Setup TMA load for SFA (same M-semantics as A: mcast across N)
-            sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
-                self.cluster_shape_mnk, self.tiled_mma.thr_id
-            )
             sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
-            tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
-                sfa_op,
-                mSFA,
-                sfa_smem_layout,
-                self.mma_tiler,
-                self.tiled_mma,
-                self.cluster_layout_vmnk.shape,
-                internal_type=cutlass.Int16,
-            )
-            # Setup TMA load for SFB.
-            # One box per stage covering the tile's SF window at chunk
-            # granularity: (256 Int16 = one 512-B atom-chunk, chunks-per-k-tile,
-            # window atoms). Because the box coordinates are free-form (not
-            # tiler multiples), a tile whose window starts mid-way into the
-            # atom sequence (tile_n=192 advances 1.5 atoms per tile) needs no
-            # layout tricks: the kernel computes first_atom = j*tile_n//128 and
-            # slices there. Tiles start (j*tile_n) % 128 into their first atom;
-            # the mma warp corrects for that via an SFB tmem column offset.
-            # The atom-n dim's extent is the allocated atom count, so a last
-            # tile whose window straddles past it (tile_n=192 with e.g. N=448:
-            # window atoms {3,4}, only 4 allocated) gets the out-of-range atom
-            # hardware-zero-filled — its columns are beyond N, where B is
-            # zero-filled too. This invariant is load-bearing: the previous
-            # overlapped-window remap presented atoms in groups of 4 and
-            # zero-filled past the *presented* extent instead, silently zeroing
-            # the last valid columns (see the N=448 regression test).
-            # SFB is duplicated (not V-split like B) across the 2-CTA MMA
-            # pair, so its multicast group spans every cluster-M CTA including
-            # the pair peer (halving SFB gmem traffic within a pair):
-            # num_multicast = cluster_m, and the box splits across that group.
-            # The op carries cta_group so 2-CTA kernels use cta_group::2
-            # multicast, whose transaction bytes aggregate at the pair
-            # leader's barrier as num_tma_load_bytes expects.
-            sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
-                self.cluster_shape_mnk, self.tiled_mma.thr_id
-            )
             sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
-            # Compact column-major: (chunk, k-chunks, window atoms).
-            sfb_window_layout = cute.make_layout(
-                (256, self.sfb_chunks_per_ktile, self.sfb_window_atoms)
-            )
-            # The chunk view must tile the actual SFB smem stage bytes exactly
-            # (atom-major, k-chunks inner — the order make_smem_layout_sfb
-            # produces).
-            assert cute.cosize(sfb_smem_layout) == 2 * cute.cosize(sfb_window_layout)
-            assert cute.cosize(self.sfb_smem_layout_staged) == (
-                2 * cute.cosize(sfb_window_layout) * self.ab_stage
-            )
-            tma_atom_sfb, tma_tensor_sfb = cpasync.make_tiled_tma_atom(
-                sfb_op,
+        # One set of load atoms per cluster shape under a mixed launch (see
+        # _make_load_tma_atoms_and_tensors); mirrors CUTLASS C++ tma_load_a /
+        # tma_load_a_fallback.
+        load_tma = self._make_load_tma_atoms_and_tensors(
+            mA,
+            mB,
+            mSFA,
+            mSFB,
+            a_smem_layout,
+            b_smem_layout,
+            sfb_smem_layout,
+            epilogue_args,
+            varlen_m,
+            varlen_k,
+            self.cluster_shape_mnk,
+            self.cluster_layout_vmnk,
+        )
+        (
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+        ) = load_tma
+        fallback_load_tma = None
+        if const_expr(self.fallback_cluster_shape_mnk is not None):
+            fallback_load_tma = self._make_load_tma_atoms_and_tensors(
+                mA,
+                mB,
+                mSFA,
                 mSFB,
-                sfb_window_layout,
-                sfb_window_layout.shape,
-                num_multicast=self.cluster_shape_mnk[0],
+                a_smem_layout,
+                b_smem_layout,
+                sfb_smem_layout,
+                epilogue_args,
+                varlen_m,
+                varlen_k,
+                self.fallback_cluster_shape_mnk,
+                self.fallback_cluster_layout_vmnk,
             )
-
         # Transaction bytes are counted with the GMEM dtype: for unpack operands
         # the layout is byte-domain (cosize == smem footprint bytes) but TMA
         # reports only the packed data bytes it copies (elements x 4 or 6 bits;
@@ -1061,7 +1208,41 @@ class GemmSm100(GemmTmaBase):
 
         self.shared_storage = SharedStorage
 
-        # Launch the kernel synchronously
+        # Launch the kernel synchronously. Mixed preferred/fallback launch: the
+        # DSL lowers cluster= to CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION
+        # and fallback_cluster= to the plain cluster dimension when both are set.
+        launch_cluster = self.cluster_shape_mnk
+        fallback_launch_kwargs = {}
+        if const_expr(self.fallback_cluster_shape_mnk is not None):
+            fallback_launch_kwargs = dict(fallback_cluster=list(self.fallback_cluster_shape_mnk))
+            if const_expr(self._force_fallback_branch):
+                # Test hook: plain launch at the fallback shape (no mixed launch),
+                # so is_preferred_cluster() is false in every cluster and the
+                # kernel takes the fallback atoms/masks/arrive counts.
+                launch_cluster = self.fallback_cluster_shape_mnk
+                fallback_launch_kwargs = {}
+        fallback_kernel_tma = None
+        if const_expr(self.fallback_cluster_shape_mnk is not None):
+            (
+                fb_atom_a,
+                fb_tensor_a,
+                fb_atom_b,
+                fb_tensor_b,
+                fb_atom_sfa,
+                fb_tensor_sfa,
+                fb_atom_sfb,
+                fb_tensor_sfb,
+            ) = fallback_load_tma
+            fallback_kernel_tma = (
+                fb_atom_a,
+                fb_tensor_a if const_expr(not self.gather_A or self.use_tma_gather) else mA,
+                fb_atom_b,
+                fb_tensor_b,
+                fb_atom_sfa,
+                fb_tensor_sfa,
+                fb_atom_sfb,
+                fb_tensor_sfb,
+            )
         self.kernel(
             self.tiled_mma,
             tma_atom_a,
@@ -1079,6 +1260,8 @@ class GemmSm100(GemmTmaBase):
             epilogue_params,
             varlen_params,
             self.cluster_layout_vmnk,
+            self.fallback_cluster_layout_vmnk,
+            fallback_kernel_tma,
             self.a_smem_layout_staged,
             self.a_smem_load_layout_staged,
             self.b_smem_layout_staged,
@@ -1092,10 +1275,11 @@ class GemmSm100(GemmTmaBase):
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
-            cluster=self.cluster_shape_mnk,
+            cluster=launch_cluster,
             stream=stream,
             min_blocks_per_mp=1,
             use_pdl=self.use_pdl,
+            **fallback_launch_kwargs,
         )
         return
 
@@ -1119,6 +1303,8 @@ class GemmSm100(GemmTmaBase):
         epilogue_params,
         varlen_params: VarlenManager.Params,
         cluster_layout_vmnk: cute.Layout,
+        fallback_cluster_layout_vmnk: Optional[cute.Layout],
+        fallback_load_tma: Optional[tuple],
         a_smem_layout: cute.ComposedLayout,
         a_smem_load_layout: cute.ComposedLayout,
         b_smem_layout: cute.ComposedLayout,
@@ -1132,7 +1318,35 @@ class GemmSm100(GemmTmaBase):
     ):
         """
         GPU device kernel performing the Persistent batched GEMM computation.
+
+        Mixed preferred/fallback cluster launches (CLC persistence): ONE kernel
+        body serves both cluster shapes, as CUTLASS C++ does with tma_load_a /
+        tma_load_a_fallback. cluster_layout_vmnk (the preferred shape) drives
+        everything static — pipeline construction, this CTA's coordinate, init
+        barriers, elections — which agrees with the fallback shape for the ranks
+        a fallback cluster actually has (the fallback divides the preferred shape
+        along its leading modes). When fallback_load_tma is given,
+        is_preferred_cluster() (runtime cluster_nctaid) selects per cluster: the
+        load TMA atoms whose multicast op / box split differ between the shapes,
+        the AB / sched pipeline consumer arrive counts and the tcgen05.commit
+        release mask, and whether the CLC drain runs.
         """
+        mixed = const_expr(fallback_load_tma is not None)
+        is_pref = None
+        fb_tma_atom_a, fb_mA_mkl, fb_tma_atom_b, fb_mB_nkl = None, None, None, None
+        fb_tma_atom_sfa, fb_mSFA_mkl, fb_tma_atom_sfb, fb_mSFB_chunks = None, None, None, None
+        if const_expr(mixed):
+            is_pref = is_preferred_cluster(self.cluster_shape_mnk)
+            (
+                fb_tma_atom_a,
+                fb_mA_mkl,
+                fb_tma_atom_b,
+                fb_mB_nkl,
+                fb_tma_atom_sfa,
+                fb_mSFA_mkl,
+                fb_tma_atom_sfb,
+                fb_mSFB_chunks,
+            ) = fallback_load_tma
 
         varlen_m = const_expr(varlen_params.cu_seqlens_m is not None)
         varlen_k = const_expr(varlen_params.cu_seqlens_k is not None)
@@ -1145,7 +1359,7 @@ class GemmSm100(GemmTmaBase):
 
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
-        # Prefetch Tma desc
+        # Prefetch Tma desc (both load-atom sets under a mixed launch)
         if warp_idx == self.ab_load_warp_id:
             for tma_atom in (
                 tma_atom_a,
@@ -1154,6 +1368,10 @@ class GemmSm100(GemmTmaBase):
                 tma_atom_sfb,
                 tma_atom_d,
                 tma_atom_c,
+                fb_tma_atom_a,
+                fb_tma_atom_b,
+                fb_tma_atom_sfa,
+                fb_tma_atom_sfb,
             ):
                 if const_expr(tma_atom is not None):
                     cpasync.prefetch_descriptor(tma_atom)
@@ -1178,6 +1396,8 @@ class GemmSm100(GemmTmaBase):
             tiled_mma=tiled_mma,
             cluster_layout_vmnk=cluster_layout_vmnk,
             is_leader_cta=is_leader_cta,
+            fallback_cluster_layout_vmnk=fallback_cluster_layout_vmnk,
+            is_pref=is_pref,
         )
         epi_pipeline = None
         if const_expr(has_epi_load):
@@ -1186,7 +1406,12 @@ class GemmSm100(GemmTmaBase):
         sched_pipeline = None
         sched_data = None
         if const_expr(self.is_persistent):
-            sched_pipeline = self.make_sched_pipeline(self.cluster_shape_mnk, has_C=has_epi_load)
+            sched_pipeline = self.make_sched_pipeline(
+                cluster_layout_vmnk,
+                has_C=has_epi_load,
+                fallback_cluster_layout_vmnk=fallback_cluster_layout_vmnk,
+                is_pref=is_pref,
+            )
             sched_data = storage.sched_data.get_tensor(cute.make_layout((4, self.sched_stage)))
         a_prefetch_pipeline = None
         if const_expr(self.gather_A):
@@ -1291,36 +1516,30 @@ class GemmSm100(GemmTmaBase):
                 cute.arch.griddepcontrol_wait()
             if const_expr(self.gather_A):
                 cute.arch.setmaxregister_decrease(self.num_regs_other)
-            # Multicast masks + partition coords for the A/B(/SFA/SFB) TMA
-            # loads: A/SFA are same-M across N peers, B same-N across M peers,
-            # and SFB spans every cluster-M CTA including the 2-CTA MMA pair
-            # peer (duplicated, not V-split — halves SFB gmem traffic within a
-            # pair).
-            block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
-            cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk = None, None
-            if const_expr(self.blockscaled):
-                cluster_layout_sfb_vmnk = cute.tiled_divide(
-                    cute.make_layout(self.cluster_shape_mnk), ((1,),)
+            # Multicast masks + partition coords/layouts for the A/B(/SFA/SFB)
+            # TMA loads, per load-atom set. Under a mixed launch the fallback set
+            # differs from the preferred one only where the multicast extent
+            # differs (op variant + box split): A/SFA on cluster N, B on cluster
+            # M per MMA atom, SFB on cluster M. Only those operands get a second
+            # partition and a runtime pick per copy; the rest reuse the preferred
+            # copy fn (equivalent atom, same multicast rank set).
+            geo = self._load_mcast_geometry(
+                cluster_layout_vmnk, self.cluster_shape_mnk, cta_rank_in_cluster
+            )
+            fb_geo, a_differs, b_differs, sfb_differs = None, False, False, False
+            if const_expr(mixed):
+                fb_geo = self._load_mcast_geometry(
+                    fallback_cluster_layout_vmnk,
+                    self.fallback_cluster_shape_mnk,
+                    cta_rank_in_cluster,
                 )
-                block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
-                    cta_rank_in_cluster
+                a_differs = cute.size(cluster_layout_vmnk.shape[2]) != cute.size(
+                    fallback_cluster_layout_vmnk.shape[2]
                 )
-            a_mcast_mask, b_mcast_mask = None, None
-            sfa_mcast_mask, sfb_mcast_mask = None, None
-            if const_expr(self.is_a_mcast or self.is_b_mcast or self.use_2cta_instrs):
-                a_mcast_mask = cpasync.create_tma_multicast_mask(
-                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                b_differs = cute.size(cluster_layout_vmnk.shape[1]) != cute.size(
+                    fallback_cluster_layout_vmnk.shape[1]
                 )
-                b_mcast_mask = cpasync.create_tma_multicast_mask(
-                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
-                )
-                if const_expr(self.blockscaled):
-                    sfa_mcast_mask = a_mcast_mask
-                    sfb_mcast_mask = cpasync.create_tma_multicast_mask(
-                        cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
-                    )
-            a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
-            b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                sfb_differs = self.cluster_shape_mnk[0] != self.fallback_cluster_shape_mnk[0]
             # Persistent tile scheduling loop
             tile_scheduler = TileSchedulerCls()
             work_tile = tile_scheduler.initial_work_tile_info()
@@ -1355,6 +1574,9 @@ class GemmSm100(GemmTmaBase):
                 # gate landed; surfaced on any cold-cache varlen compile).
                 if const_expr(getattr(tile_sched_params, "ag", None) is not None):
                     iket.range_push("ag_wait")
+                    # Deliberately self.cluster_shape_mnk (the PREFERRED shape),
+                    # not this branch's cluster_shape_mnk: the AG shard/chunk
+                    # geometry in tile_sched_params is preferred-cluster-granular.
                     ag_last_gate = ag_wait_m_tile(
                         tile_sched_params,
                         tile_coord_mnkl[0],
@@ -1368,63 +1590,22 @@ class GemmSm100(GemmTmaBase):
                     tile_coord_mnkl[1],
                     tile_coord_mnkl[3],
                 )
-                gA_mk = None
-                if const_expr(not self.gather_A):
-                    mA_mk = varlen_manager.offset_batch_A(mA_mkl, batch_idx)
-                    # (bM, bK, RestK)
-                    gA_mk = cute.local_tile(
-                        mA_mk,
-                        cute.select(self.mma_tiler, [0, 2]),
-                        (mma_tile_coord_mnl[0], None),
-                    )
-                # (bN, bK, RestK)
-                gB_nk = cute.local_tile(
-                    varlen_manager.offset_batch_B(mB_nkl, batch_idx),
-                    cute.select(self.mma_tiler, [1, 2]),
-                    (mma_tile_coord_mnl[1], None),
-                )
-                if const_expr(self.blockscaled):
-                    # (bM, bK)
-                    # SFA uses the tile-aligned per-batch offset (padded SF layout), not
-                    # the A-data offset — allows varlen_m seqlens that aren't
-                    # multiples of 128.
-                    gSFA_mkl = cute.local_tile(
-                        varlen_manager.offset_batch_SFA(mSFA_mkl, batch_idx),
-                        cute.select(self.mma_tiler, [0, 2]),
-                        (mma_tile_coord_mnl[0], None),
-                    )
-                    # (chunk, chunks-per-k-tile, window-atoms, RestK)
-                    # SFB is chunk-granular: place the tile's SF window at atom
-                    # coordinate j*tile_n/128, as a domain_offset because it is
-                    # free-form, not a tiler multiple (tile_n=64 shares an atom
-                    # between adjacent tiles, tile_n=192 advances 1.5 atoms per
-                    # tile — both are just this one formula).
-                    sfb_first_atom = (mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1]) // 128
-                    gSFB_chunks = cute.local_tile(
-                        cute.domain_offset(
-                            (None, None, sfb_first_atom),
-                            varlen_manager.offset_batch_SFB(mSFB_chunks, batch_idx),
-                        ),
-                        (256, self.sfb_chunks_per_ktile, self.sfb_window_atoms),
-                        (0, None, 0),
-                    )
-
-                # Partition global tensor for TiledMMA_A/B/D
-                # Then partition global/shared tensor for TMA load A/B
                 len_k = varlen_manager.len_k(batch_idx)
-                copy_A, prefetch_A = None, None
-                if const_expr(not self.gather_A):
-                    # (MMA, MMA_M, MMA_K, RestK)
-                    tCgA = thr_mma.partition_A(gA_mk)
-                    copy_A, _, _ = copy_utils.tma_get_copy_fn(
-                        tma_atom_a,
-                        cta_coord=block_in_cluster_coord_vmnk[2],
-                        cta_layout=a_cta_layout,
-                        src_tensor=tCgA,
-                        dst_tensor=sA,
-                        mcast_mask=a_mcast_mask,
-                    )
-                else:
+                # TMA partition + copy fns for the PREFERRED atom set (A comes
+                # from _make_gather_A_copy under gather_A).
+                copy_A, copy_B, copy_SFA, copy_SFB = self._make_tma_load_copies(
+                    (tma_atom_a, mA_mkl, tma_atom_b, mB_nkl),
+                    (tma_atom_sfa, mSFA_mkl, tma_atom_sfb, mSFB_chunks),
+                    geo,
+                    varlen_manager,
+                    batch_idx,
+                    mma_tile_coord_mnl,
+                    thr_mma,
+                    (sA, sB, sSFA, sSFB_chunks),
+                    want=(not self.gather_A, True, self.blockscaled, self.blockscaled),
+                )
+                prefetch_A = None
+                if const_expr(self.gather_A):
                     # For varlen_m paths (TMA or cp.async): consume indices from
                     # a_prefetch_pipeline once per work tile.
                     sAIdx_stage = sAIdx
@@ -1446,46 +1627,27 @@ class GemmSm100(GemmTmaBase):
                         a_prefetch_consumer_state.advance()
                     if const_expr(prefetch_A is not None):
                         prefetch_A = partial(prefetch_A, a_prefetch_pipeline)
-                # (MMA, MMA_N, MMA_K, RestK)
-                tCgB = thr_mma.partition_B(gB_nk)
-                if const_expr(self.blockscaled):
-                    # (MMA, MMA_M, MMA_K)
-                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
-                # TMA load B partition_S/D
-                copy_B, _, _ = copy_utils.tma_get_copy_fn(
-                    tma_atom_b,
-                    cta_coord=block_in_cluster_coord_vmnk[1],
-                    cta_layout=b_cta_layout,
-                    src_tensor=tCgB,
-                    dst_tensor=sB,
-                    mcast_mask=b_mcast_mask,
-                )
-                copy_SFA, copy_SFB = None, None
-                if const_expr(self.blockscaled):
-                    #  TMA load SFA partition_S/D
-                    copy_SFA, _, _ = copy_utils.tma_get_copy_fn(
-                        tma_atom_sfa,
-                        cta_coord=block_in_cluster_coord_vmnk[2],
-                        cta_layout=a_cta_layout,
-                        src_tensor=tCgSFA,
-                        dst_tensor=sSFA,
-                        filter_zeros=True,
-                        mcast_mask=sfa_mcast_mask,
+                if const_expr(mixed):
+                    fb_copy_A, fb_copy_B, fb_copy_SFA, fb_copy_SFB = self._make_tma_load_copies(
+                        (fb_tma_atom_a, fb_mA_mkl, fb_tma_atom_b, fb_mB_nkl),
+                        (fb_tma_atom_sfa, fb_mSFA_mkl, fb_tma_atom_sfb, fb_mSFB_chunks),
+                        fb_geo,
+                        varlen_manager,
+                        batch_idx,
+                        mma_tile_coord_mnl,
+                        thr_mma,
+                        (sA, sB, sSFA, sSFB_chunks),
+                        want=(
+                            a_differs and not self.gather_A,
+                            b_differs,
+                            a_differs and self.blockscaled,
+                            sfb_differs and self.blockscaled,
+                        ),
                     )
-                    # SFB multicast: same-N across all cluster-M CTAs (the
-                    # atom's num_multicast = cluster_m splits the chunk window
-                    # across the group).
-                    sfb_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
-                    )
-                    copy_SFB, _, _ = copy_utils.tma_get_copy_fn(
-                        tma_atom_sfb,
-                        cta_coord=block_in_cluster_coord_sfb_vmnk[1],
-                        cta_layout=sfb_cta_layout,
-                        src_tensor=gSFB_chunks,
-                        dst_tensor=sSFB_chunks,
-                        mcast_mask=sfb_mcast_mask,
-                    )
+                    copy_A = _select_copy_fn(is_pref, copy_A, fb_copy_A)
+                    copy_B = _select_copy_fn(is_pref, copy_B, fb_copy_B)
+                    copy_SFA = _select_copy_fn(is_pref, copy_SFA, fb_copy_SFA)
+                    copy_SFB = _select_copy_fn(is_pref, copy_SFB, fb_copy_SFB)
                 k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])
                 k_tile_start, k_tile_cnt = tile_scheduler.get_split_k_tile_range(
                     k_tile_total, split_idx
@@ -1567,7 +1729,19 @@ class GemmSm100(GemmTmaBase):
                     # burst spray caused the July 2026 varlen corruption; see
                     # cancel_pending_tail and
                     # AI/clc_spurious_invalid_investigation.md.
-                    tile_scheduler.cancel_pending_tail()
+                    # PREFERRED clusters only: the phantom gate rests on grant
+                    # monotonicity in the work id, which holds when the cluster
+                    # grid is one row (pure launches, and preferred clusters of
+                    # a mixed launch) but NOT for fallback-shaped clusters
+                    # (pn/fn rows; ids regress at row crossings) — a fallback
+                    # drain could cancel REAL pending clusters. Fallback
+                    # retirees skip the drain; excess phantoms just launch as
+                    # cheap empty waves.
+                    if const_expr(not mixed):
+                        tile_scheduler.cancel_pending_tail()
+                    else:
+                        if is_pref:
+                            tile_scheduler.cancel_pending_tail()
 
         # Specialized A-index prefetch warp (gather_A only)
         if const_expr(self.gather_A):
@@ -2056,6 +2230,152 @@ class GemmSm100(GemmTmaBase):
             tmem_alloc_barrier.arrive_and_wait()
             tmem.free(acc_tmem_ptr)
 
+    def _load_mcast_geometry(
+        self,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_shape_mnk: Tuple[int, int, int],
+        cta_rank_in_cluster: Int32,
+    ) -> _LoadMcastGeometry:
+        """Multicast masks + partition coords/layouts for the A/B(/SFA/SFB) TMA loads
+        of ONE cluster shape: A/SFA are same-M across N peers, B same-N across M
+        peers, and SFB spans every cluster-M CTA including the 2-CTA MMA pair peer
+        (duplicated, not V-split — halves SFB gmem traffic within a pair)."""
+        num_mcast_ctas_a = cute.size(cluster_layout_vmnk.shape[2])
+        num_mcast_ctas_b = cute.size(cluster_layout_vmnk.shape[1])
+        coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        cluster_layout_sfb_vmnk, sfb_coord_vmnk, sfb_cta_layout = None, None, None
+        if const_expr(self.blockscaled):
+            cluster_layout_sfb_vmnk = cute.tiled_divide(
+                cute.make_layout(cluster_shape_mnk), ((1,),)
+            )
+            sfb_coord_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+            # SFB multicast: same-N across all cluster-M CTAs (the atom's
+            # num_multicast = cluster_m splits the chunk window across the group).
+            sfb_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+            )
+        a_mcast_mask, b_mcast_mask, sfa_mcast_mask, sfb_mcast_mask = None, None, None, None
+        if const_expr(num_mcast_ctas_a > 1 or num_mcast_ctas_b > 1 or self.use_2cta_instrs):
+            a_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, coord_vmnk, mcast_mode=2
+            )
+            b_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, coord_vmnk, mcast_mode=1
+            )
+            if const_expr(self.blockscaled):
+                sfa_mcast_mask = a_mcast_mask
+                sfb_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_sfb_vmnk, sfb_coord_vmnk, mcast_mode=1
+                )
+        return _LoadMcastGeometry(
+            coord_vmnk=coord_vmnk,
+            a_cta_layout=cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape),
+            b_cta_layout=cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape),
+            a_mcast_mask=a_mcast_mask,
+            b_mcast_mask=b_mcast_mask,
+            sfa_mcast_mask=sfa_mcast_mask,
+            sfb_mcast_mask=sfb_mcast_mask,
+            sfb_coord_vmnk=sfb_coord_vmnk,
+            sfb_cta_layout=sfb_cta_layout,
+        )
+
+    def _make_tma_load_copies(
+        self,
+        ab_atoms_tensors: tuple,
+        sf_atoms_tensors: tuple,
+        geo: _LoadMcastGeometry,
+        varlen_manager: VarlenManager,
+        batch_idx: Int32,
+        mma_tile_coord_mnl: tuple,
+        thr_mma,
+        smem_tensors: tuple,
+        *,
+        want: Tuple[bool, bool, bool, bool],
+    ):
+        """Per-work-tile gmem tiling, TMA partition and copy fns for ONE load-atom set
+        (preferred or fallback). ``want`` skips operands: A under gather_A, and the
+        operands whose fallback atom is equivalent to the preferred one."""
+        tma_atom_a, mA_mkl, tma_atom_b, mB_nkl = ab_atoms_tensors
+        tma_atom_sfa, mSFA_mkl, tma_atom_sfb, mSFB_chunks = sf_atoms_tensors
+        sA, sB, sSFA, sSFB_chunks = smem_tensors
+        want_a, want_b, want_sfa, want_sfb = want
+        copy_A, copy_B, copy_SFA, copy_SFB = None, None, None, None
+        if const_expr(want_a):
+            # (bM, bK, RestK)
+            gA_mk = cute.local_tile(
+                varlen_manager.offset_batch_A(mA_mkl, batch_idx),
+                cute.select(self.mma_tiler, [0, 2]),
+                (mma_tile_coord_mnl[0], None),
+            )
+            # (MMA, MMA_M, MMA_K, RestK)
+            copy_A, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_a,
+                cta_coord=geo.coord_vmnk[2],
+                cta_layout=geo.a_cta_layout,
+                src_tensor=thr_mma.partition_A(gA_mk),
+                dst_tensor=sA,
+                mcast_mask=geo.a_mcast_mask,
+            )
+        if const_expr(want_b):
+            # (bN, bK, RestK)
+            gB_nk = cute.local_tile(
+                varlen_manager.offset_batch_B(mB_nkl, batch_idx),
+                cute.select(self.mma_tiler, [1, 2]),
+                (mma_tile_coord_mnl[1], None),
+            )
+            # (MMA, MMA_N, MMA_K, RestK)
+            copy_B, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_b,
+                cta_coord=geo.coord_vmnk[1],
+                cta_layout=geo.b_cta_layout,
+                src_tensor=thr_mma.partition_B(gB_nk),
+                dst_tensor=sB,
+                mcast_mask=geo.b_mcast_mask,
+            )
+        if const_expr(want_sfa):
+            # (bM, bK): SFA uses the tile-aligned per-batch offset (padded SF
+            # layout), not the A-data offset — allows varlen_m seqlens that
+            # aren't multiples of 128.
+            gSFA_mkl = cute.local_tile(
+                varlen_manager.offset_batch_SFA(mSFA_mkl, batch_idx),
+                cute.select(self.mma_tiler, [0, 2]),
+                (mma_tile_coord_mnl[0], None),
+            )
+            copy_SFA, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_sfa,
+                cta_coord=geo.coord_vmnk[2],
+                cta_layout=geo.a_cta_layout,
+                src_tensor=thr_mma.partition_A(gSFA_mkl),
+                dst_tensor=sSFA,
+                filter_zeros=True,
+                mcast_mask=geo.sfa_mcast_mask,
+            )
+        if const_expr(want_sfb):
+            # (chunk, chunks-per-k-tile, window-atoms, RestK)
+            # SFB is chunk-granular: place the tile's SF window at atom
+            # coordinate j*tile_n/128, as a domain_offset because it is
+            # free-form, not a tiler multiple (tile_n=64 shares an atom
+            # between adjacent tiles, tile_n=192 advances 1.5 atoms per
+            # tile — both are just this one formula).
+            sfb_first_atom = (mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1]) // 128
+            gSFB_chunks = cute.local_tile(
+                cute.domain_offset(
+                    (None, None, sfb_first_atom),
+                    varlen_manager.offset_batch_SFB(mSFB_chunks, batch_idx),
+                ),
+                (256, self.sfb_chunks_per_ktile, self.sfb_window_atoms),
+                (0, None, 0),
+            )
+            copy_SFB, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_sfb,
+                cta_coord=geo.sfb_coord_vmnk[1],
+                cta_layout=geo.sfb_cta_layout,
+                src_tensor=gSFB_chunks,
+                dst_tensor=sSFB_chunks,
+                mcast_mask=geo.sfb_mcast_mask,
+            )
+        return copy_A, copy_B, copy_SFA, copy_SFB
+
     @cute.jit
     def _make_gather_A_copy(
         self,
@@ -2517,6 +2837,9 @@ class GemmSm100(GemmTmaBase):
         self,
         tiled_mma: cute.TiledMma,
         cluster_layout_vmnk: cute.Layout,
+        *,
+        fallback_cluster_layout_vmnk: Optional[cute.Layout] = None,
+        is_pref: Optional[Boolean] = None,
         is_leader_cta: Boolean,
     ) -> pipeline.PipelineAsync:
         # If gather_A and use_2cta_instrs, the cp.async for the non-leader CTA will
@@ -2548,19 +2871,17 @@ class GemmSm100(GemmTmaBase):
             num_ab_load_warps=self.num_ab_load_warps,
         )
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, producer_cnt)
-        # Each warp will contribute to the arrive count with the number of mcast size
-        mcast_size = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
-        consumer_arrive_cnt = mcast_size
-        pipeline_checks.check_arrive_count(
-            "sm100 ab_pipeline.consumer",
-            consumer_arrive_cnt,
-            pipeline_checks.mcast_peer_ctas(
-                num_mcast_ctas_a=self.num_mcast_ctas_a,
-                num_mcast_ctas_b=self.num_mcast_ctas_b,
-            ),
-            num_mcast_ctas_a=self.num_mcast_ctas_a,
-            num_mcast_ctas_b=self.num_mcast_ctas_b,
-        )
+        # Each warp will contribute to the arrive count with the number of mcast size:
+        # the CTAs whose tcgen05.commit lands on this CTA's empty barrier. Static for
+        # the preferred shape; under a mixed launch the fallback shape's (smaller)
+        # multicast group is selected at runtime.
+        consumer_arrive_cnt = self._ab_consumer_arrive_cnt(cluster_layout_vmnk)
+        if const_expr(fallback_cluster_layout_vmnk is not None):
+            fb_consumer_arrive_cnt = self._ab_consumer_arrive_cnt(fallback_cluster_layout_vmnk)
+            if const_expr(fb_consumer_arrive_cnt != consumer_arrive_cnt):
+                consumer_arrive_cnt = _select_i32(
+                    is_pref, consumer_arrive_cnt, fb_consumer_arrive_cnt
+                )
         ab_pipeline_consumer_group = pipeline.CooperativeGroup(
             pipeline.Agent.Thread, consumer_arrive_cnt
         )
@@ -2582,7 +2903,46 @@ class GemmSm100(GemmTmaBase):
                 cta_layout_vmnk=cluster_layout_vmnk,
                 defer_sync=True,
             )
+        if const_expr(fallback_cluster_layout_vmnk is not None):
+            # The consumer's tcgen05.commit multicasts to the CTAs of its A/B
+            # multicast groups (+ the 2-CTA peer); create() derived that mask from
+            # the preferred layout. A fallback-shaped cluster needs the mask of ITS
+            # layout: self only (bit 0) for a 1-CTA fallback, else its own groups.
+            assert pipeline_ab.consumer_mask is not None, (
+                "mixed launch implies a multi-CTA preferred"
+            )
+            if const_expr(cute.size(fallback_cluster_layout_vmnk) == 1):
+                fb_mask = cutlass.Int16(1)
+            else:
+                fb_mask = pipeline.PipelineTmaUmma._compute_mcast_arrival_mask(
+                    fallback_cluster_layout_vmnk, (1, 1)
+                )
+            # Both are Int16 (create_tma_multicast_mask); tcgen05.commit takes the mask
+            # as-is. Only the consumer side is shape-dependent: the TMA producer's
+            # full-barrier arrive is always local (expect_tx on its own barrier).
+            mask = cutlass.Int16(
+                select_(is_pref, cutlass.Int16(pipeline_ab.consumer_mask), cutlass.Int16(fb_mask))
+            )
+            object.__setattr__(pipeline_ab, "consumer_mask", mask)
         return pipeline_ab
+
+    def _ab_consumer_arrive_cnt(self, cluster_layout_vmnk: cute.Layout) -> int:
+        """Empty-barrier arrive count for one cluster shape: the CTAs in this CTA's
+        A and B multicast groups (self counted once), one tcgen05.commit each."""
+        num_mcast_ctas_a = cute.size(cluster_layout_vmnk.shape[2])
+        num_mcast_ctas_b = cute.size(cluster_layout_vmnk.shape[1])
+        consumer_arrive_cnt = num_mcast_ctas_a + num_mcast_ctas_b - 1
+        pipeline_checks.check_arrive_count(
+            "sm100 ab_pipeline.consumer",
+            consumer_arrive_cnt,
+            pipeline_checks.mcast_peer_ctas(
+                num_mcast_ctas_a=num_mcast_ctas_a,
+                num_mcast_ctas_b=num_mcast_ctas_b,
+            ),
+            num_mcast_ctas_a=num_mcast_ctas_a,
+            num_mcast_ctas_b=num_mcast_ctas_b,
+        )
+        return consumer_arrive_cnt
 
     def make_acc_pipeline(self, cluster_layout_vmnk: cute.Layout) -> pipeline.PipelineAsync:
         acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
@@ -2618,12 +2978,15 @@ class GemmSm100(GemmTmaBase):
 
     def make_sched_pipeline(
         self,
-        cluster_layout_mnk: cute.Layout,
+        cluster_layout_vmnk: cute.Layout,
         has_C: bool = False,
+        *,
+        fallback_cluster_layout_vmnk: Optional[cute.Layout] = None,
+        is_pref: Optional[Boolean] = None,
     ) -> pipeline.PipelineAsync:
         # Threads/warps participating in this pipeline
         sched_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        cluster_size = cute.size(cluster_layout_mnk)
+        cluster_size = cute.size(cluster_layout_vmnk)
         # Each warp will contribute 1 to the arrive count
         extra_warp_ids = (self.a_prefetch_warp_id,) if self.gather_A else ()
         warps_per_cta = self.num_ab_load_warps + len(
@@ -2631,19 +2994,20 @@ class GemmSm100(GemmTmaBase):
         )
         if has_C:
             warps_per_cta += 1
-        consumer_arrive_cnt = warps_per_cta * cluster_size
-        # One arrive per consumer warp (elected lane); consumer_mask=0 routes every CTA
-        # in the cluster to CTA 0's barrier. per_warp is bound to elect_one_release below.
+        # One arrive per consumer warp (elected lane) from every CTA of the cluster;
+        # consumer_mask=0 routes every CTA to CTA 0's barrier. Under a mixed launch a
+        # fallback-shaped cluster has fewer CTAs: select its count at runtime (mask 0
+        # stays right — a 1-CTA cluster's rank 0 is itself). per_warp is bound to
+        # elect_one_release below.
         elect_one_release = True
-        pipeline_checks.check_arrive_count(
-            "sm100 sched_pipeline.consumer",
-            consumer_arrive_cnt,
-            pipeline_checks.async_thread_arrives(
-                warps_per_cta, per_warp=elect_one_release, ctas_routed=cluster_size
-            ),
-            warps_per_cta=warps_per_cta,
-            cluster_size=cluster_size,
+        consumer_arrive_cnt = self._sched_consumer_arrive_cnt(
+            warps_per_cta, cluster_size, elect_one_release
         )
+        if const_expr(fallback_cluster_layout_vmnk is not None):
+            fb_consumer_arrive_cnt = self._sched_consumer_arrive_cnt(
+                warps_per_cta, cute.size(fallback_cluster_layout_vmnk), elect_one_release
+            )
+            consumer_arrive_cnt = _select_i32(is_pref, consumer_arrive_cnt, fb_consumer_arrive_cnt)
         sched_pipeline_consumer_group = pipeline.CooperativeGroup(
             pipeline.Agent.Thread, consumer_arrive_cnt
         )
@@ -2665,6 +3029,21 @@ class GemmSm100(GemmTmaBase):
             # so every lane's slot read is complete, then one elected lane signals.
             elect_one_release=elect_one_release,
         )
+
+    def _sched_consumer_arrive_cnt(
+        self, warps_per_cta: int, cluster_size: int, per_warp: bool
+    ) -> int:
+        consumer_arrive_cnt = warps_per_cta * cluster_size
+        pipeline_checks.check_arrive_count(
+            "sm100 sched_pipeline.consumer",
+            consumer_arrive_cnt,
+            pipeline_checks.async_thread_arrives(
+                warps_per_cta, per_warp=per_warp, ctas_routed=cluster_size
+            ),
+            warps_per_cta=warps_per_cta,
+            cluster_size=cluster_size,
+        )
+        return consumer_arrive_cnt
 
     @cute.jit
     def make_a_prefetch_pipeline(self) -> pipeline.PipelineAsync:

--- a/quack/gemm_sm120.py
+++ b/quack/gemm_sm120.py
@@ -317,6 +317,10 @@ class GemmSm120(GemmSm90):
             )
             assert not gather_A, "Blockscaled SM120 GEMM does not support gather_A"
             assert transform_a is None, "Blockscaled SM120 GEMM does not support transform_a"
+            assert tuple(cluster_shape_mnk[:2]) == (1, 1), (
+                "Blockscaled SM120 GEMM requires a (1,1) cluster: the SFA/SFB TMA atoms are "
+                "non-multicast while their copy sites partition by the A/B cluster layouts"
+            )
         # The warp-MMA mainloop always consumes A from registers (ldmatrix
         # s2r), so there is no SS/RS mode split; mma_is_rs stays False for the
         # inherited __call__/_setup_attributes checks. A-operand transforms
@@ -932,18 +936,20 @@ class GemmSm120(GemmSm90):
                 # use_pdl=True, so the kernel must gate its first gmem reads.
                 if const_expr(self.use_pdl):
                     prims.griddepcontrol(prims.GridDepAction.WAIT)
-                # block_copy's lowering wants the coordinate held fixed by the
-                # multicast mask: A is same-M across N peers, while B is
-                # same-N across M peers. Degenerate cluster dimensions are
-                # left for the compiler lowering to simplify.
-                a_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "M",
-                }
-                b_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "N",
-                }
+                # Get mcast mask: A is same-M across N peers, B is same-N
+                # across M peers (degenerate for a (1,1) cluster).
+                cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+                block_in_cluster_coord_mnk = cluster_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+                a_mcast_mask = cute.make_layout_image_mask(
+                    cluster_layout_mnk, block_in_cluster_coord_mnk, mode=1
+                )
+                b_mcast_mask = cute.make_layout_image_mask(
+                    cluster_layout_mnk, block_in_cluster_coord_mnk, mode=0
+                )
+                a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+                b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_mnk, (0, None, 0)).shape)
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_mnk, (None, 0, 0)).shape)
 
                 # Persistent tile scheduling loop
                 is_scheduler_warp = self.num_ab_load_warps == 1 or warp_idx == self.ab_load_warp_id
@@ -977,11 +983,13 @@ class GemmSm120(GemmSm90):
                     if const_expr(a_owned):
                         # the transform owns A's gmem interpretation
                         gA_owned = self.transform_a.a_gmem_slice(mA_mkl, tile_coord_mnkl, batch_idx)
-                        copy_A = copy_utils.tma_get_block_copy_fn(
+                        copy_A, _, _ = copy_utils.tma_get_copy_fn(
                             tma_atom_a,
+                            cta_coord=block_in_cluster_coord_mnk[1],
+                            cta_layout=a_cta_layout,
                             src_tensor=gA_owned,
                             dst_tensor=sA,
-                            tma_multicast=a_tma_multicast,
+                            mcast_mask=a_mcast_mask,
                         )
                     elif const_expr(not self.gather_A):
                         mA_mk = varlen_manager.offset_batch_A(mA_mkl, batch_idx)
@@ -992,11 +1000,13 @@ class GemmSm120(GemmSm90):
                             (tile_coord_mnkl[0], None),
                         )
                         #  TMA load A partition_S/D
-                        copy_A = copy_utils.tma_get_block_copy_fn(
+                        copy_A, _, _ = copy_utils.tma_get_copy_fn(
                             tma_atom_a,
+                            cta_coord=block_in_cluster_coord_mnk[1],
+                            cta_layout=a_cta_layout,
                             src_tensor=gA_mk,
                             dst_tensor=sA,
-                            tma_multicast=a_tma_multicast,
+                            mcast_mask=a_mcast_mask,
                         )
                     else:
                         copy_A, prefetch_A = self._make_gather_A_copy(
@@ -1006,17 +1016,27 @@ class GemmSm120(GemmSm90):
                     if const_expr(self.aux_a is not None):
                         # aux A-side operand: one box per k-tile alongside A/B
                         gAux = self.aux_a.gmem_slice(mAuxA_mkl, tile_coord_mnkl, batch_idx)
-                        copy_AuxA = copy_utils.tma_get_block_copy_fn(
-                            tma_atom_aux_a,
-                            src_tensor=gAux,
-                            dst_tensor=sAuxA,
-                            # small-box aux operands (e.g. 128 B scale strips)
-                            # may opt out of the A-side multicast: each CTA
-                            # loads its own copy instead of splitting the box
-                            tma_multicast=a_tma_multicast
-                            if const_expr(getattr(self.aux_a, "multicast", True))
-                            else None,
-                        )
+                        # small-box aux operands (e.g. 128 B scale strips)
+                        # may opt out of the A-side multicast: each CTA loads
+                        # its own copy instead of splitting the box (the atom
+                        # is built non-multicast by make_tma in that case)
+                        if const_expr(getattr(self.aux_a, "multicast", True)):
+                            copy_AuxA, _, _ = copy_utils.tma_get_copy_fn(
+                                tma_atom_aux_a,
+                                cta_coord=block_in_cluster_coord_mnk[1],
+                                cta_layout=a_cta_layout,
+                                src_tensor=gAux,
+                                dst_tensor=sAuxA,
+                                mcast_mask=a_mcast_mask,
+                            )
+                        else:
+                            copy_AuxA, _, _ = copy_utils.tma_get_copy_fn(
+                                tma_atom_aux_a,
+                                cta_coord=0,
+                                cta_layout=cute.make_layout(1),
+                                src_tensor=gAux,
+                                dst_tensor=sAuxA,
+                            )
                     # (bN, bK, RestK)
                     gB_nk = cute.local_tile(
                         varlen_manager.offset_batch_B(mB_nkl, batch_idx),
@@ -1024,11 +1044,13 @@ class GemmSm120(GemmSm90):
                         (tile_coord_mnkl[1], None),
                     )
                     # TMA load B partition_S/D
-                    copy_B = copy_utils.tma_get_block_copy_fn(
+                    copy_B, _, _ = copy_utils.tma_get_copy_fn(
                         tma_atom_b,
+                        cta_coord=block_in_cluster_coord_mnk[0],
+                        cta_layout=b_cta_layout,
                         src_tensor=gB_nk,
                         dst_tensor=sB,
-                        tma_multicast=b_tma_multicast,
+                        mcast_mask=b_mcast_mask,
                     )
                     copy_SFA, copy_SFB = None, None
                     if const_expr(self.blockscaled):
@@ -1040,11 +1062,17 @@ class GemmSm120(GemmSm90):
                             cute.select(self.cta_tile_shape_mnk, [0, 2]),
                             (tile_coord_mnkl[0], None),
                         )
-                        copy_SFA = copy_utils.tma_get_block_copy_fn(
+                        # SF atoms are non-multicast (blockscaled asserts a
+                        # (1,1) cluster in __init__), so the A/B coord/mask
+                        # degenerate to match.
+                        copy_SFA, _, _ = copy_utils.tma_get_copy_fn(
                             tma_atom_sfa,
+                            cta_coord=block_in_cluster_coord_mnk[1],
+                            cta_layout=a_cta_layout,
                             src_tensor=gSFA_mk,
                             dst_tensor=sSFA,
-                            tma_multicast=a_tma_multicast,
+                            filter_zeros=True,
+                            mcast_mask=a_mcast_mask,
                         )
                         # (bN, bK, RestK). SFB is K-padded for varlen_k (same
                         # tile-offset formula as SFA); per-batch otherwise.
@@ -1057,11 +1085,14 @@ class GemmSm120(GemmSm90):
                             cute.select(self.cta_tile_shape_mnk, [1, 2]),
                             (tile_coord_mnkl[1], None),
                         )
-                        copy_SFB = copy_utils.tma_get_block_copy_fn(
+                        copy_SFB, _, _ = copy_utils.tma_get_copy_fn(
                             tma_atom_sfb,
+                            cta_coord=block_in_cluster_coord_mnk[0],
+                            cta_layout=b_cta_layout,
                             src_tensor=gSFB_nk,
                             dst_tensor=sSFB,
-                            tma_multicast=b_tma_multicast,
+                            filter_zeros=True,
+                            mcast_mask=b_mcast_mask,
                         )
                     len_k = varlen_manager.len_k(batch_idx)
                     k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])

--- a/quack/gemm_sm90.py
+++ b/quack/gemm_sm90.py
@@ -1038,18 +1038,20 @@ class GemmSm90(GemmTmaBase):
                 # PDL: wait for prior kernel before any TMA loads (matches cutlass C++ sm90 mainloop producer)
                 if const_expr(self.use_pdl):
                     prims.griddepcontrol(prims.GridDepAction.WAIT)
-                # block_copy's lowering wants the coordinate held fixed by the
-                # multicast mask: A is same-M across N peers, while B is
-                # same-N across M peers. Degenerate cluster dimensions are
-                # left for the compiler lowering to simplify.
-                a_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "M",
-                }
-                b_tma_multicast = {
-                    "cluster_shape": self.cluster_shape_mnk[:2],
-                    "multicast_dim": "N",
-                }
+                # Get mcast mask: A is same-M across N peers, B is same-N
+                # across M peers.
+                cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+                block_in_cluster_coord_mnk = cluster_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+                a_mcast_mask = cute.make_layout_image_mask(
+                    cluster_layout_mnk, block_in_cluster_coord_mnk, mode=1
+                )
+                b_mcast_mask = cute.make_layout_image_mask(
+                    cluster_layout_mnk, block_in_cluster_coord_mnk, mode=0
+                )
+                a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+                b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_mnk, (0, None, 0)).shape)
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_mnk, (None, 0, 0)).shape)
 
                 # Persistent tile scheduling loop
                 is_scheduler_warp = self.num_ab_load_warps == 1 or warp_idx == self.ab_load_warp_id
@@ -1087,11 +1089,13 @@ class GemmSm90(GemmTmaBase):
                     if const_expr(a_owned):
                         # the transform owns A's gmem interpretation
                         gA_owned = self.transform_a.a_gmem_slice(mA_mkl, tile_coord_mnkl, batch_idx)
-                        copy_A = copy_utils.tma_get_block_copy_fn(
+                        copy_A, _, _ = copy_utils.tma_get_copy_fn(
                             tma_atom_a,
+                            cta_coord=block_in_cluster_coord_mnk[1],
+                            cta_layout=a_cta_layout,
                             src_tensor=gA_owned,
                             dst_tensor=sA,
-                            tma_multicast=a_tma_multicast,
+                            mcast_mask=a_mcast_mask,
                         )
                     elif const_expr(not self.gather_A):
                         mA_mk = varlen_manager.offset_batch_A(mA_mkl, batch_idx)
@@ -1102,11 +1106,13 @@ class GemmSm90(GemmTmaBase):
                             (tile_coord_mnkl[0], None),
                         )
                         #  TMA load A partition_S/D
-                        copy_A = copy_utils.tma_get_block_copy_fn(
+                        copy_A, _, _ = copy_utils.tma_get_copy_fn(
                             tma_atom_a,
+                            cta_coord=block_in_cluster_coord_mnk[1],
+                            cta_layout=a_cta_layout,
                             src_tensor=gA_mk,
                             dst_tensor=sA,
-                            tma_multicast=a_tma_multicast,
+                            mcast_mask=a_mcast_mask,
                         )
                     else:
                         copy_A, prefetch_A = self._make_gather_A_copy(
@@ -1116,17 +1122,27 @@ class GemmSm90(GemmTmaBase):
                     if const_expr(self.aux_a is not None):
                         # aux A-side operand: one box per k-tile alongside A/B
                         gAux = self.aux_a.gmem_slice(mAuxA_mkl, tile_coord_mnkl, batch_idx)
-                        copy_AuxA = copy_utils.tma_get_block_copy_fn(
-                            tma_atom_aux_a,
-                            src_tensor=gAux,
-                            dst_tensor=sAuxA,
-                            # small-box aux operands (e.g. 128 B scale strips)
-                            # may opt out of the A-side multicast: each CTA
-                            # loads its own copy instead of splitting the box
-                            tma_multicast=a_tma_multicast
-                            if const_expr(getattr(self.aux_a, "multicast", True))
-                            else None,
-                        )
+                        # small-box aux operands (e.g. 128 B scale strips)
+                        # may opt out of the A-side multicast: each CTA loads
+                        # its own copy instead of splitting the box (the atom
+                        # is built non-multicast by make_tma in that case)
+                        if const_expr(getattr(self.aux_a, "multicast", True)):
+                            copy_AuxA, _, _ = copy_utils.tma_get_copy_fn(
+                                tma_atom_aux_a,
+                                cta_coord=block_in_cluster_coord_mnk[1],
+                                cta_layout=a_cta_layout,
+                                src_tensor=gAux,
+                                dst_tensor=sAuxA,
+                                mcast_mask=a_mcast_mask,
+                            )
+                        else:
+                            copy_AuxA, _, _ = copy_utils.tma_get_copy_fn(
+                                tma_atom_aux_a,
+                                cta_coord=0,
+                                cta_layout=cute.make_layout(1),
+                                src_tensor=gAux,
+                                dst_tensor=sAuxA,
+                            )
                     # (bN, bK, RestK)
                     gB_nk = cute.local_tile(
                         varlen_manager.offset_batch_B(mB_nkl, batch_idx),
@@ -1134,11 +1150,13 @@ class GemmSm90(GemmTmaBase):
                         (tile_coord_mnkl[1], None),
                     )
                     # TMA load B partition_S/D
-                    copy_B = copy_utils.tma_get_block_copy_fn(
+                    copy_B, _, _ = copy_utils.tma_get_copy_fn(
                         tma_atom_b,
+                        cta_coord=block_in_cluster_coord_mnk[0],
+                        cta_layout=b_cta_layout,
                         src_tensor=gB_nk,
                         dst_tensor=sB,
-                        tma_multicast=b_tma_multicast,
+                        mcast_mask=b_mcast_mask,
                     )
                     len_k = varlen_manager.len_k(batch_idx)
                     k_tile_total = cute.ceil_div(len_k, self.cta_tile_shape_mnk[2])

--- a/quack/operand_transform/kinds.py
+++ b/quack/operand_transform/kinds.py
@@ -93,7 +93,10 @@ class _StripAux:
         gemm = self.gemm
         box = self._box()
         smem_layout = cute.make_ordered_layout(box, order=(0, 1))
-        return gemm._make_tma_atoms_and_tensors(mAux, smem_layout, box, gemm.cluster_shape_mnk[1])
+        # multicast=False: non-multicast atom (full box per CTA); the copy
+        # site issues it without a multicast mask to match.
+        mcast_dim = gemm.cluster_shape_mnk[1] if self.multicast else 1
+        return gemm._make_tma_atoms_and_tensors(mAux, smem_layout, box, mcast_dim)
 
     def gmem_slice(self, mAux, tile_coord_mnkl, batch_idx):
         # (inner, outer, Gm, RestK, L) -> (inner, outer, RestK)

--- a/quack/operand_transform/transform.py
+++ b/quack/operand_transform/transform.py
@@ -175,8 +175,9 @@ class AuxKTileStrip(AuxOperandA):
     def make_tma(self, mAux):
         gemm = self.gemm
         sf_smem_layout = cute.make_ordered_layout((self.sf_bytes, self._tm64()), order=(0, 1))
+        mcast_dim = gemm.cluster_shape_mnk[1] if getattr(self, "multicast", True) else 1
         return gemm._make_tma_atoms_and_tensors(
-            mAux, sf_smem_layout, (self.sf_bytes, self._tm64()), gemm.cluster_shape_mnk[1]
+            mAux, sf_smem_layout, (self.sf_bytes, self._tm64()), mcast_dim
         )
 
     def gmem_slice(self, mAux, tile_coord_mnkl, batch_idx):

--- a/quack/tile_scheduler.py
+++ b/quack/tile_scheduler.py
@@ -67,6 +67,23 @@ def cluster_idx_from_block_idx(
 
 
 @cute.jit
+def cluster_rem_from_block_idx(
+    cluster_shape_mnk: cutlass.Constexpr[cute.Shape], *, loc=None, ip=None
+) -> Tuple[Int32, Int32]:
+    """blockIdx % cluster_shape (m, n components) with the cluster shape as a
+    compile-time constant: the CTA's offset inside the scheduler's cluster
+    footprint. Under a mixed preferred/fallback launch this differs from
+    cute.arch.block_in_cluster_idx(), which only spans the ACTUAL (possibly
+    fallback-shaped) cluster — a fallback cluster may sit at a non-zero offset
+    within the preferred footprint, and the remainder keeps that offset."""
+    bidx = cute.arch.block_idx()
+    return tuple(
+        Int32(0) if const_expr(s == 1) else Int32(Uint32(b) % s)
+        for b, s in zip(bidx[:2], cluster_shape_mnk[:2])
+    )
+
+
+@cute.jit
 def get_raster_order_from_option(
     raster_order_option: RasterOrderOption, problem_shape_ncluster_mn: cute.Shape, group_size: Int32
 ) -> RasterOrder:
@@ -523,12 +540,26 @@ class TileScheduler:
 
     @cute.jit
     def _cluster_id_to_cta_id(
-        self, cid_m: Int32, cid_n: Int32, *, block_zero_only: bool = False, loc=None, ip=None
+        self,
+        cid_m: Int32,
+        cid_n: Int32,
+        rem_mn: Optional[Tuple[Int32, Int32]] = None,
+        *,
+        block_zero_only: bool = False,
+        loc=None,
+        ip=None,
     ) -> Tuple[Int32, Int32]:
         if const_expr(
             block_zero_only or cute.size(self.params.cluster_shape_mnk, loc=loc, ip=ip) == 1
         ):
             bidx_in_cluster = (Int32(0), Int32(0))
+        elif const_expr(rem_mn is not None):
+            # CLC/NONE decode: the CTA's offset inside the params (preferred)
+            # cluster footprint, computed by the caller as a remainder of the
+            # CTA coordinate. Under a mixed preferred/fallback launch the
+            # runtime block_in_cluster_idx only spans the ACTUAL cluster, which
+            # may sit at a non-zero offset within the preferred footprint.
+            bidx_in_cluster = rem_mn
         else:
             # Get the pid from cluster id
             bidx_in_cluster = cute.arch.block_in_cluster_idx()
@@ -542,6 +573,7 @@ class TileScheduler:
         work_idx: Int32,
         bidz: Optional[Int32] = None,
         is_valid: Optional[Boolean] = None,
+        rem_mn: Optional[Tuple[Int32, Int32]] = None,
         *,
         block_zero_only: bool = False,
         loc=None,
@@ -557,6 +589,17 @@ class TileScheduler:
                 is_valid = (
                     work_idx < cute.size(params.problem_shape_ncluster_mnl) * params.num_split_k
                 )
+        # Initial (blockIdx-derived) tile: the CTA's offset inside the preferred
+        # cluster footprint comes from its own coordinates. Correct under mixed
+        # launches, and identical to block_in_cluster_idx for a pure preferred
+        # launch. Outside the dynamic `if is_valid` so rem_mn has one type on
+        # every path (CLC/NONE only; STATIC/DYNAMIC keep block_in_cluster_idx).
+        if const_expr(
+            rem_mn is None
+            and not block_zero_only
+            and params.persistence_mode in [PersistenceMode.NONE, PersistenceMode.CLC]
+        ):
+            rem_mn = cluster_rem_from_block_idx(params.cluster_shape_mnk, loc=loc, ip=ip)
         pid_m, pid_n, batch_idx = Int32(0), Int32(0), Int32(0)
         split_idx = Int32(0) if const_expr(params.num_split_k != 1) else None
         if is_valid:
@@ -613,7 +656,7 @@ class TileScheduler:
             if const_expr(params.ag is not None):
                 cid_m = cid_m + ag_shard * params.ag.nclusters_m_per_shard
             pid_m, pid_n = self._cluster_id_to_cta_id(
-                cid_m, cid_n, block_zero_only=block_zero_only, loc=loc, ip=ip
+                cid_m, cid_n, rem_mn, block_zero_only=block_zero_only, loc=loc, ip=ip
             )
             if const_expr(params.num_split_k == 1):
                 batch_idx = (
@@ -723,13 +766,34 @@ class TileScheduler:
         # needs the slot; freeing it here lets the scheduler warp recycle the stage
         # for the next query while this warp runs the (possibly expensive, e.g.
         # varlen scan) delinearization.
+        # The response carries the FIRST CTA coordinates of the canceled cluster,
+        # whose footprint matches this (requesting) cluster's RUNTIME shape. Under
+        # a mixed preferred/fallback launch that footprint may sit at a non-zero
+        # offset inside a preferred cluster block, while the decode below stays in
+        # preferred-cluster units (params.cluster_shape_mnk). Form this CTA's
+        # virtual coordinate (response + own offset in the actual cluster), divide
+        # by the preferred shape for the work idx, and keep the remainder as the
+        # CTA's offset inside the preferred footprint (mirrors CUTLASS
+        # PersistentTileSchedulerSm100::swizzle_and_rasterize). For a pure
+        # preferred launch the remainder equals block_in_cluster_idx, i.e. the
+        # previous decode.
+        vx, vy = Int32(bidx), Int32(bidy)
+        if const_expr(cute.size(params.cluster_shape_mnk) > 1):
+            bidx_in_cluster = cute.arch.block_in_cluster_idx()
+            vx, vy = vx + bidx_in_cluster[0], vy + bidx_in_cluster[1]
         cluster_idx = (
-            Int32(Uint32(bidx) // params.cluster_shape_mnk[0]),
-            Int32(Uint32(bidy) // params.cluster_shape_mnk[1]),
+            Int32(Uint32(vx) // params.cluster_shape_mnk[0]),
+            Int32(Uint32(vy) // params.cluster_shape_mnk[1]),
             Int32(Uint32(bidz) // params.cluster_shape_mnk[2]),
         )
+        rem_mn = tuple(
+            Int32(0) if const_expr(s == 1) else Int32(Uint32(v) % s)
+            for v, s in zip((vx, vy), params.cluster_shape_mnk[:2])
+        )
         work_idx, batch_idx = self._cluster_idx_to_work_idx_batch(params, cluster_idx)
-        ret = self._delinearize_work_idx(work_idx, batch_idx, Boolean(valid), loc=loc, ip=ip)
+        ret = self._delinearize_work_idx(
+            work_idx, batch_idx, Boolean(valid), rem_mn, loc=loc, ip=ip
+        )
         if Boolean(valid):
             # Track the last GRANTED work index only (bidx of an invalid
             # response is garbage; trusting it fed the drain a bogus
@@ -758,7 +822,15 @@ class TileScheduler:
         self._scheduler_pipeline.producer_acquire(pipeline_state_producer)
         mbar_ptr = self._scheduler_pipeline.producer_get_barrier(pipeline_state_producer)
         lane_idx = cute.arch.lane_idx()
-        if lane_idx < cute.size(params.cluster_shape_mnk):
+        # Arm one full barrier per CTA of the ACTUAL cluster. Under a mixed
+        # preferred/fallback launch this cluster may be fallback-shaped, and
+        # params.cluster_shape_mnk is the (larger) preferred shape — arming a
+        # rank beyond the actual cluster is a mapa to a nonexistent CTA (UB).
+        if const_expr(cute.size(params.cluster_shape_mnk) == 1):
+            num_cluster_ctas = Int32(1)
+        else:
+            num_cluster_ctas = cute.arch.cluster_size()
+        if lane_idx < num_cluster_ctas:
             # Arm each CTA's full barrier: fused arrive (count 1, matching the
             # producer group) + expect_tx(16) for the multicast response.
             cute.arch.mbarrier_arrive_and_expect_tx(mbar_ptr, SCHED_SLOT_BYTES, lane_idx)
@@ -845,6 +917,12 @@ class TileScheduler:
         ):
             params = self.params
             grid_total = Int32(Uint32(cute.arch.grid_dim()[0]) // params.cluster_shape_mnk[0])
+            # Budget is in PREFERRED-cluster work-id units. Only preferred-shaped
+            # clusters drain: gemm_sm100 compiles this call out of the fallback
+            # branch, because a fallback grid with several rows breaks the
+            # monotonicity argument below (ids regress at row crossings) and a
+            # drain there could cancel REAL pending clusters. Fallback retirees
+            # skip the drain; excess phantoms launch as cheap empty waves.
             # Remaining tail <= total work indices - the phantom index we drew.
             # Zero budget unless this cluster retired on a DECODED phantom:
             # retiring on an invalid response says NOTHING about the pool
@@ -1204,6 +1282,7 @@ class TriangularTileScheduler(TileScheduler):
         work_idx: Int32,
         bidz: Optional[Int32] = None,
         is_valid: Optional[Boolean] = None,
+        rem_mn: Optional[Tuple[Int32, Int32]] = None,
         *,
         block_zero_only: bool = False,
         loc=None,
@@ -1219,6 +1298,15 @@ class TriangularTileScheduler(TileScheduler):
                     < params.num_clusters_per_problem_fdd.divisor
                     * params.problem_shape_ncluster_mnl[2]
                 )
+        # Initial (blockIdx-derived) tile under a mixed launch: the CTA's offset
+        # inside the preferred footprint comes from its own coords. Outside the
+        # dynamic `if is_valid` so rem_mn has one type on every path.
+        if const_expr(
+            rem_mn is None
+            and not block_zero_only
+            and params.persistence_mode in [PersistenceMode.NONE, PersistenceMode.CLC]
+        ):
+            rem_mn = cluster_rem_from_block_idx(params.cluster_shape_mnk, loc=loc, ip=ip)
         pid_m, pid_n, batch_idx = Int32(0), Int32(0), Int32(0)
         if is_valid:
             if const_expr(params.persistence_mode in [PersistenceMode.NONE, PersistenceMode.CLC]):
@@ -1233,7 +1321,7 @@ class TriangularTileScheduler(TileScheduler):
                 cluster_id_in_problem = Int32(cluster_id_in_problem)  # divmod returns IntValue
             cid_m, cid_n = self._swizzle_cta(cluster_id_in_problem, loc=loc, ip=ip)
             pid_m, pid_n = self._cluster_id_to_cta_id(
-                cid_m, cid_n, block_zero_only=block_zero_only, loc=loc, ip=ip
+                cid_m, cid_n, rem_mn, block_zero_only=block_zero_only, loc=loc, ip=ip
             )
             batch_idx = bidz_
         tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
@@ -1440,6 +1528,7 @@ class VarlenMTileScheduler(TileScheduler):
         work_idx: Int32,
         bidz: Optional[Int32] = None,  # not used
         is_valid_: Optional[Boolean] = None,
+        rem_mn: Optional[Tuple[Int32, Int32]] = None,
         *,
         block_zero_only: bool = False,
         loc=None,
@@ -1447,6 +1536,15 @@ class VarlenMTileScheduler(TileScheduler):
     ) -> WorkTileInfo:
         assert bidz is None
         params = self.params
+        # Initial (blockIdx-derived) tile under a mixed launch: the CTA's offset
+        # inside the preferred footprint comes from its own coordinates (CLC/NONE
+        # only; the STATIC/DYNAMIC paths keep the runtime block_in_cluster_idx).
+        if const_expr(
+            rem_mn is None
+            and not block_zero_only
+            and params.persistence_mode in [PersistenceMode.NONE, PersistenceMode.CLC]
+        ):
+            rem_mn = cluster_rem_from_block_idx(params.cluster_shape_mnk, loc=loc, ip=ip)
         lane_idx = cute.arch.lane_idx()
         num_batch = self.params.problem_shape_ncluster_mnl[2]
         block_size = params.tile_shape_mn[0] * params.cluster_shape_mnk[0]
@@ -1481,6 +1579,20 @@ class VarlenMTileScheduler(TileScheduler):
         )
         if is_valid:
             if need_scan:
+                # The window scan below is FORWARD-only (it resumes from the
+                # cached batch). Work ids are monotone per consumer on a pure
+                # launch (the cluster grid is one row, so CLC grants follow the
+                # raster in work-id order), but under a mixed preferred/fallback
+                # launch a fallback-shaped cluster's grid has pn/fn rows and a
+                # stolen id can REGRESS when the grant raster crosses rows.
+                # Without this reset the stale window produced a negative
+                # cluster_id_in_problem, a wild pid_m, and — through the
+                # ptr_shift D descriptor — an unmapped-VA TMA store (hardware
+                # trap). Backward jumps restart the scan from batch 0; they are
+                # rare (row crossings only), the forward fast path is untouched.
+                if next_tile_idx < problems_end_tile:
+                    batch_idx = Int32(0)
+                    problems_end_tile = Int32(0)
                 while problems_end_tile <= next_tile_idx:
                     num_clusters_m = self._get_num_m_blocks(
                         lane_idx, bidb_start=batch_idx, block_size=block_size
@@ -1531,7 +1643,7 @@ class VarlenMTileScheduler(TileScheduler):
             cluster_id_in_problem = next_tile_idx - num_work_idx_before_cur_batch
             cid_m, cid_n = self._swizzle_cta(cluster_id_in_problem, num_clusters_m, loc=loc, ip=ip)
         pid_m, pid_n = self._cluster_id_to_cta_id(
-            cid_m, cid_n, block_zero_only=block_zero_only, loc=loc, ip=ip
+            cid_m, cid_n, rem_mn, block_zero_only=block_zero_only, loc=loc, ip=ip
         )
         tile_coord_mnkl = (pid_m, pid_n, None, batch_idx)
         self._current_batch_idx = batch_idx

--- a/tests/test_gemm_fallback_cluster.py
+++ b/tests/test_gemm_fallback_cluster.py
@@ -1,0 +1,206 @@
+"""Mixed preferred/fallback cluster launches for SM100 CLC-persistent GEMMs.
+
+Fallback support is on by default whenever CLC dynamic scheduling is enabled
+(``is_dynamic_persistent=True``): one kernel body carries both cluster shapes'
+load TMA atoms and selects atoms, multicast masks and barrier arrive counts at
+runtime from the cluster's actual shape, and the driver may launch any mix of
+preferred- and fallback-shaped clusters. The driver only falls back under
+resource pressure, so the mixed-launch tests validate "correct for ANY mix",
+while the forced tests deterministically execute the fallback path by shrinking
+the preferred launch shape to the fallback shape (every cluster then launches
+fallback-shaped and the runtime predicate selects the fallback atoms/masks/counts
+of the production kernel).
+
+Problem sizes are chosen to overfill the GPU (grid > SM count, counted at the
+FALLBACK shape for the forced tests) so the CLC pending pool is non-empty and
+work stealing actually happens — under-filled grids retire on their initial
+tile and never exercise the steal decode.
+
+Mixed-launch (preferred-shape) tests are limited to cluster size <= 2: CLC
+scheduling with cluster sizes >= 4 — e.g. (2,2), (4,1), (4,2), (2,4) — hangs
+under GPU contention on unmodified main, independent of fallback support. The
+forced tests launch at the fallback shape (size <= 2), so they additionally
+cover a 2-CTA preferred (2,2) whose fallback is the intact (2,1) pair.
+
+The retirement drain (``cancel_pending_tail``) runs in preferred-shaped clusters
+only, so no forced test exercises it; the mixed-launch tests do, for whichever
+clusters the driver launches preferred-shaped.
+"""
+
+import math
+
+import pytest
+import torch
+
+from cutlass import BFloat16, Float32
+
+import quack.gemm as gemm_module
+from quack.cute_dsl_utils import get_device_capacity
+from quack.gemm import gemm as quack_gemm
+from quack.gemm_sm100 import GemmSm100
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or get_device_capacity(torch.device("cuda"))[0] not in (10, 11),
+    reason="Mixed (preferred/fallback) cluster launch is SM100/SM110 only",
+)
+
+DTYPE = torch.bfloat16
+ATOL, RTOL = 3e-2, 1e-3
+
+# (tile_M, tile_N, cluster_M, cluster_N): upstream-healthy CLC cluster shapes
+# with a differing fallback. (1,2) exercises the N-remainder of the preferred
+# footprint, (2,1) with tile_M=64 (1-CTA MMA) the M-remainder.
+CONFIGS = [
+    (128, 256, 1, 2),  # 1-CTA MMA, fallback (1,1), rem_n path
+    (64, 256, 2, 1),  # 1-CTA MMA, fallback (1,1), rem_m path
+]
+# Forced-path only (launches at the size-2 fallback, never a size-4 cluster):
+# 2-CTA MMA whose fallback keeps the pair — per-shape A multicast atoms, the
+# pair's SFB/B 2SM atoms, and the pair-intact sched pipeline.
+FORCED_CONFIGS = CONFIGS + [
+    (128, 256, 2, 2),  # 2-CTA MMA, fallback (2,1), rem_n path
+    (256, 128, 4, 1),  # 2-CTA MMA, fallback (2,1), rem_m path (pair offset 2)
+]
+
+
+def _run_gemm(A, B, D, tile_M, tile_N, cluster_M, cluster_N, **kwargs):
+    quack_gemm(
+        A,
+        B,
+        D,
+        C=kwargs.pop("C", None),
+        tile_count_semaphore=None,
+        tile_M=tile_M,
+        tile_N=tile_N,
+        cluster_M=cluster_M,
+        cluster_N=cluster_N,
+        persistent=True,
+        is_dynamic_persistent=True,  # CLC scheduling: fallback support is on
+        **kwargs,
+    )
+
+
+@pytest.fixture
+def force_fallback(monkeypatch):
+    """Route every compile in the test through the fallback-forcing hook,
+    isolated from every cache layer: the force flag is invisible to the
+    arg-derived jit-cache key, so (a) disable the disk cache, (b) clear the
+    in-memory compile cache, and (c) swap in a throwaway plan cache
+    (monkeypatch reverts (a) and (c)). The forced kernels land in the in-memory
+    compile cache under normal keys; teardown scrubs them — pass or fail — so
+    later tests in this process don't pick up a forced kernel."""
+    monkeypatch.setattr("quack.cache.CACHE_ENABLED", False)
+    monkeypatch.setattr(gemm_module, "_gemm_plan_cache", {})
+    gemm_module._compile_gemm.cache_clear()
+
+    orig_compile = gemm_module.compile_gemm_kernel
+
+    def compile_forced(*args, **kwargs):
+        chained = kwargs.get("post_init")
+
+        def post_init(gemm_obj):
+            if chained is not None:
+                chained(gemm_obj)
+            assert gemm_obj.fallback_cluster_shape_mnk is not None
+            gemm_obj._force_fallback_branch = True
+
+        kwargs["post_init"] = post_init
+        return orig_compile(*args, **kwargs)
+
+    monkeypatch.setattr(gemm_module, "compile_gemm_kernel", compile_forced)
+    yield
+    gemm_module._compile_gemm.cache_clear()
+
+
+def test_fallback_cluster_defaults():
+    """Derivation rules: (2,1) with 2-CTA MMA (pair stays intact), (1,1)
+    otherwise; disabled when the preferred cluster already is the fallback
+    shape or when CLC persistence is off."""
+
+    def mk(mma_tiler, cluster, **kw):
+        return GemmSm100(Float32, BFloat16, mma_tiler, cluster, **kw)
+
+    assert mk((256, 128), (2, 1, 1)).fallback_cluster_shape_mnk is None  # 2cta, equal
+    assert mk((256, 128), (4, 2, 1)).fallback_cluster_shape_mnk == (2, 1, 1)  # 2cta
+    assert mk((128, 128), (2, 2, 1)).fallback_cluster_shape_mnk == (2, 1, 1)  # 2cta (tile_m 128)
+    assert mk((128, 128), (1, 2, 1)).fallback_cluster_shape_mnk == (1, 1, 1)  # 1cta
+    assert mk((128, 128), (1, 1, 1)).fallback_cluster_shape_mnk is None  # equal
+    clc_off = mk((256, 128), (4, 2, 1), use_clc_persistence=False)
+    assert clc_off.fallback_cluster_shape_mnk is None
+
+
+@pytest.mark.parametrize("tile_M,tile_N,cluster_M,cluster_N", CONFIGS)
+def test_gemm_mixed_cluster_launch(tile_M, tile_N, cluster_M, cluster_N):
+    """Numerics under a real mixed launch with active CLC stealing: the driver
+    picks the preferred/fallback mix at runtime, so the result must be correct
+    for any mix (all-preferred on an idle GPU included)."""
+    torch.manual_seed(0)
+    l, m, n, k = 4, 2048, 1536, 512  # grid >> SM count: steals guaranteed
+    A = torch.randn(l, m, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    B = torch.randn(l, n, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    D = torch.empty(l, m, n, dtype=DTYPE, device="cuda")
+    _run_gemm(A, B, D, tile_M, tile_N, cluster_M, cluster_N)
+    ref = torch.bmm(A.float(), B.float().mT).to(DTYPE)
+    torch.testing.assert_close(D, ref, atol=ATOL, rtol=RTOL)
+
+
+@pytest.mark.parametrize("has_C", [False, True])
+@pytest.mark.parametrize("tile_M,tile_N,cluster_M,cluster_N", FORCED_CONFIGS)
+def test_gemm_forced_fallback_branch(force_fallback, tile_M, tile_N, cluster_M, cluster_N, has_C):
+    """Deterministically execute the FALLBACK path of the production kernel
+    with CLC steals active. This is the regression test for the
+    CLC scheduler's preferred-unit remainder decode: reverting it (adding the
+    runtime block_in_cluster_idx instead of the CTA remainder modulo the
+    preferred shape) makes fallback clusters at non-zero offsets inside a
+    preferred footprint compute duplicate tiles and skip others — caught here
+    as a numerical mismatch. has_C additionally routes the epi-load warp
+    through the runtime-selected sched-pipeline arrive counts.
+    """
+    torch.manual_seed(1)
+    l, m, n, k = 4, 2048, 1536, 512  # >= 384 CTAs: > SM count even as (2,1) pairs
+    A = torch.randn(l, m, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    B = torch.randn(l, n, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    C = torch.randn(l, m, n, dtype=DTYPE, device="cuda") if has_C else None
+    D = torch.empty(l, m, n, dtype=DTYPE, device="cuda")
+    kwargs = dict(C=C, alpha=1.0, beta=0.5) if has_C else {}
+    _run_gemm(A, B, D, tile_M, tile_N, cluster_M, cluster_N, **kwargs)
+    ref = torch.bmm(A.float(), B.float().mT)
+    if has_C:
+        ref = ref + 0.5 * C.float()
+    torch.testing.assert_close(D, ref.to(DTYPE), atol=ATOL, rtol=RTOL)
+
+
+def test_gemm_forced_fallback_split_k(force_fallback):
+    """Forced fallback path with serial split-K: the split index rides the
+    work-id z decode, which must stay consistent with the remainder decode.
+    8 x 6 tiles x 4 batches x 2 splits = 384 CTAs at the (1,1) fallback, well
+    over the SM count, so the stolen-work decode runs too."""
+    torch.manual_seed(3)
+    l, m, n, k = 4, 1024, 1536, 4096  # K-heavy: split_k's home turf
+    A = torch.randn(l, m, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    B = torch.randn(l, n, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    D = torch.empty(l, m, n, dtype=DTYPE, device="cuda")
+    _run_gemm(A, B, D, tile_M=128, tile_N=256, cluster_M=1, cluster_N=2, split_k=2)
+    ref = torch.bmm(A.float(), B.float().mT).to(DTYPE)
+    torch.testing.assert_close(D, ref, atol=ATOL, rtol=RTOL)
+
+
+def test_gemm_forced_fallback_varlen_m(force_fallback):
+    """Forced fallback path on the varlen_m scheduler: exercises the
+    remainder decode in VarlenMTileScheduler and the forward-window scan reset
+    when a stolen work id regresses (fallback grids raster across rows)."""
+    torch.manual_seed(2)
+    num_groups, n, k = 16, 1024, 512
+    lens = [384, 1024, 128, 896, 640, 512, 768, 256] * 2  # ragged, not tile-aligned
+    cu_seqlens_m = torch.tensor([0] + list(torch.tensor(lens).cumsum(0)), dtype=torch.int32).cuda()
+    total_m = sum(lens)
+    A = torch.randn(total_m, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    B = torch.randn(num_groups, n, k, dtype=DTYPE, device="cuda") / math.sqrt(k)
+    D = torch.empty(total_m, n, dtype=DTYPE, device="cuda")
+    _run_gemm(A, B, D, tile_M=128, tile_N=256, cluster_M=1, cluster_N=2, cu_seqlens_m=cu_seqlens_m)
+    ref_parts = []
+    for i in range(num_groups):
+        s, e = cu_seqlens_m[i].item(), cu_seqlens_m[i + 1].item()
+        ref_parts.append(A[s:e].float() @ B[i].float().T)
+    ref = torch.cat(ref_parts).to(DTYPE)
+    torch.testing.assert_close(D, ref, atol=ATOL, rtol=RTOL)

--- a/tests/test_gemm_fallback_cluster.py
+++ b/tests/test_gemm_fallback_cluster.py
@@ -54,12 +54,15 @@ CONFIGS = [
     (128, 256, 1, 2),  # 1-CTA MMA, fallback (1,1), rem_n path
     (64, 256, 2, 1),  # 1-CTA MMA, fallback (1,1), rem_m path
 ]
-# Forced-path only (launches at the size-2 fallback, never a size-4 cluster):
+# Forced-path only (launches at the size-2 fallback, never a size-4/8 cluster):
 # 2-CTA MMA whose fallback keeps the pair — per-shape A multicast atoms, the
-# pair's SFB/B 2SM atoms, and the pair-intact sched pipeline.
+# pair's SFB/B 2SM atoms, and the pair-intact sched pipeline. The size-8 shapes
+# are in the SM100 autotune sweep (gemm_config._get_sm100_configs, CLC only).
 FORCED_CONFIGS = CONFIGS + [
     (128, 256, 2, 2),  # 2-CTA MMA, fallback (2,1), rem_n path
     (256, 128, 4, 1),  # 2-CTA MMA, fallback (2,1), rem_m path (pair offset 2)
+    (256, 256, 4, 2),  # 2-CTA MMA, fallback (2,1), rem_m + rem_n (size 8)
+    (256, 256, 2, 4),  # 2-CTA MMA, fallback (2,1), rem_n path (size 8)
 ]
 
 

--- a/tests/test_gemm_sm100_blockscaled.py
+++ b/tests/test_gemm_sm100_blockscaled.py
@@ -586,22 +586,30 @@ def test_scale_layout_matches_cublas(mn, sf_k, l):
 # End-to-end: quantized MXFP8 inputs through quack kernel vs cuBLAS vs dequant ref
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "mma_tiler_mn,cluster_shape_mn,m,n,k",
+    "mma_tiler_mn,cluster_shape_mn,m,n,k,use_clc",
     [
         # All supported blockscaled tile_n values (64, 128, 192, 256).
-        ((128, 64), (1, 1), 256, 64, 512),
-        ((128, 128), (1, 1), 256, 256, 256),
-        ((128, 128), (1, 1), 512, 512, 512),
-        ((128, 192), (1, 1), 256, 192, 256),
-        ((128, 256), (1, 1), 256, 256, 256),
-        ((256, 128), (2, 1), 512, 256, 512),
-        ((256, 192), (2, 1), 256, 192, 256),
-        ((256, 192), (2, 1), 256, 384, 256),
-        ((256, 192), (2, 1), 512, 192, 512),
-        ((256, 256), (2, 1), 512, 256, 512),
+        ((128, 64), (1, 1), 256, 64, 512, True),
+        ((128, 128), (1, 1), 256, 256, 256, True),
+        ((128, 128), (1, 1), 512, 512, 512, True),
+        ((128, 192), (1, 1), 256, 192, 256, True),
+        ((128, 256), (1, 1), 256, 256, 256, True),
+        ((256, 128), (2, 1), 512, 256, 512, True),
+        ((256, 192), (2, 1), 256, 192, 256, True),
+        ((256, 192), (2, 1), 256, 384, 256, True),
+        ((256, 192), (2, 1), 512, 192, 512, True),
+        ((256, 256), (2, 1), 512, 256, 512, True),
+        # Size-8 clusters (in the SM100 autotune sweep, CLC only): SFB multicast
+        # across 4 cluster-M CTAs / A+SFA across 4 cluster-N CTAs. Static launch
+        # here — a CLC size-8 mixed launch is excluded from CI for the same
+        # contention-hang reason as tests/test_gemm_fallback_cluster.py.
+        ((256, 256), (4, 2), 1024, 512, 512, False),
+        ((256, 128), (4, 2), 1024, 256, 512, False),
+        ((256, 256), (2, 4), 512, 1024, 512, False),
+        ((256, 128), (2, 4), 512, 512, 512, False),
     ],
 )
-def test_blockscaled_mxfp8_quantized(mma_tiler_mn, cluster_shape_mn, m, n, k):
+def test_blockscaled_mxfp8_quantized(mma_tiler_mn, cluster_shape_mn, m, n, k, use_clc):
     _skip_if_not_sm100()
     l, sf_vec = 1, 32
 
@@ -625,6 +633,7 @@ def test_blockscaled_mxfp8_quantized(mma_tiler_mn, cluster_shape_mn, m, n, k):
         mD,
         mSFA,
         mSFB,
+        use_clc_persistence=use_clc,
     )
     runner(mA, mB, mD, mSFA, mSFB)
     torch.cuda.synchronize()


### PR DESCRIPTION
Under CLC dynamic scheduling the SM100 GEMM now launches with a preferred cluster shape
plus a fallback shape in case the select cluster shape is larger than size 2 to increase occupancy. One kernel body serves both shapes and this is enabled automatically.

**1. Drop `block_copy`; bake TMA multicast into the atoms (SM90/SM100/SM120)**
- Load-side TMA atoms carry their multicast config again (multicast op variant +
  `num_multicast` box split); copy sites go through `tma_get_copy_fn` with an explicit
  CTA coordinate, CTA layout and `mcast_mask`.
- SM100 A/B/SFA/SFB ops come from `cluster_shape_to_tma_atom_*`; SFB splits its chunk
  window across every cluster-M CTA. Aux operands that opt out of A multicast build a
  non-multicast atom so atom and copy site agree.
- SM120 blockscaled asserts a 1x1 cluster: its SF atoms are non-multicast while the
  copy sites partition by the cluster layout.

**2. Preferred/fallback cluster shapes on SM100 (CLC persistence)**
- Fallback is always 2x1 with 2-CTA MMA and 1x1 otherwise; off when CLC is
  off or the preferred shape already is the fallback.
- One kernel body, as CUTLASS C++ does with `tma_load_a` / `tma_load_a_fallback`: both
  shapes' load atoms are kernel params and `is_preferred_cluster` (runtime
  `cluster_nctaid`) selects per cluster the copy fn for operands whose multicast extent
  differs, the AB/sched pipeline arrive counts, the `tcgen05.commit` release mask, and
  whether the CLC drain runs. Everything else derives from the preferred layout, which
  agrees with the fallback for the ranks a fallback cluster has.
- Versus a two-trace mega-kernel: 71.8 KB vs 126.7 KB cubin (70.3 KB with fallback off),
  ~1.4 s vs ~1.9 s cold compile.
- Tile scheduler decodes in preferred-cluster units for both shapes (CTA remainder
  inside the preferred footprint); sched barriers armed per CTA of the actual cluster;
  varlen_m scan reset when a stolen work id regresses.
- Tests: fallback derivation, real mixed launches with active stealing, forced-fallback
  runs (with C, split-K, varlen_m, and the 2-CTA 2x1 fallback of 2x2/4x1/4x2/2x4).

**3. Add 4x2 and 2x4 cluster shapes to the SM100 autotune sweep (CLC only)**
- 64 new configs (456 total, 228 after the non-gather prune), emitted with
  `is_dynamic_persistent=True` only.
- Tests: forced-fallback 4x2/2x4 dense; static 4x2/2x4 blockscaled MXFP8 rows
  bit-exact vs cuBLAS.

## Performance

GB200, bf16, CLC persistent, 2-CTA tile 256x256 / 1-CTA 128x256. Interleaved medians over
25 rounds, same inputs, idle GPU; cuBLAS is `torch.matmul`. Speedup over a fixed 2x1
2-CTA launch (the previous default):

| M × N × K | 1x2 only | 2x2 w/ fallback | 4x1 w/ fallback | 4x2 w/ fallback | 2x4 w/ fallback | cuBLAS |
|---|---|---|---|---|---|---|
| 8192³ | 0.96 | 1.04 | 1.01 | **1.13** | 1.04 | 0.97 |
| 16384² × 2048 | 0.92 | 1.04 | 1.03 | 1.16 | **1.17** | 1.07 |
| 8192² × 1024 | 0.90 | 1.05 | 1.03 | 1.11 | **1.12** | 1.06 |
| 4096³ | 0.98 | 1.05 | 1.05 | 1.11 | 1.11 | 1.13 |
| 2048² × 8192 | 0.98 | 1.01 | 1.01 | 1.19 | **1.20** | 1.10 |

The same preferred shapes launched w/ no fallback over 2x1 show large regressions from CGA quantization:

- 2x2 0.91–1.06 | 4x1 0.83–0.97 | 4x2 0.54–0.91 | 2x4 0.57–0.94
- Mixed launch is what makes size-8 clusters usable: 4x2/2x4 with fallback 2x1 is the
  fastest configuration on every shape (+10–20% over 2x1; 8192³ 1502 vs 1326 TFLOPS) and
  ahead of cuBLAS on 4 of 5 shapes.
- Size-4 mixed (2x2, 4x1) is neutral vs 2x1 within noise.
- 1x2 mixed equals 1x2 pure within noise, so the runtime selection has no measurable cost.
