### PR TITLE
Relax nvidia-cutlass-dsl pin to >=4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quack-kernels"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "nvidia-cutlass-dsl==4.7.0",
+    "nvidia-cutlass-dsl>=4.7",
     "torch",
     "apache-tvm-ffi>=0.1.6,<0.2",
     "torch-c-dlpack-ext",
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.7.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.7"]
 heuristics = ["nvidia-matmul-heuristics"]
 jax = ["jax", "jax-tvm-ffi"]
 bench = ["pandas", "tyro"]


### PR DESCRIPTION
## Human Note

trying to get fa4 4.7+

## Agent note

Relax the exact CUTLASS DSL 4.7.0 pin to `>=4.7` for both the default dependency and the
`cu13` extra. This lets downstream consumers such as FA4 use newer compatible DSL releases
without waiting for another QuACK dependency-metadata update.

The published QuACK 0.6.4 package still pins DSL 4.6.2; this change targets current main,
which already pins 4.7.0. A subsequent QuACK release is needed to make the relaxation
available on PyPI. This PR does not bump the package version or publish a release.

## Test Plan

```bash
git -C ~/meta/quack diff --check origin/main...HEAD
```

Prior validation recorded in commit `152185b` on GB200: DSL 4.7.0 (648 passed),
4.7.1 (1464 passed), and 4.8.0.dev0 (1464 passed). GPU tests were not rerun for PR creation.
